### PR TITLE
Redaction Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5][] - 2025-11-02
+
+### Changed
+- Updated installation documentation in README to address `externally-managed-environment` error
+- Added installation alternatives for macOS and modern Linux distributions:
+  - pipx installation (recommended for CLI tools)
+  - Virtual environment setup
+  - User space installation
+- Improved source installation instructions with separate options for development and virtual environment setups
+
 ## [1.0.4][] - 2025-11-02
 
 ### Changed
@@ -94,5 +104,6 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.5]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously `file:///path` would be incorrectly transformed to `file://example.com/path`
   - This changed URL semantics from local filesystem to network file share
   - Added early return in `_mask_url()` when `hostname` is `None` or empty
+- **ENHANCEMENT**: Expanded email regex to support RFC 5322 special characters
+  - Now matches emails with `!#$&'*/=?^`{|}~` in local part (e.g., `user!test@example.com`)
+  - Maintains ReDoS protection with limited repetitions
+  - Previous regex only matched `[A-Za-z0-9._%+-]`, missing many legal email addresses
 
 ### Added
 - Module-level exports control via `__all__` (PfSenseRedactor, main, parse_allowlist_file)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6][] - 2025-11-02
+
+### Security
+- **CRITICAL FIX**: Extended URL regex to handle non-HTTP protocols (FTP, FTPS, SFTP, SSH, Telnet, File, SMB, NFS)
+  - Previously only HTTP/HTTPS URLs were matched, allowing credentials in `ftp://user:pass@host` URLs to bypass redaction
+  - Credentials in non-HTTP URLs would have leaked through the bare FQDN redaction path
+  - All protocol URLs now properly redact passwords whilst preserving usernames and structure
+- **CRITICAL FIX**: URLs without hostnames (e.g., `file:///path`) are now preserved unchanged
+  - Previously `file:///path` would be incorrectly transformed to `file://example.com/path`
+  - This changed URL semantics from local filesystem to network file share
+  - Added early return in `_mask_url()` when `hostname` is `None` or empty
+
+### Added
+- Module-level exports control via `__all__` (PfSenseRedactor, main, parse_allowlist_file)
+- Python 3.9+ version check at module import time with clear error message
+- Cached IDNA encoding using `@functools.lru_cache(maxsize=256)` for improved performance
+- Type hint for maskers dictionary: `dict[str, Callable[[str], str]]`
+- XML comment in output files: `<!-- Redacted using pfsense-redactor v1.0.6 -->`
+- 14 comprehensive tests for URL handling:
+  - 8 tests for non-HTTP protocol URL redaction
+  - 6 tests for hostnameless URL preservation
+
+### Changed
+- Updated version to 1.0.6 in both `__init__.py` and `pyproject.toml`
+- Updated all test reference files to include redaction comment
+
 ## [1.0.5][] - 2025-11-02
 
 ### Changed
@@ -104,6 +130,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.6]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.6
 [1.0.5]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.3

--- a/README.md
+++ b/README.md
@@ -10,11 +10,42 @@ The **pfSense XML Configuration Redactor** safely removes sensitive information 
 pip install pfsense-redactor
 ```
 
+> **Note:** If you encounter an `externally-managed-environment` error (common on macOS and modern Linux distributions), use one of these alternatives:
+>
+> **Option 1: Install with pipx (recommended for CLI tools)**
+> ```bash
+> brew install pipx
+> pipx install pfsense-redactor
+> ```
+>
+> **Option 2: Use a virtual environment**
+> ```bash
+> python3 -m venv venv
+> source venv/bin/activate
+> pip install pfsense-redactor
+> ```
+>
+> **Option 3: Install in user space**
+> ```bash
+> pip install --user pfsense-redactor
+> ```
+
 ### From Source
 
 ```bash
 git clone https://github.com/grounzero/pfsense-redactor.git
 cd pfsense-redactor
