### PR TITLE
Feat/ipmapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Now uses precise pattern: `\b(?:password|passwd|pass|key|secret|...)\b`
   - Prevents false positives whilst maintaining security for genuine sensitive attributes
   - Added 16 comprehensive tests in `TestSensitiveAttributeAnchoring`
+- **ENHANCEMENT**: Prevent re-anonymisation of already-masked domains
+  - `_is_already_masked_host()` now recognises `domain\d+\.example` pattern when `--anonymise` is enabled
+  - Already-masked domains like `domain7.example` are no longer re-anonymised during processing
+  - Ensures consistent handling of previously redacted configurations
 
 ### Added
 - New `--quiet` / `-q` flag: Suppress progress messages (show only warnings and errors)
@@ -52,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain normalisation now strips whitespace before processing dots
 - Port stripping now requires valid IPv4 address validation
 - URL/email/FQDN redaction now uses `re.sub()` instead of tokenization to preserve whitespace
+- **IMPROVEMENT**: Simplified IPv6 documentation address mapping
+  - `_counter_to_rfc_ip()` now uses cleaner wrapping logic: `h = (counter - 1) % 0xFFFF + 1`
+  - Maps counters to single hextet (1..65535) with wrapping: `2001:db8::1` through `2001:db8::ffff`
+  - More predictable and maintainable than previous two-hextet approach
 
 ### Removed
 - `--stats-stderr` flag (replaced by automatic log routing in `--stdout` mode)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -548,8 +548,9 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             self.ip_counter += 1
             self.ip_aliases[ip_str] = f"IP_{self.ip_counter}"
 
-        # Extract counter from the alias (e.g., "IP_5" -> 5)
-        counter = self.ip_counter
+        # Extract counter from THIS IP's alias (e.g., "IP_5" -> 5)
+        alias = self.ip_aliases[ip_str]
+        counter = int(alias.split('_')[1])
         return self._counter_to_rfc_ip(counter, is_ipv6)
 
     def _mask_ip_like_tokens(self, text: str) -> str:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -511,8 +511,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # RFC 3849: 2001:db8::/32
             # Map counter to last hextet (1..65535), wrapping if needed
             # Produces addresses like 2001:db8::1, 2001:db8::2, ..., 2001:db8::ffff
-            h = (counter - 1) % 0xFFFF + 1
-            return f"2001:db8::{h:x}"
+            hextet = (counter - 1) % 0xFFFF + 1
+            return f"2001:db8::{hextet:x}"
 
         # RFC 5737 IPv4 documentation ranges (768 total addresses):
         # - 192.0.2.0/24 (TEST-NET-1): 254 usable

