### PR TITLE
Release/v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5][] - 2025-11-02
+
+### Changed
+- Updated installation documentation in README to address `externally-managed-environment` error
+- Added installation alternatives for macOS and modern Linux distributions:
+  - pipx installation (recommended for CLI tools)
+  - Virtual environment setup
+  - User space installation
+- Improved source installation instructions with separate options for development and virtual environment setups
+
 ## [1.0.4][] - 2025-11-02
 
 ### Changed
@@ -94,5 +104,6 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.5]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- **CRITICAL FIX**: Fixed whitespace domain handling vulnerability in allowlist validation
+  - Added `.strip()` to prevent allowlist bypass with whitespace-only domains (e.g., `"   "`)
+  - Whitespace-only domains could previously match ANY domain in suffix matching
+  - Added validation to reject domains with internal whitespace
+  - Added 6 comprehensive tests in `TestDomainNormalisationSecurity`
+- **MEDIUM FIX**: Fixed port stripping logic to validate IPv4 addresses
+  - Now validates IP addresses using `ipaddress.ip_address()` before stripping ports
+  - Prevents incorrect port stripping from non-IP tokens like `foo.bar.baz:8080`
+  - Previously only checked for presence of dots, not valid IP format
+  - Added 4 tests in `TestPortStrippingSecurity`
+
+### Added
+- New `--redact-url-usernames` CLI flag for enhanced URL credential redaction
+  - Allows redacting sensitive usernames (e.g., `admin`, `root`) in URLs
+  - Default behaviour: preserve usernames, always redact passwords (`ftp://user:REDACTED@host`)
+  - With flag: redact both (`ftp://REDACTED:REDACTED@host`)
+  - Added 7 tests in `TestURLUsernameRedaction`
+
+### Changed
+- Domain normalisation now strips whitespace before processing dots
+- Port stripping now requires valid IPv4 address validation
+
 ## [1.0.6][] - 2025-11-02
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously `file:///path` would be incorrectly transformed to `file://example.com/path`
   - This changed URL semantics from local filesystem to network file share
   - Added early return in `_mask_url()` when `hostname` is `None` or empty
+- **ENHANCEMENT**: Expanded email regex to support RFC 5322 special characters
+  - Now matches emails with `!#$&'*/=?^`{|}~` in local part (e.g., `user!test@example.com`)
+  - Maintains ReDoS protection with limited repetitions
+  - Previous regex only matched `[A-Za-z0-9._%+-]`, missing many legal email addresses
 
 ### Added
 - Module-level exports control via `__all__` (PfSenseRedactor, main, parse_allowlist_file)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously only checked for presence of dots, not valid IP format
   - Added 4 tests in `TestPortStrippingSecurity`
 
+### Fixed
+- **CRITICAL FIX**: Fixed whitespace corruption in URL/email/FQDN redaction
+  - `_redact_urls_safe`, `_redact_emails_safe`, and `_redact_fqdns_safe` were using `text.split()` and `' '.join()`
+  - This collapsed all whitespace (including newlines) into single spaces, corrupting XML text content
+  - Now uses `re.sub()` with callbacks to preserve original whitespace structure
+  - Maintains ReDoS protection via length pre-filtering in the callback functions
+
 ### Added
 - New `--redact-url-usernames` CLI flag for enhanced URL credential redaction
   - Allows redacting sensitive usernames (e.g., `admin`, `root`) in URLs
@@ -29,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Domain normalisation now strips whitespace before processing dots
 - Port stripping now requires valid IPv4 address validation
+- URL/email/FQDN redaction now uses `re.sub()` instead of tokenization to preserve whitespace
 
 ## [1.0.6][] - 2025-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.7][] - 2025-11-03
 
 ### Security
 - **CRITICAL FIX**: Fixed whitespace domain handling vulnerability in allowlist validation
@@ -168,6 +168,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.7]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.7
 [1.0.6]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.6
 [1.0.5]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6][] - 2025-11-02
+
+### Security
+- **CRITICAL FIX**: Extended URL regex to handle non-HTTP protocols (FTP, FTPS, SFTP, SSH, Telnet, File, SMB, NFS)
+  - Previously only HTTP/HTTPS URLs were matched, allowing credentials in `ftp://user:pass@host` URLs to bypass redaction
+  - Credentials in non-HTTP URLs would have leaked through the bare FQDN redaction path
+  - All protocol URLs now properly redact passwords whilst preserving usernames and structure
+- **CRITICAL FIX**: URLs without hostnames (e.g., `file:///path`) are now preserved unchanged
+  - Previously `file:///path` would be incorrectly transformed to `file://example.com/path`
+  - This changed URL semantics from local filesystem to network file share
+  - Added early return in `_mask_url()` when `hostname` is `None` or empty
+
+### Added
+- Module-level exports control via `__all__` (PfSenseRedactor, main, parse_allowlist_file)
+- Python 3.9+ version check at module import time with clear error message
+- Cached IDNA encoding using `@functools.lru_cache(maxsize=256)` for improved performance
+- Type hint for maskers dictionary: `dict[str, Callable[[str], str]]`
+- XML comment in output files: `<!-- Redacted using pfsense-redactor v1.0.6 -->`
+- 14 comprehensive tests for URL handling:
+  - 8 tests for non-HTTP protocol URL redaction
+  - 6 tests for hostnameless URL preservation
+
+### Changed
+- Updated version to 1.0.6 in both `__init__.py` and `pyproject.toml`
+- Updated all test reference files to include redaction comment
+
 ## [1.0.5][] - 2025-11-02
 
 ### Changed
@@ -104,6 +130,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.6]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.6
 [1.0.5]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/grounzero/pfsense-redactor/releases/tag/v1.0.3

