### PR TITLE
Feat/logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.7][] - 2025-11-03
 
-### Security
+### Fixed
+- **CRITICAL FIX**: Fixed whitespace corruption in URL/email/FQDN redaction
+  - `_redact_urls_safe`, `_redact_emails_safe`, and `_redact_fqdns_safe` were using `text.split()` and `' '.join()`
+  - This collapsed all whitespace (including newlines) into single spaces, corrupting XML text content
+  - Now uses `re.sub()` with callbacks to preserve original whitespace structure
+  - Maintains ReDoS protection via length pre-filtering in the callback functions
 - **CRITICAL FIX**: Fixed whitespace domain handling vulnerability in allowlist validation
   - Added `.strip()` to prevent allowlist bypass with whitespace-only domains (e.g., `"   "`)
   - Whitespace-only domains could previously match ANY domain in suffix matching
@@ -19,14 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously only checked for presence of dots, not valid IP format
   - Added 4 tests in `TestPortStrippingSecurity`
 
-### Fixed
-- **CRITICAL FIX**: Fixed whitespace corruption in URL/email/FQDN redaction
-  - `_redact_urls_safe`, `_redact_emails_safe`, and `_redact_fqdns_safe` were using `text.split()` and `' '.join()`
-  - This collapsed all whitespace (including newlines) into single spaces, corrupting XML text content
-  - Now uses `re.sub()` with callbacks to preserve original whitespace structure
-  - Maintains ReDoS protection via length pre-filtering in the callback functions
-
 ### Added
+- New `--quiet` / `-q` flag: Suppress progress messages (show only warnings and errors)
+- New `--verbose` / `-v` flag: Show detailed debug information
+- Flags are mutually exclusive and validated at runtime
+- `ColouredFormatter` class for optional ANSI colour output
+- `setup_logging()` function for configuring log levels and output streams
 - New `--redact-url-usernames` CLI flag for enhanced URL credential redaction
   - Allows redacting sensitive usernames (e.g., `admin`, `root`) in URLs
   - Default behaviour: preserve usernames, always redact passwords (`ftp://user:REDACTED@host`)
@@ -34,9 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added 7 tests in `TestURLUsernameRedaction`
 
 ### Changed
+- **BREAKING**: Replaced `print()` statements with Python's `logging` module for better integration
+  - All output now uses proper log levels (ERROR, WARNING, INFO, DEBUG)
+  - Logs route to stdout by default, stderr when using `--stdout` mode
+  - Removed `--stats-stderr` flag (no longer needed - logging handles routing automatically)
+- Coloured log output when outputting to a TTY (auto-detected, disabled for pipes/redirects)
+  - ERROR: Red, WARNING: Yellow, INFO: Green, DEBUG: Cyan
 - Domain normalisation now strips whitespace before processing dots
 - Port stripping now requires valid IPv4 address validation
 - URL/email/FQDN redaction now uses `re.sub()` instead of tokenization to preserve whitespace
+
+### Removed
+- `--stats-stderr` flag (replaced by automatic log routing in `--stdout` mode)
 
 ## [1.0.6][] - 2025-11-02
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -22,11 +22,11 @@ IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 
-class ColoredFormatter(logging.Formatter):
+class ColouredFormatter(logging.Formatter):
     """Add ANSI colour codes to log messages for TTY output"""
-
+    
     # ANSI colour codes