+```
+
+**Option 1: Development mode (recommended for contributing)**
+```bash
+pip install -e .
+```
+
+**Option 2: With virtual environment**
+```bash
+python3 -m venv venv
+source venv/bin/activate
 pip install -e .
 ```
 

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -15,5 +15,5 @@ if sys.version_info < (3, 9):
 
 from .redactor import PfSenseRedactor, main, parse_allowlist_file
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -4,7 +4,16 @@ Safely removes sensitive information from pfSense config.xml exports before
 they are shared with support, consultants, auditors, or AI tools for security analysis.
 """
 
-from .redactor import PfSenseRedactor
+import sys
 
-__version__ = "1.0.0"
-__all__ = ["PfSenseRedactor"]
+# Require Python 3.9+ (for ET.indent and other features)
+if sys.version_info < (3, 9):
+    raise RuntimeError(
+        "pfsense-redactor requires Python 3.9 or later. "
+        f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
+    )
+
+from .redactor import PfSenseRedactor, main, parse_allowlist_file
+
+__version__ = "1.0.5"
+__all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -15,6 +15,7 @@ if sys.version_info < (3, 9):
 
 __version__ = "1.0.6"
 
-from .redactor import PfSenseRedactor, main, parse_allowlist_file  # noqa: E402
+# pylint: disable=wrong-import-position
+from .redactor import PfSenseRedactor, main, parse_allowlist_file
 
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,8 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-from .redactor import PfSenseRedactor, main, parse_allowlist_file
-
 __version__ = "1.0.6"
+
+from .redactor import PfSenseRedactor, main, parse_allowlist_file  # noqa: E402
+
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -16,8 +16,8 @@ from collections.abc import Callable
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
 # Type aliases for clarity (using string annotations for Python 3.9 compatibility)
-IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+IPAddress = "ipaddress.IPv4Address | ipaddress.IPv6Address"
+IPNetwork = "ipaddress.IPv4Network | ipaddress.IPv6Network"
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -13,12 +13,11 @@ import functools
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TypeAlias
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
-# Type aliases for clarity
-IPAddress: TypeAlias = ipaddress.IPv4Address | ipaddress.IPv6Address
-IPNetwork: TypeAlias = ipaddress.IPv4Network | ipaddress.IPv6Network
+# Type aliases for clarity (using string annotations for Python 3.9 compatibility)
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -13,11 +13,12 @@ import functools
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
+from typing import TypeAlias
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
 # Type aliases for clarity
-IPAddress = "ipaddress.IPv4Address | ipaddress.IPv6Address"
-IPNetwork = "ipaddress.IPv4Network | ipaddress.IPv6Network"
+IPAddress: TypeAlias = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork: TypeAlias = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -862,12 +862,11 @@ class PfSenseRedactor:
         except (ImportError, AttributeError):
             # Fallback: try to get version from pyproject.toml or use unknown
             try:
-                from pathlib import Path
-                import re as version_re
-                pyproject = Path(__file__).parent.parent / "pyproject.toml"
-                if pyproject.exists():
-                    content = pyproject.read_text(encoding='utf-8')
-                    match = version_re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+                # pylint: disable=import-outside-toplevel,reimported,redefined-outer-name
+                pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+                if pyproject_path.exists():
+                    content = pyproject_path.read_text(encoding='utf-8')
+                    match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
                     version = match.group(1) if match else "unknown"
                 else:
                     version = "unknown"

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -594,6 +594,11 @@ class PfSenseRedactor:
 
         host = parts.hostname or ''
 
+        # Skip URLs without hostnames (e.g., file:///path, about:blank)
+        # These have no network location to redact and no credentials to leak
+        if not host:
+            return url
+
         # Check if already masked
         if self._is_already_masked_host(host):
             return self._normalise_masked_url(parts, host)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -162,7 +162,9 @@ class PfSenseRedactor:
         # Domain/email/URL patterns
         # ReDoS mitigation: limit repetitions to prevent catastrophic backtracking
         self.EMAIL_RE = re.compile(r'(?<!:)\b[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\.){1,10}[A-Za-z]{2,}\b')
-        self.URL_RE = re.compile(r'\bhttps?://[^\s<>"\']+\b')
+        # URL pattern: matches common protocols (http, https, ftp, ftps, sftp, ssh, telnet, etc.)
+        # This ensures credentials in URLs like ftp://user:pass@host are properly redacted
+        self.URL_RE = re.compile(r'\b(?:https?|ftps?|sftp|ssh|telnet|file|smb|nfs)://[^\s<>"\']+\b')
         # FQDN pattern is intentionally broad for security (better to over-redact than under-redact)
         # Matches: label.label.tld where labels are alphanumeric with hyphens, TLD is 2+ letters
         # Note: This may match some non-domains (e.g., version numbers like 1.2.3a) but that's acceptable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.5"
+version = "1.0.6"
 description = "Safely removes sensitive information from pfSense config.xml exports"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.4"
+version = "1.0.5"
 description = "Safely removes sensitive information from pfSense config.xml exports"
 readme = "README.md"
 authors = [

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -74,5 +74,105 @@ class TestURLWithIPHandling:
         assert "[" in result and "]" in result
 
 
+class TestNonHTTPProtocolURLs:
+    """Test URL handling for protocols other than HTTP/HTTPS"""
+
+    def test_ftp_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that FTP URLs with credentials are properly redacted"""
+        url = "ftp://user:password@ftp.example.com/files"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "password" not in result
+        assert "REDACTED" in result
+        # Should preserve username and protocol
+        assert "ftp://" in result
+        assert "user" in result
+        # Should mask domain
+        assert "ftp.example.com" not in result
+
+    def test_ftps_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that FTPS URLs with credentials are properly redacted"""
+        url = "ftps://admin:secret123@secure.example.org:990/data"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "secret123" not in result
+        assert "REDACTED" in result
+        # Should preserve protocol and username
+        assert "ftps://" in result
+        assert "admin" in result
+        # Should preserve port
+        assert ":990" in result
+
+    def test_sftp_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SFTP URLs with credentials are properly redacted"""
+        url = "sftp://backup:pass@192.168.1.100/backups"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "pass" not in result
+        assert "REDACTED" in result
+        # Should mask IP
+        assert "192.168.1.100" not in result
+
+    def test_ssh_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SSH URLs with credentials are properly redacted"""
+        url = "ssh://root:toor@server.local:22"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "toor" not in result
+        assert "REDACTED" in result
+        assert "ssh://" in result
+
+    def test_telnet_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that Telnet URLs with credentials are properly redacted"""
+        url = "telnet://admin:admin@router.local:23"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "REDACTED" in result
+        assert "telnet://" in result
+
+    def test_file_url_preserved(self, basic_redactor):
+        """Verify that file:// URLs are handled"""
+        url = "file:///etc/config.xml"
+        result = basic_redactor._mask_url(url)
+
+        # file:// URLs don't have hosts, so should be preserved
+        assert "file://" in result
+
+    def test_smb_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SMB URLs with credentials are properly redacted"""
+        url = "smb://domain\\user:password@fileserver/share"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "password" not in result
+        assert "REDACTED" in result
+        assert "smb://" in result
+
+    def test_mixed_protocols_in_text(self, basic_redactor):
+        """Verify that multiple protocol URLs in text are all redacted"""
+        text = """
+        FTP: ftp://user:pass@ftp.example.com/files
+        HTTPS: https://admin:secret@web.example.com/admin
+        SFTP: sftp://backup:key@192.168.1.50/data
+        """
+        result = basic_redactor.redact_text(text)
+
+        # All passwords should be redacted
+        assert "pass" not in result
+        assert "secret" not in result
+        assert "key" not in result
+        # Should have REDACTED markers
+        assert result.count("REDACTED") >= 3
+        # Protocols should be preserved
+        assert "ftp://" in result
+        assert "https://" in result
+        assert "sftp://" in result
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -6,6 +6,7 @@ Tests for URL masking, reconstruction, and IPv6 URL handling
 """
 
 import pytest
+from urllib.parse import urlparse
 
 
 class TestNormaliseMaskedURLAnonymise:
@@ -158,7 +159,7 @@ class TestNonHTTPProtocolURLs:
 
         # Should mask the hostname
         assert "fileserver.local" not in result
-        assert "example.com" in result
+        assert urlparse(result).hostname == "example.com"
         assert "file://" in result
 
     def test_nfs_url_without_hostname_preserved(self, basic_redactor):

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -142,7 +142,6 @@ class TestNonHTTPProtocolURLs:
 
         # file:// URLs without hostnames should be preserved exactly
         assert result == url
-        assert "example.com" not in result
 
     def test_file_url_windows_path_preserved(self, basic_redactor):
         """Verify that file:// URLs with Windows paths are preserved"""
@@ -151,7 +150,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved exactly, not transformed to network path
         assert result == url
-        assert "example.com" not in result
 
     def test_file_url_with_hostname_redacted(self, basic_redactor):
         """Verify that file:// URLs with actual hostnames are redacted"""
@@ -170,7 +168,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved unchanged
         assert result == url
-        assert "example.com" not in result
 
     def test_smb_url_without_hostname_preserved(self, basic_redactor):
         """Verify that SMB URLs without hostnames are preserved"""
@@ -179,7 +176,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved unchanged
         assert result == url
-        assert "example.com" not in result
 
     def test_smb_url_with_credentials_redacted(self, basic_redactor):
         """Verify that SMB URLs with credentials are properly redacted"""


### PR DESCRIPTION
This pull request releases version 1.0.6 of `pfsense-redactor` with critical security fixes, performance improvements, new features, and updated documentation. The most significant changes are enhanced URL redaction to prevent credential leaks in non-HTTP protocols, improved handling of URLs without hostnames, performance optimizations for domain encoding, and the addition of a redaction comment to output files. Installation instructions and test coverage have also been expanded.

**Security and Redaction Improvements:**
* Extended URL regex to handle non-HTTP protocols (FTP, FTPS, SFTP, SSH, Telnet, File, SMB, NFS), ensuring credentials in all supported protocol URLs are properly redacted and not leaked. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL147-R167) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)
* Fixed handling of URLs without hostnames (e.g., `file:///path`), preserving them unchanged to avoid altering their semantics. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR597-R601) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43)