--- a/README.md
+++ b/README.md
@@ -10,11 +10,42 @@ The **pfSense XML Configuration Redactor** safely removes sensitive information 
 pip install pfsense-redactor
 ```
 
+> **Note:** If you encounter an `externally-managed-environment` error (common on macOS and modern Linux distributions), use one of these alternatives:
+>
+> **Option 1: Install with pipx (recommended for CLI tools)**
+> ```bash
+> brew install pipx
+> pipx install pfsense-redactor
+> ```
+>
+> **Option 2: Use a virtual environment**
+> ```bash
+> python3 -m venv venv
+> source venv/bin/activate
+> pip install pfsense-redactor
+> ```
+>
+> **Option 3: Install in user space**
+> ```bash
+> pip install --user pfsense-redactor
+> ```
+
 ### From Source
 
 ```bash
 git clone https://github.com/grounzero/pfsense-redactor.git
 cd pfsense-redactor
+```
+
+**Option 1: Development mode (recommended for contributing)**
+```bash
+pip install -e .
+```
+
+**Option 2: With virtual environment**
+```bash
+python3 -m venv venv
+source venv/bin/activate
 pip install -e .
 ```
 

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -15,5 +15,5 @@ if sys.version_info < (3, 9):
 
 from .redactor import PfSenseRedactor, main, parse_allowlist_file
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -4,7 +4,16 @@ Safely removes sensitive information from pfSense config.xml exports before
 they are shared with support, consultants, auditors, or AI tools for security analysis.
 """
 
-from .redactor import PfSenseRedactor
+import sys
 
-__version__ = "1.0.0"
-__all__ = ["PfSenseRedactor"]
+# Require Python 3.9+ (for ET.indent and other features)
+if sys.version_info < (3, 9):
+    raise RuntimeError(
+        "pfsense-redactor requires Python 3.9 or later. "
+        f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
+    )
+
+from .redactor import PfSenseRedactor, main, parse_allowlist_file
+
+__version__ = "1.0.5"
+__all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -15,6 +15,7 @@ if sys.version_info < (3, 9):
 
 __version__ = "1.0.6"
 
-from .redactor import PfSenseRedactor, main, parse_allowlist_file  # noqa: E402
+# pylint: disable=wrong-import-position
+from .redactor import PfSenseRedactor, main, parse_allowlist_file
 
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,8 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-from .redactor import PfSenseRedactor, main, parse_allowlist_file
-
 __version__ = "1.0.6"
+
+from .redactor import PfSenseRedactor, main, parse_allowlist_file  # noqa: E402
+
 __all__ = ["PfSenseRedactor", "main", "parse_allowlist_file"]

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -79,8 +79,9 @@ def _idna_encode(domain: str) -> str:
     """
     try:
         return domain.encode('idna').decode('ascii')
-    except (UnicodeError, UnicodeDecodeError, UnicodeEncodeError):
+    except UnicodeError:
         # IDNA encoding failed (malformed domain or unsupported characters)
+        # UnicodeError catches both UnicodeDecodeError and UnicodeEncodeError
         return domain
 
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -16,8 +16,8 @@ from collections.abc import Callable
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
 # Type aliases for clarity (using string annotations for Python 3.9 compatibility)
-IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+IPAddress = "ipaddress.IPv4Address | ipaddress.IPv6Address"
+IPNetwork = "ipaddress.IPv4Network | ipaddress.IPv6Network"
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -13,12 +13,11 @@ import functools
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TypeAlias
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
-# Type aliases for clarity
-IPAddress: TypeAlias = ipaddress.IPv4Address | ipaddress.IPv6Address
-IPNetwork: TypeAlias = ipaddress.IPv4Network | ipaddress.IPv6Network
+# Type aliases for clarity (using string annotations for Python 3.9 compatibility)
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -13,11 +13,12 @@ import functools
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
+from typing import TypeAlias
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
 # Type aliases for clarity
-IPAddress = "ipaddress.IPv4Address | ipaddress.IPv6Address"
-IPNetwork = "ipaddress.IPv4Network | ipaddress.IPv6Network"
+IPAddress: TypeAlias = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork: TypeAlias = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -862,12 +862,11 @@ class PfSenseRedactor:
         except (ImportError, AttributeError):
             # Fallback: try to get version from pyproject.toml or use unknown
             try:
-                from pathlib import Path
-                import re as version_re
-                pyproject = Path(__file__).parent.parent / "pyproject.toml"
-                if pyproject.exists():
-                    content = pyproject.read_text(encoding='utf-8')
-                    match = version_re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+                # pylint: disable=import-outside-toplevel,reimported,redefined-outer-name
+                pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+                if pyproject_path.exists():
+                    content = pyproject_path.read_text(encoding='utf-8')
+                    match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
                     version = match.group(1) if match else "unknown"
                 else:
                     version = "unknown"

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -13,11 +13,12 @@ import functools
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
+from typing import Union
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
-# Type aliases for clarity
-IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+# Type aliases for clarity (using Union for Python 3.9 compatibility)
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({
@@ -637,29 +638,21 @@ class PfSenseRedactor:
 
     def _redact_urls_safe(self, text: str) -> str:
         """Redact URLs with ReDoS protection via length pre-filtering"""
-        # Split on whitespace to get URL candidates
-        tokens = text.split()
-        result_tokens = []
+        def url_replacer(match):
+            url = match.group(0)
+            # Pre-filter: Skip obviously too-long URLs
+            if len(url) > self.MAX_URL_LENGTH:
+                return url  # Too long, don't process
+            return self._mask_url(url)
         
-        for token in tokens:
-            # Pre-filter: Skip obviously too-long strings before regex
-            if len(token) > self.MAX_URL_LENGTH:
-                # Too long to be legitimate URL, skip regex entirely
-                result_tokens.append(token)
-                continue
-            
-            # Safe to run regex on reasonable-length strings
-            result_tokens.append(
-                self.URL_RE.sub(lambda m: self._mask_url(m.group(0)), token)
-            )
-        
-        return ' '.join(result_tokens)
+        # Use re.sub directly to preserve whitespace
+        return self.URL_RE.sub(url_replacer, text)
 
     def _redact_emails_safe(self, text: str) -> str:
         """Redact emails with ReDoS protection via length pre-filtering"""
         def email_mask_safe(match):
             email = match.group(0)
-            # Double-check length (defence in depth)
+            # Pre-filter: Skip obviously too-long emails
             if len(email) > self.MAX_EMAIL_LENGTH:
                 return email  # Don't process suspiciously long "emails"
             
@@ -670,25 +663,14 @@ class PfSenseRedactor:
                 return f'user@{token}'
             return 'user@example.com'
         
-        # Split text into tokens and only process reasonable-length ones
-        tokens = text.split()
-        result_tokens = []
-        
-        for token in tokens:
-            if len(token) > self.MAX_EMAIL_LENGTH:
-                # Too long, skip regex
-                result_tokens.append(token)
-            else:
-                # Safe to run regex
-                result_tokens.append(self.EMAIL_RE.sub(email_mask_safe, token))
-        
-        return ' '.join(result_tokens)
+        # Use re.sub directly to preserve whitespace
+        return self.EMAIL_RE.sub(email_mask_safe, text)
 
     def _redact_fqdns_safe(self, text: str) -> str:
         """Redact FQDNs with ReDoS protection via length pre-filtering"""
         def fqdn_mask_safe(match):
             domain = match.group(0)
-            # Double-check length
+            # Pre-filter: Skip obviously too-long domains
             if len(domain) > self.MAX_FQDN_LENGTH:
                 return domain  # Don't process suspiciously long "domains"
             
@@ -701,17 +683,8 @@ class PfSenseRedactor:
                 self._add_sample('FQDN', domain, replacement)
             return replacement
         
-        # Split and pre-filter
-        tokens = text.split()
-        result_tokens = []
-        
-        for token in tokens:
-            if len(token) > self.MAX_FQDN_LENGTH:
-                result_tokens.append(token)
-            else:
-                result_tokens.append(self.FQDN_RE.sub(fqdn_mask_safe, token))
-        
-        return ' '.join(result_tokens)
+        # Use re.sub directly to preserve whitespace
+        return self.FQDN_RE.sub(fqdn_mask_safe, text)
 
     def redact_text(self, text: str, redact_ips: bool = True, redact_domains: bool = True) -> str:
         """Redact sensitive patterns from text"""

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -594,6 +594,11 @@ class PfSenseRedactor:
 
         host = parts.hostname or ''
 
+        # Skip URLs without hostnames (e.g., file:///path, about:blank)
+        # These have no network location to redact and no credentials to leak
+        if not host:
+            return url
+
         # Check if already masked
         if self._is_already_masked_host(host):
             return self._normalise_masked_url(parts, host)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -162,7 +162,9 @@ class PfSenseRedactor:
         # Domain/email/URL patterns
         # ReDoS mitigation: limit repetitions to prevent catastrophic backtracking
         self.EMAIL_RE = re.compile(r'(?<!:)\b[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\.){1,10}[A-Za-z]{2,}\b')
-        self.URL_RE = re.compile(r'\bhttps?://[^\s<>"\']+\b')
+        # URL pattern: matches common protocols (http, https, ftp, ftps, sftp, ssh, telnet, etc.)
+        # This ensures credentials in URLs like ftp://user:pass@host are properly redacted
+        self.URL_RE = re.compile(r'\b(?:https?|ftps?|sftp|ssh|telnet|file|smb|nfs)://[^\s<>"\']+\b')
         # FQDN pattern is intentionally broad for security (better to over-redact than under-redact)
         # Matches: label.label.tld where labels are alphanumeric with hyphens, TLD is 2+ letters
         # Note: This may match some non-domains (e.g., version numbers like 1.2.3a) but that's acceptable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.5"
+version = "1.0.6"
 description = "Safely removes sensitive information from pfSense config.xml exports"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.4"
+version = "1.0.5"
 description = "Safely removes sensitive information from pfSense config.xml exports"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.6"
+version = "1.0.7"
 description = "Safely removes sensitive information from pfSense config.xml exports"
 readme = "README.md"
 authors = [

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor vunknown -->
+  <!-- Redacted using pfsense-redactor v1.0.6 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.6 -->
+  <!-- Redacted using pfsense-redactor v1.0.7 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_domain_handling.py
+++ b/tests/unit/test_domain_handling.py
@@ -99,7 +99,7 @@ class TestDomainNormalisationSecurity:
     def test_whitespace_only_domain_rejected(self, redactor_factory):
         """Verify that whitespace-only domains are rejected (security fix)"""
         redactor = redactor_factory()
-        
+
         # Test various whitespace-only inputs
         test_cases = [
             "   ",           # spaces
@@ -108,7 +108,7 @@ class TestDomainNormalisationSecurity:
             " \t\n ",        # mixed whitespace
             "  .  ",         # whitespace with dots
         ]
-        
+
         for domain in test_cases:
             norm, idna = redactor._normalise_domain(domain)
             assert norm is None, f"Whitespace domain '{repr(domain)}' should be rejected"
@@ -117,13 +117,13 @@ class TestDomainNormalisationSecurity:
     def test_domain_with_internal_whitespace_rejected(self, redactor_factory):
         """Verify that domains with internal whitespace are rejected"""
         redactor = redactor_factory()
-        
+
         test_cases = [
             "example .com",
             "example. com",
             "exam ple.com",
         ]
-        
+
         for domain in test_cases:
             norm, idna = redactor._normalise_domain(domain)
             assert norm is None, f"Domain with internal whitespace '{domain}' should be rejected"
@@ -132,14 +132,14 @@ class TestDomainNormalisationSecurity:
     def test_valid_domain_with_surrounding_whitespace_accepted(self, redactor_factory):
         """Verify that valid domains with surrounding whitespace are accepted after stripping"""
         redactor = redactor_factory()
-        
+
         # These should be accepted after stripping
         test_cases = [
             ("  example.com  ", "example.com"),
             ("\texample.com\t", "example.com"),
             (" .example.com. ", "example.com"),
         ]
-        
+
         for input_domain, expected in test_cases:
             norm, idna = redactor._normalise_domain(input_domain)
             assert norm == expected, f"Domain '{input_domain}' should normalise to '{expected}'"
@@ -148,10 +148,10 @@ class TestDomainNormalisationSecurity:
     def test_empty_domain_rejected(self, redactor_factory):
         """Verify that empty domains are rejected"""
         redactor = redactor_factory()
-        
+
         # These should all be rejected as empty/invalid
         test_cases = ["", ".", "..", "..."]
-        
+
         for domain in test_cases:
             norm, idna = redactor._normalise_domain(domain)
             assert norm is None, f"Empty domain '{domain}' should be rejected"
@@ -160,7 +160,7 @@ class TestDomainNormalisationSecurity:
     def test_wildcard_only_domains_handled(self, redactor_factory):
         """Verify that wildcard-only domains are handled correctly"""
         redactor = redactor_factory()
-        
+
         # After stripping dots and processing wildcard, these become invalid
         # "*." -> strip dots -> "" -> empty (rejected)
         # "*.*" -> strip dots -> "*" -> process wildcard -> "" -> empty (rejected)
@@ -168,7 +168,7 @@ class TestDomainNormalisationSecurity:
             ("*.", None),   # Becomes empty after stripping
             ("*.*", None),  # Becomes "*" then empty after wildcard processing
         ]
-        
+
         for domain, expected in test_cases:
             norm, idna = redactor._normalise_domain(domain)
             if expected is None:
@@ -181,11 +181,11 @@ class TestDomainNormalisationSecurity:
         # This is the critical security test - whitespace domains should not match anything
         domains = {'   '}  # Whitespace-only domain in allowlist
         redactor = redactor_factory(allowlist_domains=domains)
-        
+
         # Should have no valid domains in allowlist (whitespace domain rejected)
         assert len(redactor.allowlist_domains) == 0
         assert len(redactor.allowlist_domains_idna) == 0
-        
+
         # Without any allowlist, domains should be redacted
         text = "Visit example.com and test.org"
         result = redactor.redact_text(text)

--- a/tests/unit/test_ip_handling.py
+++ b/tests/unit/test_ip_handling.py
@@ -118,7 +118,7 @@ class TestPortStrippingSecurity:
             ("some.thing:9999", "XXX.XXX.XXX.XXX:9999"),       # Should NOT become this
             ("999.999.999.999:80", "XXX.XXX.XXX.XXX:80"),      # Should NOT become this
         ]
-        
+
         for text, should_not_be in test_cases:
             result = basic_redactor.redact_text(text)
             # The key assertion: should NOT be treated as IP:port
@@ -139,7 +139,7 @@ class TestPortStrippingSecurity:
             ("10.0.0.1:443", "XXX.XXX.XXX.XXX:443"),
             ("172.16.0.1:22", "XXX.XXX.XXX.XXX:22"),
         ]
-        
+
         for text, expected in test_cases:
             result = basic_redactor.redact_text(text)
             assert expected in result, f"'{text}' should become '{expected}'"

--- a/tests/unit/test_ip_handling.py
+++ b/tests/unit/test_ip_handling.py
@@ -105,5 +105,53 @@ class TestIPv6Handling:
         assert "[" in result and "]" in result
 
 
+class TestPortStrippingSecurity:
+    """Test port stripping security fix"""
+
+    def test_non_ip_with_port_not_stripped_as_ip(self, basic_redactor):
+        """Verify that port is not stripped from non-IP tokens (security fix)"""
+        # These should NOT have their ports stripped as if they were IPs
+        # The key test is that they don't become XXX.XXX.XXX.XXX:port
+        test_cases = [
+            ("foo.bar.baz:8080", "XXX.XXX.XXX.XXX:8080"),      # Should NOT become this
+            ("file.name.txt:123", "XXX.XXX.XXX.XXX:123"),      # Should NOT become this
+            ("some.thing:9999", "XXX.XXX.XXX.XXX:9999"),       # Should NOT become this
+            ("999.999.999.999:80", "XXX.XXX.XXX.XXX:80"),      # Should NOT become this
+        ]
+        
+        for text, should_not_be in test_cases:
+            result = basic_redactor.redact_text(text)
+            # The key assertion: should NOT be treated as IP:port
+            assert should_not_be not in result, f"'{text}' should NOT become '{should_not_be}' (not a valid IP)"
+
+    def test_invalid_ip_with_port_not_treated_as_ip(self, basic_redactor):
+        """Verify that invalid IPs with ports are not treated as IP:port"""
+        # Invalid IP (only 3 octets) - should not be treated as IP
+        text = "1.2.3:8080"
+        result = basic_redactor.redact_text(text)
+        # Should NOT become XXX.XXX.XXX.XXX:8080
+        assert "XXX.XXX.XXX.XXX:8080" not in result
+
+    def test_valid_ipv4_with_port_stripped_correctly(self, basic_redactor):
+        """Verify that valid IPv4:port has port stripped correctly"""
+        test_cases = [
+            ("192.168.1.1:8080", "XXX.XXX.XXX.XXX:8080"),
+            ("10.0.0.1:443", "XXX.XXX.XXX.XXX:443"),
+            ("172.16.0.1:22", "XXX.XXX.XXX.XXX:22"),
+        ]
+        
+        for text, expected in test_cases:
+            result = basic_redactor.redact_text(text)
+            assert expected in result, f"'{text}' should become '{expected}'"
+            assert text not in result
+
+    def test_ipv4_without_port_still_works(self, basic_redactor):
+        """Verify that plain IPv4 addresses still work correctly"""
+        text = "192.168.1.1"
+        result = basic_redactor.redact_text(text)
+        assert "XXX.XXX.XXX.XXX" in result
+        assert "192.168.1.1" not in result
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/unit/test_redos_protection.py
+++ b/tests/unit/test_redos_protection.py
@@ -77,7 +77,8 @@ class TestReDoSProtection:
         text = "Server at server.example.org"
         result = redactor.redact_text(text, redact_domains=True)
 
-        assert "example.com" in result
+        # Verify the domain was redacted (not URL sanitization - this is a redaction tool test)
+        assert result == "Server at example.com"
         assert "server.example.org" not in result
 
     def test_max_text_chunk_protection(self):

--- a/tests/unit/test_redos_protection.py
+++ b/tests/unit/test_redos_protection.py
@@ -12,119 +12,119 @@ class TestReDoSProtection:
     def test_url_redos_protection(self):
         """Ensure URL regex doesn't hang on pathological input"""
         redactor = PfSenseRedactor()
-        
+
         # Pathological input: almost-URL with 100k chars
         pathological = "https://" + "a" * 100000 + " normal text"
-        
+
         start = time.time()
         result = redactor.redact_text(pathological, redact_domains=True)
         elapsed = time.time() - start
-        
+
         # Should complete quickly (< 1 second)
         assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
-        
+
         # Should preserve non-URL text
         assert "normal text" in result
 
     def test_email_redos_protection(self):
         """Ensure email regex doesn't hang on pathological input"""
         redactor = PfSenseRedactor()
-        
+
         pathological = "a" * 100000 + "@example.com"
-        
+
         start = time.time()
         result = redactor.redact_text(pathological, redact_domains=True)
         elapsed = time.time() - start
-        
+
         assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
 
     def test_fqdn_redos_protection(self):
         """Ensure FQDN regex doesn't hang on pathological input"""
         redactor = PfSenseRedactor()
-        
+
         pathological = ("subdomain." * 1000) + "example.com"
-        
+
         start = time.time()
         result = redactor.redact_text(pathological, redact_domains=True)
         elapsed = time.time() - start
-        
+
         assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
 
     def test_legitimate_urls_still_work(self):
         """Ensure legitimate URLs are still properly redacted"""
         redactor = PfSenseRedactor()
-        
+
         text = "Visit https://firmware.netgate.com for updates"
         result = redactor.redact_text(text, redact_domains=True)
-        
+
         assert "example.com" in result or "domain" in result.lower()
         assert "netgate.com" not in result
 
     def test_legitimate_emails_still_work(self):
         """Ensure legitimate emails are still properly redacted"""
         redactor = PfSenseRedactor()
-        
+
         text = "Contact admin@example.org for help"
         result = redactor.redact_text(text, redact_domains=True)
-        
+
         assert "user@example.com" in result
         assert "admin@example.org" not in result
 
     def test_legitimate_fqdns_still_work(self):
         """Ensure legitimate FQDNs are still properly redacted"""
         redactor = PfSenseRedactor()
-        
+
         text = "Server at server.example.org"
         result = redactor.redact_text(text, redact_domains=True)
-        
+
         assert "example.com" in result
         assert "server.example.org" not in result
 
     def test_max_text_chunk_protection(self):
         """Ensure absurdly long text chunks are truncated"""
         redactor = PfSenseRedactor()
-        
+
         # Create text larger than MAX_TEXT_CHUNK (1MB)
         huge_text = "a" * (redactor.MAX_TEXT_CHUNK + 1000)
-        
+
         result = redactor.redact_text(huge_text, redact_domains=True)
-        
+
         # Should be truncated to MAX_TEXT_CHUNK
         assert len(result) <= redactor.MAX_TEXT_CHUNK
 
     def test_url_length_limit(self):
         """Ensure URLs longer than MAX_URL_LENGTH are skipped"""
         redactor = PfSenseRedactor()
-        
+
         # Create a URL-like string longer than MAX_URL_LENGTH
         long_url = "https://" + "a" * (redactor.MAX_URL_LENGTH + 100) + ".com"
-        
+
         result = redactor.redact_text(long_url, redact_domains=True)
-        
+
         # Should be unchanged (too long to process)
         assert long_url in result
 
     def test_email_length_limit(self):
         """Ensure emails longer than MAX_EMAIL_LENGTH are skipped"""
         redactor = PfSenseRedactor()
-        
+
         # Create an email-like string longer than MAX_EMAIL_LENGTH
         long_email = "a" * (redactor.MAX_EMAIL_LENGTH + 100) + "@example.com"
-        
+
         result = redactor.redact_text(long_email, redact_domains=True)
-        
+
         # Should be unchanged (too long to process)
         assert long_email in result
 
     def test_fqdn_length_limit(self):
         """Ensure FQDNs longer than MAX_FQDN_LENGTH are skipped"""
         redactor = PfSenseRedactor()
-        
+
         # Create an FQDN-like string longer than MAX_FQDN_LENGTH
         long_fqdn = "a" * (redactor.MAX_FQDN_LENGTH + 100) + ".com"
-        
+
         result = redactor.redact_text(long_fqdn, redact_domains=True)
-        
+
         # Should be unchanged (too long to process)
         assert long_fqdn in result
 
@@ -135,18 +135,18 @@ class TestExceptionHandling:
     def test_idna_encode_normal_domains(self):
         """Test IDNA encoding works for normal domains"""
         from pfsense_redactor.redactor import _idna_encode
-        
+
         assert _idna_encode("example.com") == "example.com"
         assert _idna_encode("bücher.de") == "xn--bcher-kva.de"
 
     def test_idna_encode_malformed_domains(self):
         """Test IDNA encoding handles malformed domains gracefully"""
         from pfsense_redactor.redactor import _idna_encode
-        
+
         # Should not crash on malformed input
         assert _idna_encode("") == ""
         assert _idna_encode("...") == "..."
-        
+
         # Should handle edge cases
         result = _idna_encode("invalid\x00domain")
         assert result is not None  # Should return something, not crash

--- a/tests/unit/test_redos_protection.py
+++ b/tests/unit/test_redos_protection.py
@@ -1,0 +1,152 @@
+"""
+Test ReDoS (Regular Expression Denial of Service) protection
+"""
+import time
+import pytest
+from pfsense_redactor.redactor import PfSenseRedactor
+
+
+class TestReDoSProtection:
+    """Test that regex patterns don't hang on pathological input"""
+
+    def test_url_redos_protection(self):
+        """Ensure URL regex doesn't hang on pathological input"""
+        redactor = PfSenseRedactor()
+        
+        # Pathological input: almost-URL with 100k chars
+        pathological = "https://" + "a" * 100000 + " normal text"
+        
+        start = time.time()
+        result = redactor.redact_text(pathological, redact_domains=True)
+        elapsed = time.time() - start
+        
+        # Should complete quickly (< 1 second)
+        assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
+        
+        # Should preserve non-URL text
+        assert "normal text" in result
+
+    def test_email_redos_protection(self):
+        """Ensure email regex doesn't hang on pathological input"""
+        redactor = PfSenseRedactor()
+        
+        pathological = "a" * 100000 + "@example.com"
+        
+        start = time.time()
+        result = redactor.redact_text(pathological, redact_domains=True)
+        elapsed = time.time() - start
+        
+        assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
+
+    def test_fqdn_redos_protection(self):
+        """Ensure FQDN regex doesn't hang on pathological input"""
+        redactor = PfSenseRedactor()
+        
+        pathological = ("subdomain." * 1000) + "example.com"
+        
+        start = time.time()
+        result = redactor.redact_text(pathological, redact_domains=True)
+        elapsed = time.time() - start
+        
+        assert elapsed < 1.0, f"ReDoS detected: took {elapsed:.2f}s"
+
+    def test_legitimate_urls_still_work(self):
+        """Ensure legitimate URLs are still properly redacted"""
+        redactor = PfSenseRedactor()
+        
+        text = "Visit https://firmware.netgate.com for updates"
+        result = redactor.redact_text(text, redact_domains=True)
+        
+        assert "example.com" in result or "domain" in result.lower()
+        assert "netgate.com" not in result
+
+    def test_legitimate_emails_still_work(self):
+        """Ensure legitimate emails are still properly redacted"""
+        redactor = PfSenseRedactor()
+        
+        text = "Contact admin@example.org for help"
+        result = redactor.redact_text(text, redact_domains=True)
+        
+        assert "user@example.com" in result
+        assert "admin@example.org" not in result
+
+    def test_legitimate_fqdns_still_work(self):
+        """Ensure legitimate FQDNs are still properly redacted"""
+        redactor = PfSenseRedactor()
+        
+        text = "Server at server.example.org"
+        result = redactor.redact_text(text, redact_domains=True)
+        
+        assert "example.com" in result
+        assert "server.example.org" not in result
+
+    def test_max_text_chunk_protection(self):
+        """Ensure absurdly long text chunks are truncated"""
+        redactor = PfSenseRedactor()
+        
+        # Create text larger than MAX_TEXT_CHUNK (1MB)
+        huge_text = "a" * (redactor.MAX_TEXT_CHUNK + 1000)
+        
+        result = redactor.redact_text(huge_text, redact_domains=True)
+        
+        # Should be truncated to MAX_TEXT_CHUNK
+        assert len(result) <= redactor.MAX_TEXT_CHUNK
+
+    def test_url_length_limit(self):
+        """Ensure URLs longer than MAX_URL_LENGTH are skipped"""
+        redactor = PfSenseRedactor()
+        
+        # Create a URL-like string longer than MAX_URL_LENGTH
+        long_url = "https://" + "a" * (redactor.MAX_URL_LENGTH + 100) + ".com"
+        
+        result = redactor.redact_text(long_url, redact_domains=True)
+        
+        # Should be unchanged (too long to process)
+        assert long_url in result
+
+    def test_email_length_limit(self):
+        """Ensure emails longer than MAX_EMAIL_LENGTH are skipped"""
+        redactor = PfSenseRedactor()
+        
+        # Create an email-like string longer than MAX_EMAIL_LENGTH
+        long_email = "a" * (redactor.MAX_EMAIL_LENGTH + 100) + "@example.com"
+        
+        result = redactor.redact_text(long_email, redact_domains=True)
+        
+        # Should be unchanged (too long to process)
+        assert long_email in result
+
+    def test_fqdn_length_limit(self):
+        """Ensure FQDNs longer than MAX_FQDN_LENGTH are skipped"""
+        redactor = PfSenseRedactor()
+        
+        # Create an FQDN-like string longer than MAX_FQDN_LENGTH
+        long_fqdn = "a" * (redactor.MAX_FQDN_LENGTH + 100) + ".com"
+        
+        result = redactor.redact_text(long_fqdn, redact_domains=True)
+        
+        # Should be unchanged (too long to process)
+        assert long_fqdn in result
+
+
+class TestExceptionHandling:
+    """Test that exception handling is specific and correct"""
+
+    def test_idna_encode_normal_domains(self):
+        """Test IDNA encoding works for normal domains"""
+        from pfsense_redactor.redactor import _idna_encode
+        
+        assert _idna_encode("example.com") == "example.com"
+        assert _idna_encode("bücher.de") == "xn--bcher-kva.de"
+
+    def test_idna_encode_malformed_domains(self):
+        """Test IDNA encoding handles malformed domains gracefully"""
+        from pfsense_redactor.redactor import _idna_encode
+        
+        # Should not crash on malformed input
+        assert _idna_encode("") == ""
+        assert _idna_encode("...") == "..."
+        
+        # Should handle edge cases
+        result = _idna_encode("invalid\x00domain")
+        assert result is not None  # Should return something, not crash

--- a/tests/unit/test_redos_protection.py
+++ b/tests/unit/test_redos_protection.py
@@ -57,7 +57,8 @@ class TestReDoSProtection:
         text = "Visit https://firmware.netgate.com for updates"
         result = redactor.redact_text(text, redact_domains=True)
 
-        assert "example.com" in result or "domain" in result.lower()
+        # Verify URL was redacted (not URL sanitization - this is a redaction tool test)
+        assert result == "Visit https://example.com for updates"
         assert "netgate.com" not in result
 
     def test_legitimate_emails_still_work(self):
@@ -67,7 +68,8 @@ class TestReDoSProtection:
         text = "Contact admin@example.org for help"
         result = redactor.redact_text(text, redact_domains=True)
 
-        assert "user@example.com" in result
+        # Verify email was redacted (not URL sanitization - this is a redaction tool test)
+        assert result == "Contact user@example.com for help"
         assert "admin@example.org" not in result
 
     def test_legitimate_fqdns_still_work(self):

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -74,5 +74,105 @@ class TestURLWithIPHandling:
         assert "[" in result and "]" in result
 
 
+class TestNonHTTPProtocolURLs:
+    """Test URL handling for protocols other than HTTP/HTTPS"""
+
+    def test_ftp_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that FTP URLs with credentials are properly redacted"""
+        url = "ftp://user:password@ftp.example.com/files"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "password" not in result
+        assert "REDACTED" in result
+        # Should preserve username and protocol
+        assert "ftp://" in result
+        assert "user" in result
+        # Should mask domain
+        assert "ftp.example.com" not in result
+
+    def test_ftps_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that FTPS URLs with credentials are properly redacted"""
+        url = "ftps://admin:secret123@secure.example.org:990/data"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "secret123" not in result
+        assert "REDACTED" in result
+        # Should preserve protocol and username
+        assert "ftps://" in result
+        assert "admin" in result
+        # Should preserve port
+        assert ":990" in result
+
+    def test_sftp_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SFTP URLs with credentials are properly redacted"""
+        url = "sftp://backup:pass@192.168.1.100/backups"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "pass" not in result
+        assert "REDACTED" in result
+        # Should mask IP
+        assert "192.168.1.100" not in result
+
+    def test_ssh_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SSH URLs with credentials are properly redacted"""
+        url = "ssh://root:toor@server.local:22"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "toor" not in result
+        assert "REDACTED" in result
+        assert "ssh://" in result
+
+    def test_telnet_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that Telnet URLs with credentials are properly redacted"""
+        url = "telnet://admin:admin@router.local:23"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "REDACTED" in result
+        assert "telnet://" in result
+
+    def test_file_url_preserved(self, basic_redactor):
+        """Verify that file:// URLs are handled"""
+        url = "file:///etc/config.xml"
+        result = basic_redactor._mask_url(url)
+
+        # file:// URLs don't have hosts, so should be preserved
+        assert "file://" in result
+
+    def test_smb_url_with_credentials_redacted(self, basic_redactor):
+        """Verify that SMB URLs with credentials are properly redacted"""
+        url = "smb://domain\\user:password@fileserver/share"
+        result = basic_redactor._mask_url(url)
+
+        # Should redact password
+        assert "password" not in result
+        assert "REDACTED" in result
+        assert "smb://" in result
+
+    def test_mixed_protocols_in_text(self, basic_redactor):
+        """Verify that multiple protocol URLs in text are all redacted"""
+        text = """
+        FTP: ftp://user:pass@ftp.example.com/files
+        HTTPS: https://admin:secret@web.example.com/admin
+        SFTP: sftp://backup:key@192.168.1.50/data
+        """
+        result = basic_redactor.redact_text(text)
+
+        # All passwords should be redacted
+        assert "pass" not in result
+        assert "secret" not in result
+        assert "key" not in result
+        # Should have REDACTED markers
+        assert result.count("REDACTED") >= 3
+        # Protocols should be preserved
+        assert "ftp://" in result
+        assert "https://" in result
+        assert "sftp://" in result
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -6,6 +6,7 @@ Tests for URL masking, reconstruction, and IPv6 URL handling
 """
 
 import pytest
+from urllib.parse import urlparse
 
 
 class TestNormaliseMaskedURLAnonymise:
@@ -158,7 +159,7 @@ class TestNonHTTPProtocolURLs:
 
         # Should mask the hostname
         assert "fileserver.local" not in result
-        assert "example.com" in result
+        assert urlparse(result).hostname == "example.com"
         assert "file://" in result
 
     def test_nfs_url_without_hostname_preserved(self, basic_redactor):

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -216,7 +216,7 @@ class TestURLUsernameRedaction:
         """Verify that usernames are preserved by default"""
         url = "ftp://admin:password@ftp.example.com/files"
         result = basic_redactor._mask_url(url)
-        
+
         # Username should be preserved
         assert "admin" in result
         # Password should be redacted
@@ -228,7 +228,7 @@ class TestURLUsernameRedaction:
         redactor = redactor_factory(redact_url_usernames=True)
         url = "ftp://admin:password@ftp.example.com/files"
         result = redactor._mask_url(url)
-        
+
         # Username should be redacted
         assert "admin" not in result
         # Should have REDACTED for both username and password
@@ -240,7 +240,7 @@ class TestURLUsernameRedaction:
         """Verify that username-only URLs preserve username by default"""
         url = "ftp://anonymous@ftp.example.com/pub"
         result = basic_redactor._mask_url(url)
-        
+
         # Username should be preserved (no password)
         assert "anonymous" in result
         assert "REDACTED" not in result
@@ -250,7 +250,7 @@ class TestURLUsernameRedaction:
         redactor = redactor_factory(redact_url_usernames=True)
         url = "ftp://anonymous@ftp.example.com/pub"
         result = redactor._mask_url(url)
-        
+
         # Username should be redacted
         assert "anonymous" not in result
         assert "REDACTED@" in result
@@ -260,14 +260,14 @@ class TestURLUsernameRedaction:
     def test_multiple_urls_with_different_usernames(self, redactor_factory):
         """Verify that multiple URLs with different usernames are handled correctly"""
         redactor = redactor_factory(redact_url_usernames=True)
-        
+
         text = """
         ftp://admin:pass1@server1.com/data
         ftp://backup:pass2@server2.com/files
         ftp://guest@server3.com/public
         """
         result = redactor.redact_text(text)
-        
+
         # All usernames should be redacted
         assert "admin" not in result
         assert "backup" not in result
@@ -279,13 +279,13 @@ class TestURLUsernameRedaction:
     def test_sensitive_usernames_redacted(self, redactor_factory):
         """Verify that sensitive usernames like 'root' and 'admin' can be redacted"""
         redactor = redactor_factory(redact_url_usernames=True)
-        
+
         test_cases = [
             "ssh://root:toor@server.local",
             "ftp://admin:admin@router.local",
             "telnet://administrator:pass@switch.local",
         ]
-        
+
         for url in test_cases:
             result = redactor._mask_url(url)
             # Usernames should be redacted
@@ -302,7 +302,7 @@ class TestURLUsernameRedaction:
         result = redactor_preserve._mask_url(url)
         assert "apiuser" in result
         assert "apikey" not in result
-        
+
         # With flag - redact username
         redactor_redact = redactor_factory(redact_url_usernames=True)
         result = redactor_redact._mask_url(url)

--- a/tests/unit/test_url_handling.py
+++ b/tests/unit/test_url_handling.py
@@ -142,7 +142,6 @@ class TestNonHTTPProtocolURLs:
 
         # file:// URLs without hostnames should be preserved exactly
         assert result == url
-        assert "example.com" not in result
 
     def test_file_url_windows_path_preserved(self, basic_redactor):
         """Verify that file:// URLs with Windows paths are preserved"""
@@ -151,7 +150,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved exactly, not transformed to network path
         assert result == url
-        assert "example.com" not in result
 
     def test_file_url_with_hostname_redacted(self, basic_redactor):
         """Verify that file:// URLs with actual hostnames are redacted"""
@@ -170,7 +168,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved unchanged
         assert result == url
-        assert "example.com" not in result
 
     def test_smb_url_without_hostname_preserved(self, basic_redactor):
         """Verify that SMB URLs without hostnames are preserved"""
@@ -179,7 +176,6 @@ class TestNonHTTPProtocolURLs:
 
         # Should be preserved unchanged
         assert result == url
-        assert "example.com" not in result
 
     def test_smb_url_with_credentials_redacted(self, basic_redactor):
         """Verify that SMB URLs with credentials are properly redacted"""


### PR DESCRIPTION
This pull request introduces version 1.0.7 of `pfsense-redactor` with multiple security fixes, improvements to the redaction logic, and a new CLI feature. The most significant changes address vulnerabilities in domain allowlist validation and whitespace handling, enhance the robustness of port stripping and redaction routines, and add support for redacting usernames in URLs. The changelog and version numbers have been updated accordingly.

**Security and Validation Fixes:**

* Fixed a critical vulnerability in allowlist domain validation by stripping whitespace and rejecting domains with internal whitespace, preventing allowlist bypasses with whitespace-only domains. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL191-R207) [[3]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL204-R220)
* Improved port stripping logic to only strip ports from valid IPv4 addresses, preventing incorrect handling of non-IP tokens. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL408-R436)

**Redaction Logic Improvements:**

* Fixed whitespace corruption in URL, email, and FQDN redaction by switching from tokenization (`split`/`join`) to `re.sub()` with callbacks, preserving original whitespace and preventing XML corruption. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR644-R705) [[3]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL647-R735) [[4]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL673-R745)
* Added ReDoS protection and length pre-filtering to redaction routines for URLs, emails, and FQDNs.

**New Features:**

* Added a `--redact-url-usernames` CLI flag to optionally redact usernames in URLs, in addition to always redacting passwords. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR581-R583) [[3]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL103-R128) [[4]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR1217-R1218) [[5]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL1261-R1322)

**Maintenance and Versioning:**

* Updated version numbers and references from 1.0.6 to 1.0.7 in `__init__.py`, `pyproject.toml`, and reference XML outputs. [[1]](diffhunk://#diff-0e508264480c70371d524532476e35f4e6d73599eb7f55bab6632bc828bdb74cL16-R16) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[3]](diffhunk://#diff-0bda50d7449131fb4240cdcfd9ba285da21febf575096ec19b8daeb14667f833L3-R3) [[4]](diffhunk://#diff-fd905daad6cdb5197a94886b7bb1bdb752029ac9a70e9552ed06820f2e79bb43L3-R3) [[5]](diffhunk://#diff-5835199699e33e2ce0071ae966e42a9e7bd3f81b971b18d368739b97be160657L3-R3)
* Updated the changelog with detailed entries for all fixes and features, and added a link for the new release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR171)

**Type Annotation and Documentation:**

* Improved type annotations for IP address/network types for better Python 3.9 compatibility and clarified class documentation. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR16-R21) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL81-R93)

These changes significantly improve the security, reliability, and flexibility of the redaction process.