--- a/tests/unit/test_ip_counter_consistency.py
+++ b/tests/unit/test_ip_counter_consistency.py
@@ -6,7 +6,6 @@ These tests verify that:
 2. IPv6 counters handle large values correctly (>65535)
 """
 
-import pytest
 from pfsense_redactor.redactor import PfSenseRedactor
 
 

--- a/tests/unit/test_ip_counter_consistency.py
+++ b/tests/unit/test_ip_counter_consistency.py
@@ -1,0 +1,183 @@
+"""
+Tests for IP counter consistency in anonymization mode.
+
+These tests verify that:
+1. The same IP always maps to the same RFC documentation IP
+2. IPv6 counters handle large values correctly (>65535)
+"""
+
+import pytest
+from pfsense_redactor.redactor import PfSenseRedactor
+
+
+class TestIPCounterConsistency:
+    """Test that IP counters are extracted correctly from aliases"""
+
+    def test_same_ipv4_gets_consistent_rfc_ip(self):
+        """Verify same IPv4 always maps to same RFC IP across multiple calls"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        ip1 = "10.0.0.1"
+        ip2 = "10.0.0.2"
+        
+        # First call for ip1 - should get 192.0.2.1
+        result1a = redactor._anonymise_ip_for_url(ip1, False)
+        
+        # First call for ip2 - should get 192.0.2.2
+        result2 = redactor._anonymise_ip_for_url(ip2, False)
+        
+        # Second call for ip1 - should STILL get 192.0.2.1 (not 192.0.2.2!)
+        result1b = redactor._anonymise_ip_for_url(ip1, False)
+        
+        assert result1a == "192.0.2.1", f"First call should map to 192.0.2.1, got {result1a}"
+        assert result2 == "192.0.2.2", f"Second IP should map to 192.0.2.2, got {result2}"
+        assert result1b == "192.0.2.1", f"Repeated call should still map to 192.0.2.1, got {result1b}"
+        assert result1a == result1b, "Same IP must always map to same RFC IP"
+
+    def test_same_ipv6_gets_consistent_rfc_ip(self):
+        """Verify same IPv6 always maps to same RFC IP across multiple calls"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        ip1 = "2001:470::1"
+        ip2 = "2001:470::2"
+        
+        # First call for ip1 - should get 2001:db8::1
+        result1a = redactor._anonymise_ip_for_url(ip1, True)
+        
+        # First call for ip2 - should get 2001:db8::2
+        result2 = redactor._anonymise_ip_for_url(ip2, True)
+        
+        # Second call for ip1 - should STILL get 2001:db8::1
+        result1b = redactor._anonymise_ip_for_url(ip1, True)
+        
+        assert result1a == "2001:db8::1", f"First call should map to 2001:db8::1, got {result1a}"
+        assert result2 == "2001:db8::2", f"Second IP should map to 2001:db8::2, got {result2}"
+        assert result1b == "2001:db8::1", f"Repeated call should still map to 2001:db8::1, got {result1b}"
+        assert result1a == result1b, "Same IP must always map to same RFC IP"
+
+    def test_multiple_ips_maintain_stable_mapping(self):
+        """Test that multiple IPs maintain stable mappings even after many operations"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        ips = [f"10.0.0.{i}" for i in range(1, 11)]
+        
+        # First pass: establish mappings
+        first_pass = {ip: redactor._anonymise_ip_for_url(ip, False) for ip in ips}
+        
+        # Second pass: verify consistency
+        second_pass = {ip: redactor._anonymise_ip_for_url(ip, False) for ip in ips}
+        
+        # Third pass: interleaved access
+        third_pass = {}
+        for ip in reversed(ips):  # Access in reverse order
+            third_pass[ip] = redactor._anonymise_ip_for_url(ip, False)
+        
+        assert first_pass == second_pass, "Second pass should match first pass"
+        assert first_pass == third_pass, "Third pass should match first pass"
+        
+        # Verify each IP has unique mapping
+        assert len(set(first_pass.values())) == len(ips), "Each IP should have unique RFC IP"
+
+
+class TestIPv6HextetOverflow:
+    """Test that IPv6 RFC IPs handle large counter values correctly"""
+
+    def test_ipv6_counter_within_single_hextet(self):
+        """Test counters that fit in a single hextet (1-65535)"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        test_cases = [
+            (1, "2001:db8::1"),
+            (255, "2001:db8::ff"),
+            (65535, "2001:db8::ffff"),  # Max single hextet
+        ]
+        
+        for counter, expected in test_cases:
+            result = redactor._counter_to_rfc_ip(counter, is_ipv6=True)
+            assert result == expected, f"Counter {counter} should map to {expected}, got {result}"
+
+    def test_ipv6_counter_exceeds_single_hextet(self):
+        """Test counters that require two hextets (>65535)"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        test_cases = [
+            (65536, "2001:db8::1:0"),      # First value needing two hextets
+            (65537, "2001:db8::1:1"),
+            (131071, "2001:db8::1:ffff"),  # Max with high=1
+            (131072, "2001:db8::2:0"),     # First with high=2
+            (196607, "2001:db8::2:ffff"),
+            (196608, "2001:db8::3:0"),
+        ]
+        
+        for counter, expected in test_cases:
+            result = redactor._counter_to_rfc_ip(counter, is_ipv6=True)
+            assert result == expected, f"Counter {counter} should map to {expected}, got {result}"
+
+    def test_ipv6_very_large_counter(self):
+        """Test very large counter values"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        # Test a large counter (e.g., 1 million)
+        counter = 1_000_000
+        result = redactor._counter_to_rfc_ip(counter, is_ipv6=True)
+        
+        # Should be 2001:db8::f:4240 (1000000 = 0xF4240)
+        # high = 0xF, low = 0x4240
+        assert result == "2001:db8::f:4240", f"Counter {counter} should map to 2001:db8::f:4240, got {result}"
+
+    def test_ipv6_counter_boundary_values(self):
+        """Test boundary values around hextet overflow"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        # Test around the 65535/65536 boundary
+        result_max_single = redactor._counter_to_rfc_ip(65535, is_ipv6=True)
+        result_min_double = redactor._counter_to_rfc_ip(65536, is_ipv6=True)
+        
+        assert result_max_single == "2001:db8::ffff", "Max single hextet should be ::ffff"
+        assert result_min_double == "2001:db8::1:0", "Min double hextet should be ::1:0"
+        
+        # Verify they're different
+        assert result_max_single != result_min_double, "Boundary values should produce different IPs"
+
+
+class TestIPCounterInURLContext:
+    """Test IP counter consistency specifically in URL contexts"""
+
+    def test_url_with_repeated_ip_uses_consistent_rfc_ip(self):
+        """Test that URLs with the same IP get consistent RFC IPs"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        # Process URLs directly (not through redact_text which uses IP_n for bare IPs)
+        url1a = "http://10.0.0.1/path1"
+        url2 = "http://10.0.0.2/path2"
+        url1b = "http://10.0.0.1/path3"
+        
+        result1a = redactor._mask_url(url1a)
+        result2 = redactor._mask_url(url2)
+        result1b = redactor._mask_url(url1b)
+        
+        # Both occurrences of 10.0.0.1 should map to 192.0.2.1
+        assert "192.0.2.1" in result1a, f"First URL should use 192.0.2.1, got {result1a}"
+        assert "192.0.2.2" in result2, f"Second URL should use 192.0.2.2, got {result2}"
+        assert "192.0.2.1" in result1b, f"Third URL should use 192.0.2.1, got {result1b}"
+        
+        # Verify the IP part is consistent (paths will differ)
+        assert result1a == "http://192.0.2.1/path1", "First URL should have correct IP and path"
+        assert result1b == "http://192.0.2.1/path3", "Third URL should have same IP, different path"
+
+    def test_mixed_bare_and_url_ips_use_same_counter(self):
+        """Test that bare IPs and IPs in URLs share the same counter system"""
+        redactor = PfSenseRedactor(anonymise=True)
+        
+        # First encounter as bare IP
+        bare_result = redactor._anonymise_ip("10.0.0.1")
+        
+        # Second encounter in URL context
+        url_result = redactor._anonymise_ip_for_url("10.0.0.1", False)
+        
+        # Both should use counter 1
+        assert bare_result == "IP_1", f"Bare IP should get IP_1 alias, got {bare_result}"
+        assert url_result == "192.0.2.1", f"URL should use RFC IP 192.0.2.1, got {url_result}"
+        
+        # Verify they share the same underlying counter
+        assert redactor.ip_aliases["10.0.0.1"] == "IP_1", "Should have IP_1 alias"

--- a/tests/unit/test_sensitive_attribute_anchoring.py
+++ b/tests/unit/test_sensitive_attribute_anchoring.py
@@ -16,10 +16,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'compass_heading' attribute is not redacted (contains 'pass' substring)"""
         xml = '<config><device compass_heading="north"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         # compass_heading should NOT be redacted (doesn't match \bpass\b)
         assert root.find('device').get('compass_heading') == 'north'
         assert redactor.stats['secrets_redacted'] == 0