**Performance and Code Quality:**
* Introduced cached IDNA encoding with `@functools.lru_cache(maxsize=256)` to optimize repeated domain encoding operations. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR69-R84) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL185-R206) [[3]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL200-R218) [[4]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL466-R480)
* Added type hints for the maskers dictionary to improve code clarity and maintainability.

**Features and Output:**
* Added an XML comment to output files: `<!-- Redacted using pfsense-redactor v1.0.6 -->` to indicate redaction provenance. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR852-R866) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR907-R909)
* Updated all test reference XML files to include the new redaction comment. [[1]](diffhunk://#diff-0bda50d7449131fb4240cdcfd9ba285da21febf575096ec19b8daeb14667f833R3) [[2]](diffhunk://#diff-fd905daad6cdb5197a94886b7bb1bdb752029ac9a70e9552ed06820f2e79bb43R3) [[3]](diffhunk://#diff-5835199699e33e2ce0071ae966e42a9e7bd3f81b971b18d368739b97be160657R3) [[4]](diffhunk://#diff-e5f4b83aa91f503be32720ebb87d5da3d48df10403cae91f9dd63fcf2abd10eeR3) [[5]](diffhunk://#diff-b78fa60112acc587fcfee3ff10f7d8594678132c7b954080a2b9f1967d6b6dbfR3) [[6]](diffhunk://#diff-160ef931ffd85f6e9d7da8caa852fdc6b7c38e3210d56fce7085ef5462579273R3) [[7]](diffhunk://#diff-173ae4d15d6ed5e719160f2c89cd2c1753510b811d30af4984174843109fbd3dR3) [[8]](diffhunk://#diff-eea9c6b724549d5a503c1a622c1f46316e9299d55c08501b4e40e84cdca1847fR3) [[9]](diffhunk://#diff-29d2082b2e7d0d503b4d9291982816c645b9b6c85276a430af0deeebf01cea2fR3) [[10]](diffhunk://#diff-21c31c509cff8129b098b38047666b77a90738031d81fedf2adf611adffe2da3R3)

**Documentation and Packaging:**
* Improved installation instructions in the `README.md` to address `externally-managed-environment` errors, including pipx, virtual environment, and user-space installation options.
* Updated version to 1.0.6 in `__init__.py` and `pyproject.toml`. [[1]](diffhunk://#diff-0e508264480c70371d524532476e35f4e6d73599eb7f55bab6632bc828bdb74cL7-R19) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)
* Added module-level exports control via `__all__` and enforced Python 3.9+ version check at import time.

**Testing:**
* Added 14 comprehensive tests for URL handling, including non-HTTP protocol redaction and hostnameless URL preservation.

For full details, see the updated `CHANGELOG.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R43) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR133-R134)