-    COLORS = {
+    COLOURS = {
         'DEBUG': '\033[36m',    # Cyan
         'INFO': '\033[32m',     # Green
         'WARNING': '\033[33m',  # Yellow
@@ -39,10 +39,10 @@ class ColoredFormatter(logging.Formatter):
         # Only add colours if outputting to a TTY
         if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty():
             levelname = record.levelname
-            if levelname in self.COLORS:
+            if levelname in self.COLOURS:
                 # Colour the level name and message
-                colour = self.COLORS[levelname]
-                reset = self.COLORS['RESET']
+                colour = self.COLOURS[levelname]
+                reset = self.COLOURS['RESET']
                 record.levelname = f"{colour}{levelname}{reset}"
                 record.msg = f"{colour}{record.msg}{reset}"
         return super().format(record)
@@ -62,7 +62,7 @@ def setup_logging(level: int = logging.INFO, use_stderr: bool = False) -> loggin
     logger.setLevel(level)
     logger.handlers.clear()  # Remove any existing handlers
 
-    formatter = ColoredFormatter('%(message)s')
+    formatter = ColouredFormatter('%(message)s')
 
     if use_stderr:
         # In --stdout mode, route everything to stderr

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -10,6 +10,7 @@ import re
 import sys
 import ipaddress
 import functools
+import logging
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
@@ -19,6 +20,60 @@ from urllib.parse import urlsplit, urlunsplit, SplitResult
 # Type aliases for clarity (using Union for Python 3.9 compatibility)
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+
+
+class ColoredFormatter(logging.Formatter):
+    """Add ANSI colour codes to log messages for TTY output"""
+    
+    # ANSI colour codes
+    COLORS = {
+        'DEBUG': '\033[36m',    # Cyan
+        'INFO': '\033[32m',     # Green
+        'WARNING': '\033[33m',  # Yellow
+        'ERROR': '\033[31m',    # Red
+        'RESET': '\033[0m'      # Reset
+    }
+    
+    def format(self, record):
+        """Format log record with colours if outputting to a TTY"""
+        # Only add colours if outputting to a TTY
+        if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty():
+            levelname = record.levelname
+            if levelname in self.COLORS:
+                # Colour the level name and message
+                colour = self.COLORS[levelname]
+                reset = self.COLORS['RESET']
+                record.levelname = f"{colour}{levelname}{reset}"
+                record.msg = f"{colour}{record.msg}{reset}"
+        return super().format(record)
+
+
+def setup_logging(level: int = logging.INFO, use_stderr: bool = False) -> logging.Logger:
+    """Configure logging for pfSense redactor
+    
+    Args:
+        level: Logging level (DEBUG, INFO, WARNING, ERROR)
+        use_stderr: If True, route logs to stderr (for --stdout mode)
+    
+    Returns:
+        Configured logger instance
+    """
+    logger = logging.getLogger('pfsense_redactor')
+    logger.setLevel(level)
+    logger.handlers.clear()  # Remove any existing handlers
+    
+    # Route to stderr for --stdout mode, otherwise stdout
+    stream = sys.stderr if use_stderr else sys.stdout
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(level)
+    
+    # Simple format - just the message (we include [+]/[!] in the message itself)
+    formatter = ColoredFormatter('%(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    
+    return logger
+
 
 # Module-level constants (immutable for safety)
 ALWAYS_PRESERVE_IPS: frozenset[str] = frozenset({
@@ -117,6 +172,9 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.fail_on_warn = fail_on_warn
         self.dry_run_verbose = dry_run_verbose
         self.redact_url_usernames = redact_url_usernames
+        
+        # Get logger instance
+        self.logger = logging.getLogger('pfsense_redactor')
 
         # ReDoS protection constants (instance attributes for easy access)
         self.MAX_URL_LENGTH: int = 2048  # RFC 2616 suggests 2048 as reasonable max
@@ -700,8 +758,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # ReDoS protection - reject absurdly long text chunks
         if len(text) > self.MAX_TEXT_CHUNK:
             # Log warning and truncate
-            print(f"[!] Warning: Text chunk too long ({len(text)} chars), truncating",
-                  file=sys.stderr)
+            self.logger.warning("[!] Warning: Text chunk too long (%d chars), truncating", len(text))
             text = text[:self.MAX_TEXT_CHUNK]
 
         result = text
@@ -959,21 +1016,21 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             if root_tag != 'pfsense':
                 msg = f"[!] Warning: Root tag is '{root.tag}', expected 'pfsense'."
                 if self.fail_on_warn:
-                    print(f"{msg} Exiting.", file=sys.stderr)
+                    self.logger.error("%s Exiting.", msg)
                     return False
-                print(f"{msg} Proceeding anyway...", file=sys.stderr)
+                self.logger.warning("%s Proceeding anyway...", msg)
 
             if not dry_run and not stdout_mode:
-                print(f"[+] Parsing XML configuration from: {input_file}")
+                self.logger.info("[+] Parsing XML configuration from: %s", input_file)
 
             # Redact the configuration
             if not dry_run and not stdout_mode:
-                print("[+] Redacting sensitive information...")
+                self.logger.info("[+] Redacting sensitive information...")
             self.redact_element(root, redact_ips, redact_domains)
 
             # Dry run mode: just print stats
             if dry_run:
-                print("[+] Dry run - no files modified")
+                self.logger.info("[+] Dry run - no files modified")
                 self._print_stats()
                 return True
 
@@ -988,75 +1045,62 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 tree.write(sys.stdout.buffer, encoding='utf-8', xml_declaration=True)
             elif inplace:
                 tree.write(input_file, encoding='utf-8', xml_declaration=True)
-                print(f"[+] Redacted configuration written in-place to: {input_file}")
+                self.logger.info("[+] Redacted configuration written in-place to: %s", input_file)
             else:
                 tree.write(output_file, encoding='utf-8', xml_declaration=True)
-                print(f"[+] Redacted configuration written to: {output_file}")
+                self.logger.info("[+] Redacted configuration written to: %s", output_file)
 
             # Print summary
-            if stdout_mode and stats_stderr:
-                self._print_stats(output=sys.stderr)
-            elif not stdout_mode:
+            if not stdout_mode:
                 self._print_stats()
 
             return True
 
         except ET.ParseError as e:
-            print(f"[!] Error parsing XML: {e}", file=sys.stderr)
+            self.logger.error("[!] Error parsing XML: %s", e)
             return False
         except (IOError, OSError) as e:
-            print(f"[!] Error reading/writing file: {e}", file=sys.stderr)
+            self.logger.error("[!] Error reading/writing file: %s", e)
             return False
         except (ValueError, TypeError) as e:
-            print(f"[!] Error processing configuration: {e}", file=sys.stderr)
+            self.logger.error("[!] Error processing configuration: %s", e)
             return False
 
-    def _print_stats(self, output=sys.stdout) -> None:
-        """Print redaction statistics"""
-        # Ensure UTF-8 encoding for Unicode characters (e.g., arrow →)
-        # On Windows, sys.stdout may use 'charmap' encoding which doesn't support Unicode
-        try:
-            # Try to reconfigure the stream to use UTF-8
-            if hasattr(output, 'reconfigure'):
-                output.reconfigure(encoding='utf-8', errors='replace')
-        except (AttributeError, OSError):
-            # If reconfigure fails or doesn't exist, we'll use ASCII fallback for arrow
-            pass
-
-        print("\n[+] Redaction summary:", file=output)
+    def _print_stats(self) -> None:
+        """Print redaction statistics using logger"""
+        self.logger.info("\n[+] Redaction summary:")
         if self.stats['secrets_redacted']:
-            print(f"    - Passwords/keys/secrets: {self.stats['secrets_redacted']}", file=output)
+            self.logger.info("    - Passwords/keys/secrets: %d", self.stats['secrets_redacted'])
         if self.stats['certs_redacted']:
-            print(f"    - Certificates: {self.stats['certs_redacted']}", file=output)
+            self.logger.info("    - Certificates: %d", self.stats['certs_redacted'])
         if self.stats['ips_redacted']:
-            print(f"    - IP addresses: {self.stats['ips_redacted']}", file=output)
+            self.logger.info("    - IP addresses: %d", self.stats['ips_redacted'])
         if self.stats['macs_redacted']:
-            print(f"    - MAC addresses: {self.stats['macs_redacted']}", file=output)
+            self.logger.info("    - MAC addresses: %d", self.stats['macs_redacted'])
         if self.stats['domains_redacted']:
-            print(f"    - Domain names: {self.stats['domains_redacted']}", file=output)
+            self.logger.info("    - Domain names: %d", self.stats['domains_redacted'])
         if self.stats['emails_redacted']:
-            print(f"    - Email addresses: {self.stats['emails_redacted']}", file=output)
+            self.logger.info("    - Email addresses: %d", self.stats['emails_redacted'])
         if self.stats['urls_redacted']:
-            print(f"    - URLs: {self.stats['urls_redacted']}", file=output)
+            self.logger.info("    - URLs: %d", self.stats['urls_redacted'])
 
         if self.anonymise:
-            print("\n[+] Anonymisation stats:", file=output)
-            print(f"    - Unique IPs anonymised: {len(self.ip_aliases)}", file=output)
-            print(f"    - Unique domains anonymised: {len(self.domain_aliases)}", file=output)
+            self.logger.info("\n[+] Anonymisation stats:")
+            self.logger.info("    - Unique IPs anonymised: %d", len(self.ip_aliases))
+            self.logger.info("    - Unique domains anonymised: %d", len(self.domain_aliases))
 
         # Print samples if in dry-run-verbose mode
         if self.dry_run_verbose:
-            print(f"\n[+] Samples of changes (limit N={self.sample_limit}):", file=output)
+            self.logger.info("\n[+] Samples of changes (limit N=%d):", self.sample_limit)
             has_any = any(self.samples.get(cat) for cat in ['IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key'])
             if has_any:
                 # Print in consistent order
-                # Use ASCII arrow '->' instead of Unicode '→' for Windows compatibility
                 for category in ['IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key']:
                     if category in self.samples and self.samples[category]:
                         for before_masked, after in self.samples[category]:
-                            print(f"    {category}: {before_masked} -> {after}", file=output)
+                            self.logger.info("    %s: %s -> %s", category, before_masked, after)
             else:
-                print("    (no examples collected)", file=output)
+                self.logger.info("    (no examples collected)")
 
 
 def parse_allowlist_file(filepath: str, silent_if_missing: bool = False) -> tuple[set[str], list[IPNetwork], set[str]]:
@@ -1201,8 +1245,10 @@ CDATA sections are not preserved.
                         help='Overwrite output file if it exists')
     parser.add_argument('--aggressive', action='store_true',
                         help='Apply IP/domain redaction to all element text, not just known fields')
-    parser.add_argument('--stats-stderr', action='store_true',
-                        help='Print statistics to stderr (useful with --stdout)')
+    parser.add_argument('--quiet', '-q', action='store_true',
+                        help='Suppress progress messages (show only warnings and errors)')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Show detailed debug information')
     parser.add_argument('--fail-on-warn', action='store_true',
                         help='Exit with non-zero code if root tag is not pfsense (useful in CI)')
     parser.add_argument('--allowlist-ip', action='append', dest='allowlist_ips', metavar='IP_OR_CIDR',
@@ -1219,6 +1265,22 @@ CDATA sections are not preserved.
                         help='Redact usernames in URLs (e.g., ftp://user@host becomes ftp://REDACTED@host). By default, usernames are preserved while passwords are always redacted.')
 
     args = parser.parse_args()
+    
+    # Validate mutually exclusive flags
+    if args.quiet and args.verbose:
+        parser.error("--quiet and --verbose are mutually exclusive")
+    
+    # Determine log level
+    if args.verbose:
+        log_level = logging.DEBUG
+    elif args.quiet:
+        log_level = logging.WARNING
+    else:
+        log_level = logging.INFO
+    
+    # Setup logging (route to stderr when using --stdout)
+    use_stderr = args.stdout
+    setup_logging(log_level, use_stderr)
 
     # Handle --dry-run-verbose
     if args.dry_run_verbose:
@@ -1331,7 +1393,7 @@ CDATA sections are not preserved.
         dry_run=args.dry_run,
         stdout_mode=args.stdout,
         inplace=args.inplace,
-        stats_stderr=args.stats_stderr
+        stats_stderr=False  # No longer needed - logging handles routing
     )
 
     sys.exit(0 if success else 1)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1002,8 +1002,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         redact_domains: bool = True,
         dry_run: bool = False,
         stdout_mode: bool = False,
-        inplace: bool = False,
-        stats_stderr: bool = False
+        inplace: bool = False
     ) -> bool:
         """Redact pfSense configuration file"""
         try:
@@ -1392,8 +1391,7 @@ CDATA sections are not preserved.
         redact_domains=not args.no_redact_domains,
         dry_run=args.dry_run,
         stdout_mode=args.stdout,
-        inplace=args.inplace,
-        stats_stderr=False  # No longer needed - logging handles routing
+        inplace=args.inplace
     )
 
     sys.exit(0 if success else 1)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -126,7 +126,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         # Allow-lists (opt-in, empty by default)
         # IP allow-lists: support both individual IPs and CIDR networks
-        self.allowlist_ip_addrs: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+        self.allowlist_ip_addrs: set[IPAddress] = set()
         if allowlist_ips:
             for ip_str in allowlist_ips:
                 try:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -24,7 +24,7 @@ IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 class ColouredFormatter(logging.Formatter):
     """Add ANSI colour codes to log messages for TTY output"""
-    
+
     # ANSI colour codes
     COLOURS = {
         'DEBUG': '\033[36m',    # Cyan
@@ -138,10 +138,10 @@ SENSITIVE_ATTR_TOKENS: tuple[str, ...] = (
 @functools.lru_cache(maxsize=256)
 def _idna_encode(domain: str) -> str:
     """Cache IDNA encoding for performance (domains are often repeated)
-    
+
     Args:
         domain: Domain name to encode
-        
+
     Returns:
         IDNA-encoded (punycode) ASCII string, or original if encoding fails
     """
@@ -155,7 +155,7 @@ def _idna_encode(domain: str) -> str:
 
 class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     """pfSense configuration redactor for sensitive data handling
-    
+
     Note: This class intentionally has many instance attributes to maintain
     clear separation of concerns and avoid premature optimization. The attributes
     are logically grouped and well-documented.

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1079,7 +1079,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
     def _print_stats(self) -> None:
         """Print redaction statistics using logger"""
-        self.logger.info("\n[+] Redaction summary:")
+        self.logger.info("")
+        self.logger.info("[+] Redaction summary:")
         if self.stats['secrets_redacted']:
             self.logger.info("    - Passwords/keys/secrets: %d", self.stats['secrets_redacted'])
         if self.stats['certs_redacted']:
@@ -1096,13 +1097,15 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             self.logger.info("    - URLs: %d", self.stats['urls_redacted'])
 
         if self.anonymise:
-            self.logger.info("\n[+] Anonymisation stats:")
+            self.logger.info("")
+            self.logger.info("[+] Anonymisation stats:")
             self.logger.info("    - Unique IPs anonymised: %d", len(self.ip_aliases))
             self.logger.info("    - Unique domains anonymised: %d", len(self.domain_aliases))
 
         # Print samples if in dry-run-verbose mode
         if self.dry_run_verbose:
-            self.logger.info("\n[+] Samples of changes (limit N=%d):", self.sample_limit)
+            self.logger.info("")
+            self.logger.info("[+] Samples of changes (limit N=%d):", self.sample_limit)
             has_any = any(self.samples.get(cat) for cat in ['IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key'])
             if has_any:
                 # Print in consistent order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import tempfile
 from pathlib import Path
 import xml.etree.ElementTree as ET
 

--- a/tests/integration/test_allowlist_features.py
+++ b/tests/integration/test_allowlist_features.py
@@ -9,8 +9,6 @@ Tests for IP and domain allow-list functionality including:
 - Case-insensitive matching
 - Statistics accuracy with allow-lists
 """
-import pytest
-from pathlib import Path
 import re
 
 

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -90,8 +90,7 @@ def test_stats_stderr_with_stdout(cli_runner, create_xml_file):
 """)
 
     exit_code, stdout, stderr = cli_runner.run_to_stdout(
-        str(xml_file),
-        flags=["--stats-stderr"]
+        str(xml_file)
     )
 
     assert exit_code == 0

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -3,8 +3,6 @@ CLI behaviour and safety tests
 
 Test command-line interface behaviour, error handling, and safety features
 """
-import pytest
-from pathlib import Path
 import subprocess
 
 

--- a/tests/integration/test_reference_snapshots.py
+++ b/tests/integration/test_reference_snapshots.py
@@ -5,7 +5,6 @@ These tests run the CLI with various flag combinations and compare outputs
 to reference files. Set UPDATE_REFERENCE=1 to regenerate snapshots.
 """
 import pytest
-from pathlib import Path
 
 
 # Test modes with their corresponding CLI flags

--- a/tests/integration/test_reference_snapshots.py
+++ b/tests/integration/test_reference_snapshots.py
@@ -142,7 +142,7 @@ def test_stats_stderr_mode(sample_files, cli_runner, stats_parser):
         # Run with --stdout --stats-stderr
         exit_code, stdout, stderr = cli_runner.run_to_stdout(
             str(sample_file),
-            flags=["--stats-stderr"]
+            flags=[]
         )
 
         assert exit_code == 0

--- a/tests/integration/test_statistics.py
+++ b/tests/integration/test_statistics.py
@@ -3,7 +3,6 @@ Statistics assertion tests
 
 Verify that the redactor correctly counts and reports redacted items
 """
-import pytest
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path

--- a/tests/unit/test_dry_run_verbose.py
+++ b/tests/unit/test_dry_run_verbose.py
@@ -7,8 +7,6 @@ Tests for the --dry-run-verbose feature including:
 - Sample format verification
 - No file creation in dry-run mode
 """
-import pytest
-from pathlib import Path
 
 
 def test_dry_run_verbose_shows_samples(cli_runner, create_xml_file):

--- a/tests/unit/test_focused_behaviour.py
+++ b/tests/unit/test_focused_behaviour.py
@@ -4,9 +4,6 @@ Focused behaviour tests using synthetic mini-fixtures
 These tests use minimal inline XML to verify specific redaction logic
 without depending on large sample files.
 """
-import pytest
-import xml.etree.ElementTree as ET
-
 
 # Synthetic XML fixtures
 SECRETS_XML = """<?xml version="1.0"?>

--- a/tests/unit/test_ipv6_zone_identifiers.py
+++ b/tests/unit/test_ipv6_zone_identifiers.py
@@ -7,7 +7,6 @@ parsed and preserved, including complex interface names with dots, dashes, and c
 """
 
 import pytest
-import sys
 from pathlib import Path
 import importlib.util
 

--- a/tests/unit/test_redos_protection.py
+++ b/tests/unit/test_redos_protection.py
@@ -2,7 +2,6 @@
 Test ReDoS (Regular Expression Denial of Service) protection
 """
 import time
-import pytest
 from pfsense_redactor.redactor import PfSenseRedactor
 
 

--- a/tests/unit/test_sample_masking.py
+++ b/tests/unit/test_sample_masking.py
@@ -251,15 +251,15 @@ class TestPrintStatsDefaultdictFix:
         stream = io.StringIO()
         handler = logging.StreamHandler(stream)
         handler.setLevel(logging.DEBUG)
-        
+
         # Clear existing handlers and add our test handler
         redactor.logger.handlers.clear()
         redactor.logger.addHandler(handler)
         redactor.logger.setLevel(logging.DEBUG)
-        
+
         redactor._print_stats()
         result = stream.getvalue()
-        
+
         # Clean up
         redactor.logger.removeHandler(handler)
 
@@ -279,15 +279,15 @@ class TestPrintStatsDefaultdictFix:
         stream = io.StringIO()
         handler = logging.StreamHandler(stream)
         handler.setLevel(logging.DEBUG)
-        
+
         # Clear existing handlers and add our test handler
         redactor.logger.handlers.clear()
         redactor.logger.addHandler(handler)
         redactor.logger.setLevel(logging.DEBUG)
-        
+
         redactor._print_stats()
         result = stream.getvalue()
-        
+
         # Clean up
         redactor.logger.removeHandler(handler)
 

--- a/tests/unit/test_sample_masking.py
+++ b/tests/unit/test_sample_masking.py
@@ -243,14 +243,26 @@ class TestPrintStatsDefaultdictFix:
     def test_empty_samples_prints_no_examples_collected(self, basic_redactor):
         """Verify that empty samples dict prints '(no examples collected)'"""
         import io
+        import logging
+        import sys
         redactor = basic_redactor
         redactor.dry_run_verbose = True
 
-        # Capture output
-        output = io.StringIO()
-        redactor._print_stats(output=output)
-
-        result = output.getvalue()
+        # Capture output - clear existing handlers and add our own
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.DEBUG)
+        
+        # Clear existing handlers and add our test handler
+        redactor.logger.handlers.clear()
+        redactor.logger.addHandler(handler)
+        redactor.logger.setLevel(logging.DEBUG)
+        
+        redactor._print_stats()
+        result = stream.getvalue()
+        
+        # Clean up
+        redactor.logger.removeHandler(handler)
 
         # Should print the message about no examples
         assert "(no examples collected)" in result
@@ -259,17 +271,29 @@ class TestPrintStatsDefaultdictFix:
     def test_with_samples_does_not_print_no_examples(self, basic_redactor):
         """Verify that when samples exist, we don't print '(no examples collected)'"""
         import io
+        import logging
+        import sys
         redactor = basic_redactor
         redactor.dry_run_verbose = True
 
         # Add a sample
         redactor._add_sample('IP', '192.168.1.1', 'XXX.XXX.XXX.XXX')
 
-        # Capture output
-        output = io.StringIO()
-        redactor._print_stats(output=output)
-
-        result = output.getvalue()
+        # Capture output - clear existing handlers and add our own
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.DEBUG)
+        
+        # Clear existing handlers and add our test handler
+        redactor.logger.handlers.clear()
+        redactor.logger.addHandler(handler)
+        redactor.logger.setLevel(logging.DEBUG)
+        
+        redactor._print_stats()
+        result = stream.getvalue()
+        
+        # Clean up
+        redactor.logger.removeHandler(handler)
 
         # Should NOT print the no examples message
         assert "(no examples collected)" not in result

--- a/tests/unit/test_sample_masking.py
+++ b/tests/unit/test_sample_masking.py
@@ -4,6 +4,8 @@ Tests for specific fixes applied to pfsense-redactor.py
 These tests verify the correctness of targeted bug fixes and improvements.
 """
 
+import io
+import logging
 import pytest
 import subprocess
 from pathlib import Path
@@ -242,9 +244,6 @@ class TestPrintStatsDefaultdictFix:
 
     def test_empty_samples_prints_no_examples_collected(self, basic_redactor):
         """Verify that empty samples dict prints '(no examples collected)'"""
-        import io
-        import logging
-        import sys
         redactor = basic_redactor
         redactor.dry_run_verbose = True
 
@@ -270,9 +269,6 @@ class TestPrintStatsDefaultdictFix:
 
     def test_with_samples_does_not_print_no_examples(self, basic_redactor):
         """Verify that when samples exist, we don't print '(no examples collected)'"""
-        import io
-        import logging
-        import sys
         redactor = basic_redactor
         redactor.dry_run_verbose = True
 

--- a/tests/unit/test_sample_masking.py
+++ b/tests/unit/test_sample_masking.py
@@ -6,9 +6,6 @@ These tests verify the correctness of targeted bug fixes and improvements.
 
 import io
 import logging
-import pytest
-import subprocess
-from pathlib import Path
 
 
 class TestIPv6URLReconstruction:


### PR DESCRIPTION
This pull request refactors the logging system in `pfsense_redactor/redactor.py` to use Python's `logging` module instead of direct `print` statements, and introduces colorized log output for improved readability. It also adds new command-line options for controlling log verbosity and simplifies how statistics are reported. The changes improve maintainability, configurability, and user experience, especially when running in different output modes.

**Logging system overhaul:**

* Introduced a `ColouredFormatter` class to add ANSI colour codes to log messages, making log output more readable in TTY environments.
* Added a `setup_logging` function to configure the logger, allowing logs to be routed to either stdout or stderr as appropriate (e.g., for `--stdout` mode). [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR24-R77) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR1269-R1284)
* Replaced all `print` statements used for progress, warnings, errors, and statistics with logger calls (`self.logger.info`, `self.logger.warning`, `self.logger.error`). [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL703-R761) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL962-R1033) [[3]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL991-R1103)
* The logger instance is now stored as `self.logger` in the main class for use throughout the codebase.

**Command-line interface improvements:**

* Added `--quiet` (`-q`) and `--verbose` (`-v`) flags to control logging verbosity, replacing the older `--stats-stderr` option. Mutually exclusive flag validation is enforced. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL1204-R1251) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR1269-R1284)
* The logging level is set according to the selected verbosity, and logging output is automatically routed to stderr when using `--stdout`.

**Statistics reporting:**

* The `_print_stats` method now uses the logger for output, ensuring all statistics and sample outputs are handled consistently by the logging system.

**Code consistency and cleanup:**

* Updated type annotation for `self.allowlist_ip_addrs` to use the `IPAddress` alias for clarity and consistency.
* Removed the now-unnecessary `stats_stderr` parameter and related logic, as logging handles output routing.