### PR TITLE
Add version checker with --version and --check-version flags, fix ver…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+- **NEW**: Version checking functionality with `--version` and `--check-version` flags
+  - `--version`: Display current version and exit (instant, no network call)
+  - `--check-version`: Check PyPI for latest version with context-aware upgrade instructions
+  - Automatic installation method detection (pipx, venv, user, source, pip)
+
 ## [1.0.8] - 2025-11-05
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -166,6 +166,66 @@ pfsense-redactor config.xml --inplace --force
 
 ---
 
+## Command-Line Flags Reference
+
+### Version & Help
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Show program version and exit |
+| `--check-version` | Check for updates from PyPI |
+| `-h, --help` | Show help message and exit |
+
+### Input/Output
+
+| Flag | Description |
+|------|-------------|
+| `input` | Input pfSense config.xml file (positional argument) |
+| `output` | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
+| `--stdout` | Write redacted XML to stdout instead of file |
+| `--inplace` | Overwrite input file with redacted output (use with caution) |
+| `--force` | Overwrite output file if it already exists |
+| `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security) |
+
+### Redaction Modes
+
+| Flag | Description |
+|------|-------------|
+| `--keep-private-ips` | Keep non-global IP addresses visible (RFC1918/ULA/loopback/link-local). Netmasks and unspecified addresses (0.0.0.0, ::) always preserved |
+| `--no-keep-private-ips` | When used with `--anonymise`, do NOT keep private IPs visible (mask all IPs) |
+| `--anonymise` | Use consistent aliases (IP_1, domain1.example) to preserve network topology. Implies `--keep-private-ips` unless `--no-keep-private-ips` specified |
+| `--aggressive` | Apply IP/domain redaction to all element text, not just known fields |
+| `--no-redact-ips` | Do not redact IP addresses |
+| `--no-redact-domains` | Do not redact domain names |
+| `--redact-url-usernames` | Redact usernames in URLs (default: preserve usernames, always redact passwords) |
+
+### Allow-lists
+
+| Flag | Description |
+|------|-------------|
+| `--allowlist-ip IP_OR_CIDR` | IP address or CIDR network to never redact (repeatable). Applies to text and URLs |
+| `--allowlist-domain DOMAIN` | Domain to never redact (repeatable, case-insensitive, supports suffix matching). Applies to bare FQDNs and URL hostnames |
+| `--allowlist-file PATH` | File containing IPs, CIDR networks, and domains to never redact (one per line) |
+| `--no-default-allowlist` | Do not load default allow-list files (.pfsense-allowlist in current dir or ~/.pfsense-allowlist) |
+
+### Testing & Diagnostics
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show statistics only, do not write output file |
+| `--dry-run-verbose` | Show statistics with sample redactions (safely masked to prevent leaks) |
+| `--fail-on-warn` | Exit with non-zero code if root tag is not 'pfsense' (useful in CI) |
+
+### Output Control
+
+| Flag | Description |
+|------|-------------|
+| `-q, --quiet` | Suppress progress messages (show only warnings and errors) |
+| `-v, --verbose` | Show detailed debug information |
+
+
+---
+
 ## Allow-lists
 
 Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1714,7 +1714,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     except ImportError:
         # Fallback when running as script (not as module)
         __version__ = "1.0.8"
-    
+
     parser = argparse.ArgumentParser(
         description='Redact sensitive information from pfSense XML configuration files',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1749,7 +1749,7 @@ CDATA sections are not preserved.
                         help='Show program version and exit')
     parser.add_argument('--check-version', action='store_true',
                         help='Check for updates from PyPI')
-    
+
     parser.add_argument('input', nargs='?', help='Input pfSense config.xml file')
     parser.add_argument('output', nargs='?', help='Output redacted config.xml file')
     parser.add_argument('--no-redact-ips', action='store_true',
@@ -1799,10 +1799,10 @@ CDATA sections are not preserved.
     if args.check_version:
         # Import version checker
         from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
-        
+
         # Setup basic logging for version check
         setup_logging(logging.INFO, use_stderr=False)
-        
+
         # Run version check and exit
         success = print_version_check(verbose=False)
         sys.exit(0 if success else 1)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1798,7 +1798,7 @@ CDATA sections are not preserved.
     # Handle --check-version flag
     if args.check_version:
         # Import version checker
-        from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
+        from .version_checker import print_version_check  # pylint: disable=C0415
 
         # Setup basic logging for version check
         setup_logging(logging.INFO, use_stderr=False)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1795,6 +1795,10 @@ CDATA sections are not preserved.
 
     args = parser.parse_args()
 
+    # Validate required arguments for normal operation
+    if not args.check_version and not args.input:
+        parser.error("the following arguments are required: input")
+
     # Handle --check-version flag
     if args.check_version:
         # Import version checker

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,7 +32,7 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=C0415,no-member
+        import importlib.metadata  # pylint: disable=import-outside-toplevel,no-member
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly
@@ -130,7 +130,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed as editable (development mode)
     try:
-        import pkg_resources  # pylint: disable=C0415,import-error
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if dist.location and Path(dist.location).name == 'pfsense-redactor':
             # Editable install (likely `pip install -e .`)
@@ -144,8 +144,8 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed in user site-packages
     try:
-        import site  # pylint: disable=C0415
-        import pkg_resources  # pylint: disable=C0415,import-error
+        import site  # pylint: disable=import-outside-toplevel
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         user_site = site.getusersitepackages()
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -144,9 +144,11 @@ def detect_installation_method() -> InstallationMethod:
     # Check if installed in user site-packages
     try:
         import site  # pylint: disable=import-outside-toplevel
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         user_site = site.getusersitepackages()
-        if user_site and Path(sys.prefix).samefile(Path(sys.base_prefix)):
-            # Not in venv and might be user install
+        dist = pkg_resources.get_distribution('pfsense-redactor')
+        if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):
+            # Installed in user site-packages
             return InstallationMethod(
                 method="user",
                 upgrade_command="pip install --user --upgrade pfsense-redactor"

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -138,7 +138,8 @@ def detect_installation_method() -> InstallationMethod:
                 method="source",
                 upgrade_command="git pull && pip install -e ."
             )
-    except Exception:  # pylint: disable=broad-except
+    except (ImportError, AttributeError, ValueError, TypeError):
+        # pkg_resources not available or distribution not found
         pass
 
     # Check if installed in user site-packages
@@ -153,7 +154,8 @@ def detect_installation_method() -> InstallationMethod:
                 method="user",
                 upgrade_command="pip install --user --upgrade pfsense-redactor"
             )
-    except Exception:  # pylint: disable=broad-except
+    except (ImportError, AttributeError, ValueError, TypeError, OSError):
+        # site/pkg_resources not available, or path resolution failed
         pass
 
     # Default/unknown method

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,14 +32,14 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=import-outside-toplevel
+        import importlib.metadata  # pylint: disable=C0415
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly
         try:
             init_file = Path(__file__).parent / '__init__.py'
-            with open(init_file, 'r', encoding='utf-8') as f:
-                for line in f:
+            with open(init_file, 'r', encoding='utf-8') as file_handle:
+                for line in file_handle:
                     if line.startswith('__version__'):
                         # Extract version from __version__ = "x.y.z"
                         return line.split('=')[1].strip().strip('"').strip("'")
@@ -130,7 +130,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed as editable (development mode)
     try:
-        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        import pkg_resources  # pylint: disable=C0415,import-error
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if dist.location and Path(dist.location).name == 'pfsense-redactor':
             # Editable install (likely `pip install -e .`)
@@ -143,8 +143,8 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed in user site-packages
     try:
-        import site  # pylint: disable=import-outside-toplevel
-        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        import site  # pylint: disable=C0415
+        import pkg_resources  # pylint: disable=C0415,import-error
         user_site = site.getusersitepackages()
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -31,9 +31,20 @@ class InstallationMethod(NamedTuple):
 def get_current_version() -> str:
     """Get the current installed version"""
     try:
-        from . import __version__  # pylint: disable=import-outside-toplevel
-        return __version__
-    except ImportError:
+        # Use importlib.metadata to avoid cyclic import
+        import importlib.metadata  # pylint: disable=import-outside-toplevel
+        return importlib.metadata.version('pfsense-redactor')
+    except Exception:  # pylint: disable=broad-except
+        # Fallback: try to read from __init__.py directly
+        try:
+            init_file = Path(__file__).parent / '__init__.py'
+            with open(init_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if line.startswith('__version__'):
+                        # Extract version from __version__ = "x.y.z"
+                        return line.split('=')[1].strip().strip('"').strip("'")
+        except Exception:  # pylint: disable=broad-except
+            pass
         return "unknown"
 
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -70,17 +70,17 @@ def check_pypi_version(timeout: int = 5) -> str | None:
             data = json.loads(response.read().decode('utf-8'))
             return data['info']['version']
 
-    except urllib.error.HTTPError as e:
-        logger.debug("HTTP error checking PyPI: %s", e)
+    except urllib.error.HTTPError as err:
+        logger.debug("HTTP error checking PyPI: %s", err)
         return None
-    except urllib.error.URLError as e:
-        logger.debug("Network error checking PyPI: %s", e)
+    except urllib.error.URLError as err:
+        logger.debug("Network error checking PyPI: %s", err)
         return None
-    except (json.JSONDecodeError, KeyError) as e:
-        logger.debug("Error parsing PyPI response: %s", e)
+    except (json.JSONDecodeError, KeyError) as err:
+        logger.debug("Error parsing PyPI response: %s", err)
         return None
-    except Exception as e:  # pylint: disable=broad-except
-        logger.debug("Unexpected error checking PyPI: %s", e)
+    except Exception as err:  # pylint: disable=broad-except
+        logger.debug("Unexpected error checking PyPI: %s", err)
         return None
 
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -121,7 +121,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if running in a virtual environment
     if hasattr(sys, 'real_prefix') or (
-        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+            hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
     ):
         return InstallationMethod(
             method="venv",

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -3,7 +3,7 @@
 Checks PyPI for the latest version and provides upgrade instructions
 based on detected installation method.
 """
-from __future__ import annotations
+from __future__ import annotations  # pylint: disable=no-name-in-module
 
 import json
 import os
@@ -15,14 +15,14 @@ from typing import NamedTuple
 import logging
 
 
-class VersionInfo(NamedTuple):
+class VersionInfo(NamedTuple):  # pylint: disable=too-few-public-methods
     """Version information from PyPI"""
     current: str
     latest: str
     update_available: bool
 
 
-class InstallationMethod(NamedTuple):
+class InstallationMethod(NamedTuple):  # pylint: disable=too-few-public-methods
     """Detected installation method and upgrade command"""
     method: str
     upgrade_command: str

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,7 +32,7 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=C0415
+        import importlib.metadata  # pylint: disable=C0415,no-member
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -1,0 +1,213 @@
+"""Version checker for pfsense-redactor
+
+Checks PyPI for the latest version and provides upgrade instructions
+based on detected installation method.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import NamedTuple
+import logging
+
+
+class VersionInfo(NamedTuple):
+    """Version information from PyPI"""
+    current: str
+    latest: str
+    update_available: bool
+
+
+class InstallationMethod(NamedTuple):
+    """Detected installation method and upgrade command"""
+    method: str
+    upgrade_command: str
+
+
+def get_current_version() -> str:
+    """Get the current installed version"""
+    try:
+        from . import __version__  # pylint: disable=import-outside-toplevel
+        return __version__
+    except ImportError:
+        return "unknown"
+
+
+def check_pypi_version(timeout: int = 5) -> str | None:
+    """Check PyPI for the latest version
+
+    Args:
+        timeout: Request timeout in seconds
+
+    Returns:
+        Latest version string or None if check failed
+    """
+    logger = logging.getLogger('pfsense_redactor')
+
+    try:
+        url = "https://pypi.org/pypi/pfsense-redactor/json"
+        req = urllib.request.Request(
+            url,
+            headers={'User-Agent': 'pfsense-redactor-version-checker'}
+        )
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return data['info']['version']
+
+    except urllib.error.HTTPError as e:
+        logger.debug("HTTP error checking PyPI: %s", e)
+        return None
+    except urllib.error.URLError as e:
+        logger.debug("Network error checking PyPI: %s", e)
+        return None
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.debug("Error parsing PyPI response: %s", e)
+        return None
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug("Unexpected error checking PyPI: %s", e)
+        return None
+
+
+def compare_versions(current: str, latest: str) -> bool:
+    """Compare version strings to check if update is available
+
+    Args:
+        current: Current version string (e.g., "1.0.8")
+        latest: Latest version string from PyPI
+
+    Returns:
+        True if update is available, False otherwise
+    """
+    if current == "unknown" or latest == "unknown":
+        return False
+
+    try:
+        # Simple comparison - split by dots and compare as tuples
+        current_parts = tuple(int(x) for x in current.split('.'))
+        latest_parts = tuple(int(x) for x in latest.split('.'))
+        return latest_parts > current_parts
+    except (ValueError, AttributeError):
+        return False
+
+
+def detect_installation_method() -> InstallationMethod:
+    """Detect how pfsense-redactor was installed
+
+    Returns:
+        InstallationMethod with method name and upgrade command
+    """
+    # Check if running in pipx environment
+    if 'PIPX_HOME' in os.environ or 'pipx' in sys.prefix:
+        return InstallationMethod(
+            method="pipx",
+            upgrade_command="pipx upgrade pfsense-redactor"
+        )
+
+    # Check if running in a virtual environment
+    if hasattr(sys, 'real_prefix') or (
+        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+    ):
+        return InstallationMethod(
+            method="venv",
+            upgrade_command="pip install --upgrade pfsense-redactor"
+        )
+
+    # Check if installed as editable (development mode)
+    try:
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        dist = pkg_resources.get_distribution('pfsense-redactor')
+        if dist.location and Path(dist.location).name == 'pfsense-redactor':
+            # Editable install (likely `pip install -e .`)
+            return InstallationMethod(
+                method="source",
+                upgrade_command="git pull && pip install -e ."
+            )
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    # Check if installed in user site-packages
+    try:
+        import site  # pylint: disable=import-outside-toplevel
+        user_site = site.getusersitepackages()
+        if user_site and Path(sys.prefix).samefile(Path(sys.base_prefix)):
+            # Not in venv and might be user install
+            return InstallationMethod(
+                method="user",
+                upgrade_command="pip install --user --upgrade pfsense-redactor"
+            )
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    # Default/unknown method
+    return InstallationMethod(
+        method="pip",
+        upgrade_command="pip install --upgrade pfsense-redactor"
+    )
+
+
+def get_version_info() -> VersionInfo | None:
+    """Get version information comparing current vs. latest
+
+    Returns:
+        VersionInfo or None if check failed
+    """
+    current = get_current_version()
+    latest = check_pypi_version()
+
+    if latest is None:
+        return None
+
+    update_available = compare_versions(current, latest)
+
+    return VersionInfo(
+        current=current,
+        latest=latest,
+        update_available=update_available
+    )
+
+
+def print_version_check(verbose: bool = False) -> bool:
+    """Print version check results
+
+    Args:
+        verbose: If True, show detailed information
+
+    Returns:
+        True if check was successful, False otherwise
+    """
+    logger = logging.getLogger('pfsense_redactor')
+
+    version_info = get_version_info()
+
+    if version_info is None:
+        logger.error("[!] Error: Could not connect to PyPI to check for updates")
+        logger.info("    Check your internet connection or try again later")
+        return False
+
+    # Print version information
+    logger.info("Current version: %s", version_info.current)
+    logger.info("Latest version:  %s", version_info.latest)
+    logger.info("")
+
+    if version_info.update_available:
+        # Detect installation method
+        install_method = detect_installation_method()
+
+        logger.info("[i] Update available!")
+        logger.info("")
+        logger.info("To upgrade:")
+        logger.info("  %s", install_method.upgrade_command)
+
+        if verbose or install_method.method not in ('pipx', 'venv', 'user'):
+            logger.info("")
+            logger.info("For other installation methods, see:")
+            logger.info("  https://github.com/grounzero/pfsense-redactor#installation")
+    else:
+        logger.info("[✓] You are using the latest version")
+
+    return True


### PR DESCRIPTION
This pull request adds a new version checking feature to the pfSense redactor CLI, allowing users to check for updates from PyPI and receive upgrade instructions based on their installation method. It also updates the version number and improves the CLI argument handling. The most important changes are:

**New Features:**

* Added a new `version_checker.py` module that checks PyPI for the latest version, compares it to the current version, detects the installation method, and provides upgrade instructions.
* Introduced a `--check-version` CLI flag to trigger the version check and print results, including upgrade commands and installation method detection. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL1741-R1753) [[2]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bR1798-R1809)

**CLI Improvements:**

* Added a `--version` flag to display the program version and updated argument parsing to make input/output files optional.
* Ensured the CLI can import the version string robustly, with a fallback for script execution.

**Version Update:**

* Bumped the package version from `1.0.7` to `1.0.8` in `__init__.py`.…sion mismatch to 1.0.8