@@ -28,10 +28,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'author' attribute is not redacted (contains 'auth' substring)"""
         xml = '<config><document author="John Doe"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         # author should NOT be redacted (doesn't match \bauth\b or \bauthentication\b)
         assert root.find('document').get('author') == 'John Doe'
         assert redactor.stats['secrets_redacted'] == 0
@@ -40,10 +40,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'bypass' attribute is not redacted (contains 'pass' substring)"""
         xml = '<config><rule bypass="true"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         # bypass should NOT be redacted
         assert root.find('rule').get('bypass') == 'true'
         assert redactor.stats['secrets_redacted'] == 0
@@ -52,10 +52,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'password' attribute IS redacted (exact match)"""
         xml = '<config><user password="secret123"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         # password SHOULD be redacted
         assert root.find('user').get('password') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
@@ -64,10 +64,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'passwd' attribute IS redacted"""
         xml = '<config><user passwd="secret123"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('user').get('passwd') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
 
@@ -75,10 +75,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'pass' attribute IS redacted (whole word)"""
         xml = '<config><user pass="secret123"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('user').get('pass') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
 
@@ -88,10 +88,10 @@ class TestSensitiveAttributeAnchoring:
             <service api_key="key1" api-key="key2" apikey="key3"/>
         </config>'''
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         service = root.find('service')
         assert service.get('api_key') == '[REDACTED]'
         assert service.get('api-key') == '[REDACTED]'
@@ -104,10 +104,10 @@ class TestSensitiveAttributeAnchoring:
             <service auth="val1" auth_key="val2" auth_token="val3" authentication="val4"/>
         </config>'''
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         service = root.find('service')
         assert service.get('auth') == '[REDACTED]'
         assert service.get('auth_key') == '[REDACTED]'
@@ -119,10 +119,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify client_secret and client-secret are redacted"""
         xml = '<config><oauth client_secret="s1" client-secret="s2"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         oauth = root.find('oauth')
         assert oauth.get('client_secret') == '[REDACTED]'
         assert oauth.get('client-secret') == '[REDACTED]'
@@ -141,21 +141,21 @@ class TestSensitiveAttributeAnchoring:
             />
         </config>'''
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         device = root.find('device')
         # Safe attributes preserved
         assert device.get('compass_heading') == 'north'
         assert device.get('author') == 'John'
         assert device.get('bypass') == 'true'
-        
+
         # Sensitive attributes redacted
         assert device.get('password') == '[REDACTED]'
         assert device.get('api_key') == '[REDACTED]'
         assert device.get('token') == '[REDACTED]'
-        
+
         # Should have redacted exactly 3 attributes
         assert redactor.stats['secrets_redacted'] == 3
 
@@ -165,10 +165,10 @@ class TestSensitiveAttributeAnchoring:
             <service PASSWORD="s1" ApiKey="s2" AUTH="s3"/>
         </config>'''
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         service = root.find('service')
         assert service.get('PASSWORD') == '[REDACTED]'
         assert service.get('ApiKey') == '[REDACTED]'
@@ -179,10 +179,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'key' attribute is redacted"""
         xml = '<config><item key="secret"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('item').get('key') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
 
@@ -190,10 +190,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'secret' attribute is redacted"""
         xml = '<config><item secret="value"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('item').get('secret') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
 
@@ -201,10 +201,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'bearer' and 'token' attributes are redacted"""
         xml = '<config><auth bearer="xyz" token="abc"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         auth = root.find('auth')
         assert auth.get('bearer') == '[REDACTED]'
         assert auth.get('token') == '[REDACTED]'
@@ -214,10 +214,10 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'cookie' attribute is redacted"""
         xml = '<config><session cookie="sessionid=xyz"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('session').get('cookie') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
 
@@ -225,9 +225,9 @@ class TestSensitiveAttributeAnchoring:
         """Verify 'signature' attribute is redacted"""
         xml = '<config><message signature="abc123"/></config>'
         root = ET.fromstring(xml)
-        
+
         redactor = PfSenseRedactor()
         redactor.redact_element(root)
-        
+
         assert root.find('message').get('signature') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1

--- a/tests/unit/test_sensitive_attribute_anchoring.py
+++ b/tests/unit/test_sensitive_attribute_anchoring.py
@@ -5,7 +5,6 @@ This test suite verifies that the sensitive attribute pattern uses word boundari
 to avoid matching substrings like 'pass' in 'compass_heading' or 'auth' in 'author'.
 """
 import xml.etree.ElementTree as ET
-import pytest
 from pfsense_redactor.redactor import PfSenseRedactor
 
 


### PR DESCRIPTION
This pull request enhances the IP anonymisation logic in `pfsense_redactor/redactor.py` by introducing the use of RFC documentation IP addresses for anonymised output, especially in URL contexts. The update ensures that anonymised IPs are valid and parseable, improving both clarity and compliance with documentation standards.

Key improvements to IP anonymisation:

* Added a new method `_counter_to_rfc_ip` that maps anonymised IP counters to valid RFC documentation IP addresses for both IPv4 (RFC 5737) and IPv6 (RFC 3849) ranges, ensuring generated IPs are always valid for documentation and testing purposes.
* Introduced `_anonymise_ip_for_url`, which reuses the anonymisation counter to provide consistent RFC documentation IPs for use in URLs, replacing the previous generic `IP_n` format in these contexts.
* Updated the `_mask_ip_host` method to use `_anonymise_ip_for_url` when anonymising IPs in URL hosts, ensuring all anonymised IPs in URLs are valid and parseable.