### PR TITLE
Feat/version checker

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,7 @@ disable=
     C0301,  # line-too-long (regex patterns and help text are hard to break meaningfully)
     C0415,  # import-outside-toplevel (intentional for avoiding circular imports)
     E1101,  # no-member (false positive for importlib.metadata in some pylint versions)
+    E0611,  # no-name-in-module (false positive for __future__.annotations in Python 3.7+)
     R0903,  # too-few-public-methods (not applicable to NamedTuple classes)
 
 [BASIC]

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,8 @@ disable=
     W0718,  # broad-exception-caught (intentional for IDNA encoding fallback)
     C0302,  # too-many-lines (single-module design is intentional for this tool)
     C0301,  # line-too-long (regex patterns and help text are hard to break meaningfully)
+    C0415,  # import-outside-toplevel (intentional for avoiding circular imports)
+    E1101,  # no-member (false positive for importlib.metadata in some pylint versions)
 
 [BASIC]
 # Allow common short variable names

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,10 +7,12 @@
 disable=
     R0801,  # duplicate-code (can occur in similar logic paths)
     W0718,  # broad-exception-caught (intentional for IDNA encoding fallback)
+    W0703,  # broad-except (intentional for fallback error handling in version checker)
     C0302,  # too-many-lines (single-module design is intentional for this tool)
     C0301,  # line-too-long (regex patterns and help text are hard to break meaningfully)
     C0415,  # import-outside-toplevel (intentional for avoiding circular imports)
     E1101,  # no-member (false positive for importlib.metadata in some pylint versions)
+    R0903,  # too-few-public-methods (not applicable to NamedTuple classes)
 
 [BASIC]
 # Allow common short variable names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+- **NEW**: Version checking functionality with `--version` and `--check-version` flags
+  - `--version`: Display current version and exit (instant, no network call)
+  - `--check-version`: Check PyPI for latest version with context-aware upgrade instructions
+  - Automatic installation method detection (pipx, venv, user, source, pip)
+
 ## [1.0.8] - 2025-11-05
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -166,6 +166,66 @@ pfsense-redactor config.xml --inplace --force
 
 ---
 
+## Command-Line Flags Reference
+
+### Version & Help
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Show program version and exit |
+| `--check-version` | Check for updates from PyPI |
+| `-h, --help` | Show help message and exit |
+
+### Input/Output
+
+| Flag | Description |
+|------|-------------|
+| `input` | Input pfSense config.xml file (positional argument) |
+| `output` | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
+| `--stdout` | Write redacted XML to stdout instead of file |
+| `--inplace` | Overwrite input file with redacted output (use with caution) |
+| `--force` | Overwrite output file if it already exists |
+| `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security) |
+
+### Redaction Modes
+
+| Flag | Description |
+|------|-------------|
+| `--keep-private-ips` | Keep non-global IP addresses visible (RFC1918/ULA/loopback/link-local). Netmasks and unspecified addresses (0.0.0.0, ::) always preserved |
+| `--no-keep-private-ips` | When used with `--anonymise`, do NOT keep private IPs visible (mask all IPs) |
+| `--anonymise` | Use consistent aliases (IP_1, domain1.example) to preserve network topology. Implies `--keep-private-ips` unless `--no-keep-private-ips` specified |
+| `--aggressive` | Apply IP/domain redaction to all element text, not just known fields |
+| `--no-redact-ips` | Do not redact IP addresses |
+| `--no-redact-domains` | Do not redact domain names |
+| `--redact-url-usernames` | Redact usernames in URLs (default: preserve usernames, always redact passwords) |
+
+### Allow-lists
+
+| Flag | Description |
+|------|-------------|
+| `--allowlist-ip IP_OR_CIDR` | IP address or CIDR network to never redact (repeatable). Applies to text and URLs |
+| `--allowlist-domain DOMAIN` | Domain to never redact (repeatable, case-insensitive, supports suffix matching). Applies to bare FQDNs and URL hostnames |
+| `--allowlist-file PATH` | File containing IPs, CIDR networks, and domains to never redact (one per line) |
+| `--no-default-allowlist` | Do not load default allow-list files (.pfsense-allowlist in current dir or ~/.pfsense-allowlist) |
+
+### Testing & Diagnostics
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show statistics only, do not write output file |
+| `--dry-run-verbose` | Show statistics with sample redactions (safely masked to prevent leaks) |
+| `--fail-on-warn` | Exit with non-zero code if root tag is not 'pfsense' (useful in CI) |
+
+### Output Control
+
+| Flag | Description |
+|------|-------------|
+| `-q, --quiet` | Suppress progress messages (show only warnings and errors) |
+| `-v, --verbose` | Show detailed debug information |
+
+
+---
+
 ## Allow-lists
 
 Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1714,7 +1714,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     except ImportError:
         # Fallback when running as script (not as module)
         __version__ = "1.0.8"
-    
+
     parser = argparse.ArgumentParser(
         description='Redact sensitive information from pfSense XML configuration files',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1749,7 +1749,7 @@ CDATA sections are not preserved.
                         help='Show program version and exit')
     parser.add_argument('--check-version', action='store_true',
                         help='Check for updates from PyPI')
-    
+
     parser.add_argument('input', nargs='?', help='Input pfSense config.xml file')
     parser.add_argument('output', nargs='?', help='Output redacted config.xml file')
     parser.add_argument('--no-redact-ips', action='store_true',
@@ -1799,10 +1799,10 @@ CDATA sections are not preserved.
     if args.check_version:
         # Import version checker
         from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
-        
+
         # Setup basic logging for version check
         setup_logging(logging.INFO, use_stderr=False)
-        
+
         # Run version check and exit
         success = print_version_check(verbose=False)
         sys.exit(0 if success else 1)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1798,7 +1798,7 @@ CDATA sections are not preserved.
     # Handle --check-version flag
     if args.check_version:
         # Import version checker
-        from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
+        from .version_checker import print_version_check  # pylint: disable=C0415
 
         # Setup basic logging for version check
         setup_logging(logging.INFO, use_stderr=False)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1750,7 +1750,7 @@ CDATA sections are not preserved.
     parser.add_argument('--check-version', action='store_true',
                         help='Check for updates from PyPI')
 
-    parser.add_argument('input', nargs='?', help='Input pfSense config.xml file')
+    parser.add_argument('input', nargs='?', help='Input pfSense config.xml file (required unless --check-version is used)')
     parser.add_argument('output', nargs='?', help='Output redacted config.xml file')
     parser.add_argument('--no-redact-ips', action='store_true',
                         help='Do not redact IP addresses')

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1795,6 +1795,10 @@ CDATA sections are not preserved.
 
     args = parser.parse_args()
 
+    # Validate required arguments for normal operation
+    if not args.check_version and not args.input:
+        parser.error("the following arguments are required: input")
+
     # Handle --check-version flag
     if args.check_version:
         # Import version checker

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1710,7 +1710,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     """Main entry point for the pfSense redactor CLI"""
     # Import version for --version flag
     try:
-        from . import __version__  # pylint: disable=import-outside-toplevel
+        from . import __version__
     except ImportError:
         # Fallback when running as script (not as module)
         __version__ = "1.0.8"
@@ -1802,7 +1802,7 @@ CDATA sections are not preserved.
     # Handle --check-version flag
     if args.check_version:
         # Import version checker
-        from .version_checker import print_version_check  # pylint: disable=C0415
+        from .version_checker import print_version_check
 
         # Setup basic logging for version check
         setup_logging(logging.INFO, use_stderr=False)

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,7 +32,7 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=C0415,no-member
+        import importlib.metadata  # pylint: disable=import-outside-toplevel,no-member
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly
@@ -130,7 +130,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed as editable (development mode)
     try:
-        import pkg_resources  # pylint: disable=C0415,import-error
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if dist.location and Path(dist.location).name == 'pfsense-redactor':
             # Editable install (likely `pip install -e .`)
@@ -144,8 +144,8 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed in user site-packages
     try:
-        import site  # pylint: disable=C0415
-        import pkg_resources  # pylint: disable=C0415,import-error
+        import site  # pylint: disable=import-outside-toplevel
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         user_site = site.getusersitepackages()
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -137,7 +137,7 @@ def detect_installation_method() -> InstallationMethod:
         import importlib.metadata
         dist = importlib.metadata.distribution('pfsense-redactor')
         # Use the public files() API to check if this is an editable install
-        if dist.read_text('direct_url.json'):
+        if dist.files and any(f.name == 'direct_url.json' for f in dist.files):
             # Has direct_url.json which indicates editable or direct install
             # Check if it's a local directory (editable install)
             direct_url_data = json.loads(dist.read_text('direct_url.json'))

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -3,7 +3,7 @@
 Checks PyPI for the latest version and provides upgrade instructions
 based on detected installation method.
 """
-from __future__ import annotations  # pylint: disable=no-name-in-module
+from __future__ import annotations
 
 import json
 import os
@@ -19,14 +19,14 @@ import logging
 COMMON_INSTALL_METHODS = ('pipx', 'venv', 'user')
 
 
-class VersionInfo(NamedTuple):  # pylint: disable=too-few-public-methods
+class VersionInfo(NamedTuple):
     """Version information from PyPI"""
     current: str
     latest: str
     update_available: bool
 
 
-class InstallationMethod(NamedTuple):  # pylint: disable=too-few-public-methods
+class InstallationMethod(NamedTuple):
     """Detected installation method and upgrade command"""
     method: str
     upgrade_command: str
@@ -47,7 +47,7 @@ def get_current_version() -> str:
                     if line.startswith('__version__'):
                         # Extract version from __version__ = "x.y.z"
                         return line.split('=')[1].strip().strip('"').strip("'")
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             pass
         return "unknown"
 
@@ -83,7 +83,7 @@ def check_pypi_version(timeout: int = 5) -> str | None:
     except (json.JSONDecodeError, KeyError) as err:
         logger.debug("Error parsing PyPI response: %s", err)
         return None
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:
         logger.debug("Unexpected error checking PyPI: %s", err)
         return None
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -144,9 +144,11 @@ def detect_installation_method() -> InstallationMethod:
     # Check if installed in user site-packages
     try:
         import site  # pylint: disable=import-outside-toplevel
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
         user_site = site.getusersitepackages()
-        if user_site and Path(sys.prefix).samefile(Path(sys.base_prefix)):
-            # Not in venv and might be user install
+        dist = pkg_resources.get_distribution('pfsense-redactor')
+        if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):
+            # Installed in user site-packages
             return InstallationMethod(
                 method="user",
                 upgrade_command="pip install --user --upgrade pfsense-redactor"

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -15,6 +15,10 @@ from typing import NamedTuple
 import logging
 
 
+# Installation methods that provide full upgrade instructions
+COMMON_INSTALL_METHODS = ('pipx', 'venv', 'user')
+
+
 class VersionInfo(NamedTuple):  # pylint: disable=too-few-public-methods
     """Version information from PyPI"""
     current: str
@@ -231,7 +235,7 @@ def print_version_check(verbose: bool = False) -> bool:
         logger.info("To upgrade:")
         logger.info("  %s", install_method.upgrade_command)
 
-        if verbose or install_method.method not in ('pipx', 'venv', 'user'):
+        if verbose or install_method.method not in COMMON_INSTALL_METHODS:
             logger.info("")
             logger.info("For other installation methods, see:")
             logger.info("  https://github.com/grounzero/pfsense-redactor#installation")

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -138,7 +138,8 @@ def detect_installation_method() -> InstallationMethod:
                 method="source",
                 upgrade_command="git pull && pip install -e ."
             )
-    except Exception:  # pylint: disable=broad-except
+    except (ImportError, AttributeError, ValueError, TypeError):
+        # pkg_resources not available or distribution not found
         pass
 
     # Check if installed in user site-packages
@@ -153,7 +154,8 @@ def detect_installation_method() -> InstallationMethod:
                 method="user",
                 upgrade_command="pip install --user --upgrade pfsense-redactor"
             )
-    except Exception:  # pylint: disable=broad-except
+    except (ImportError, AttributeError, ValueError, TypeError, OSError):
+        # site/pkg_resources not available, or path resolution failed
         pass
 
     # Default/unknown method

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,14 +32,14 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=import-outside-toplevel
+        import importlib.metadata  # pylint: disable=C0415
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly
         try:
             init_file = Path(__file__).parent / '__init__.py'
-            with open(init_file, 'r', encoding='utf-8') as f:
-                for line in f:
+            with open(init_file, 'r', encoding='utf-8') as file_handle:
+                for line in file_handle:
                     if line.startswith('__version__'):
                         # Extract version from __version__ = "x.y.z"
                         return line.split('=')[1].strip().strip('"').strip("'")
@@ -130,7 +130,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed as editable (development mode)
     try:
-        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        import pkg_resources  # pylint: disable=C0415,import-error
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if dist.location and Path(dist.location).name == 'pfsense-redactor':
             # Editable install (likely `pip install -e .`)
@@ -143,8 +143,8 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed in user site-packages
     try:
-        import site  # pylint: disable=import-outside-toplevel
-        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        import site  # pylint: disable=C0415
+        import pkg_resources  # pylint: disable=C0415,import-error
         user_site = site.getusersitepackages()
         dist = pkg_resources.get_distribution('pfsense-redactor')
         if user_site and Path(dist.location).resolve().is_relative_to(Path(user_site).resolve()):

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -31,9 +31,20 @@ class InstallationMethod(NamedTuple):
 def get_current_version() -> str:
     """Get the current installed version"""
     try:
-        from . import __version__  # pylint: disable=import-outside-toplevel
-        return __version__
-    except ImportError:
+        # Use importlib.metadata to avoid cyclic import
+        import importlib.metadata  # pylint: disable=import-outside-toplevel
+        return importlib.metadata.version('pfsense-redactor')
+    except Exception:  # pylint: disable=broad-except
+        # Fallback: try to read from __init__.py directly
+        try:
+            init_file = Path(__file__).parent / '__init__.py'
+            with open(init_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if line.startswith('__version__'):
+                        # Extract version from __version__ = "x.y.z"
+                        return line.split('=')[1].strip().strip('"').strip("'")
+        except Exception:  # pylint: disable=broad-except
+            pass
         return "unknown"
 
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -36,7 +36,7 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=import-outside-toplevel,no-member
+        import importlib.metadata
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly
@@ -134,7 +134,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed as editable (development mode)
     try:
-        import importlib.metadata  # pylint: disable=import-outside-toplevel,no-member
+        import importlib.metadata
         dist = importlib.metadata.distribution('pfsense-redactor')
         # Use the public files() API to check if this is an editable install
         if dist.read_text('direct_url.json'):
@@ -152,8 +152,8 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if installed in user site-packages
     try:
-        import site  # pylint: disable=import-outside-toplevel
-        import importlib.metadata  # pylint: disable=import-outside-toplevel,no-member
+        import site
+        import importlib.metadata
         user_site = site.getusersitepackages()
         dist = importlib.metadata.distribution('pfsense-redactor')
         # Get the location using the metadata's locate_file method

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -70,17 +70,17 @@ def check_pypi_version(timeout: int = 5) -> str | None:
             data = json.loads(response.read().decode('utf-8'))
             return data['info']['version']
 
-    except urllib.error.HTTPError as e:
-        logger.debug("HTTP error checking PyPI: %s", e)
+    except urllib.error.HTTPError as err:
+        logger.debug("HTTP error checking PyPI: %s", err)
         return None
-    except urllib.error.URLError as e:
-        logger.debug("Network error checking PyPI: %s", e)
+    except urllib.error.URLError as err:
+        logger.debug("Network error checking PyPI: %s", err)
         return None
-    except (json.JSONDecodeError, KeyError) as e:
-        logger.debug("Error parsing PyPI response: %s", e)
+    except (json.JSONDecodeError, KeyError) as err:
+        logger.debug("Error parsing PyPI response: %s", err)
         return None
-    except Exception as e:  # pylint: disable=broad-except
-        logger.debug("Unexpected error checking PyPI: %s", e)
+    except Exception as err:  # pylint: disable=broad-except
+        logger.debug("Unexpected error checking PyPI: %s", err)
         return None
 
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -121,7 +121,7 @@ def detect_installation_method() -> InstallationMethod:
 
     # Check if running in a virtual environment
     if hasattr(sys, 'real_prefix') or (
-        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+            hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
     ):
         return InstallationMethod(
             method="venv",

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -3,7 +3,7 @@
 Checks PyPI for the latest version and provides upgrade instructions
 based on detected installation method.
 """
-from __future__ import annotations
+from __future__ import annotations  # pylint: disable=no-name-in-module
 
 import json
 import os
@@ -15,14 +15,14 @@ from typing import NamedTuple
 import logging
 
 
-class VersionInfo(NamedTuple):
+class VersionInfo(NamedTuple):  # pylint: disable=too-few-public-methods
     """Version information from PyPI"""
     current: str
     latest: str
     update_available: bool
 
 
-class InstallationMethod(NamedTuple):
+class InstallationMethod(NamedTuple):  # pylint: disable=too-few-public-methods
     """Detected installation method and upgrade command"""
     method: str
     upgrade_command: str

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -163,7 +163,8 @@ def detect_installation_method() -> InstallationMethod:
             first_file = dist_files[0]
             location = first_file.locate().resolve().parent
             # Navigate up to find the site-packages directory
-            while location.parent != location and location.name not in ('site-packages', 'dist-packages'):
+            # Stop at root (location.parent == location) or when we find site-packages
+            while location.name not in ('site-packages', 'dist-packages') and location != location.parent:
                 location = location.parent
             if location.is_relative_to(Path(user_site).resolve()):
                 # Installed in user site-packages

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -32,7 +32,7 @@ def get_current_version() -> str:
     """Get the current installed version"""
     try:
         # Use importlib.metadata to avoid cyclic import
-        import importlib.metadata  # pylint: disable=C0415
+        import importlib.metadata  # pylint: disable=C0415,no-member
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
         # Fallback: try to read from __init__.py directly

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -1,0 +1,213 @@
+"""Version checker for pfsense-redactor
+
+Checks PyPI for the latest version and provides upgrade instructions
+based on detected installation method.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import NamedTuple
+import logging
+
+
+class VersionInfo(NamedTuple):
+    """Version information from PyPI"""
+    current: str
+    latest: str
+    update_available: bool
+
+
+class InstallationMethod(NamedTuple):
+    """Detected installation method and upgrade command"""
+    method: str
+    upgrade_command: str
+
+
+def get_current_version() -> str:
+    """Get the current installed version"""
+    try:
+        from . import __version__  # pylint: disable=import-outside-toplevel
+        return __version__
+    except ImportError:
+        return "unknown"
+
+
+def check_pypi_version(timeout: int = 5) -> str | None:
+    """Check PyPI for the latest version
+
+    Args:
+        timeout: Request timeout in seconds
+
+    Returns:
+        Latest version string or None if check failed
+    """
+    logger = logging.getLogger('pfsense_redactor')
+
+    try:
+        url = "https://pypi.org/pypi/pfsense-redactor/json"
+        req = urllib.request.Request(
+            url,
+            headers={'User-Agent': 'pfsense-redactor-version-checker'}
+        )
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return data['info']['version']
+
+    except urllib.error.HTTPError as e:
+        logger.debug("HTTP error checking PyPI: %s", e)
+        return None
+    except urllib.error.URLError as e:
+        logger.debug("Network error checking PyPI: %s", e)
+        return None
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.debug("Error parsing PyPI response: %s", e)
+        return None
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug("Unexpected error checking PyPI: %s", e)
+        return None
+
+
+def compare_versions(current: str, latest: str) -> bool:
+    """Compare version strings to check if update is available
+
+    Args:
+        current: Current version string (e.g., "1.0.8")
+        latest: Latest version string from PyPI
+
+    Returns:
+        True if update is available, False otherwise
+    """
+    if current == "unknown" or latest == "unknown":
+        return False
+
+    try:
+        # Simple comparison - split by dots and compare as tuples
+        current_parts = tuple(int(x) for x in current.split('.'))
+        latest_parts = tuple(int(x) for x in latest.split('.'))
+        return latest_parts > current_parts
+    except (ValueError, AttributeError):
+        return False
+
+
+def detect_installation_method() -> InstallationMethod:
+    """Detect how pfsense-redactor was installed
+
+    Returns:
+        InstallationMethod with method name and upgrade command
+    """
+    # Check if running in pipx environment
+    if 'PIPX_HOME' in os.environ or 'pipx' in sys.prefix:
+        return InstallationMethod(
+            method="pipx",
+            upgrade_command="pipx upgrade pfsense-redactor"
+        )
+
+    # Check if running in a virtual environment
+    if hasattr(sys, 'real_prefix') or (
+        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+    ):
+        return InstallationMethod(
+            method="venv",
+            upgrade_command="pip install --upgrade pfsense-redactor"
+        )
+
+    # Check if installed as editable (development mode)
+    try:
+        import pkg_resources  # pylint: disable=import-outside-toplevel,import-error
+        dist = pkg_resources.get_distribution('pfsense-redactor')
+        if dist.location and Path(dist.location).name == 'pfsense-redactor':
+            # Editable install (likely `pip install -e .`)
+            return InstallationMethod(
+                method="source",
+                upgrade_command="git pull && pip install -e ."
+            )
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    # Check if installed in user site-packages
+    try:
+        import site  # pylint: disable=import-outside-toplevel
+        user_site = site.getusersitepackages()
+        if user_site and Path(sys.prefix).samefile(Path(sys.base_prefix)):
+            # Not in venv and might be user install
+            return InstallationMethod(
+                method="user",
+                upgrade_command="pip install --user --upgrade pfsense-redactor"
+            )
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    # Default/unknown method
+    return InstallationMethod(
+        method="pip",
+        upgrade_command="pip install --upgrade pfsense-redactor"
+    )
+
+
+def get_version_info() -> VersionInfo | None:
+    """Get version information comparing current vs. latest
+
+    Returns:
+        VersionInfo or None if check failed
+    """
+    current = get_current_version()
+    latest = check_pypi_version()
+
+    if latest is None:
+        return None
+
+    update_available = compare_versions(current, latest)
+
+    return VersionInfo(
+        current=current,
+        latest=latest,
+        update_available=update_available
+    )
+
+
+def print_version_check(verbose: bool = False) -> bool:
+    """Print version check results
+
+    Args:
+        verbose: If True, show detailed information
+
+    Returns:
+        True if check was successful, False otherwise
+    """
+    logger = logging.getLogger('pfsense_redactor')
+
+    version_info = get_version_info()
+
+    if version_info is None:
+        logger.error("[!] Error: Could not connect to PyPI to check for updates")
+        logger.info("    Check your internet connection or try again later")
+        return False
+
+    # Print version information
+    logger.info("Current version: %s", version_info.current)
+    logger.info("Latest version:  %s", version_info.latest)
+    logger.info("")
+
+    if version_info.update_available:
+        # Detect installation method
+        install_method = detect_installation_method()
+
+        logger.info("[i] Update available!")
+        logger.info("")
+        logger.info("To upgrade:")
+        logger.info("  %s", install_method.upgrade_command)
+
+        if verbose or install_method.method not in ('pipx', 'venv', 'user'):
+            logger.info("")
+            logger.info("For other installation methods, see:")
+            logger.info("  https://github.com/grounzero/pfsense-redactor#installation")
+    else:
+        logger.info("[✓] You are using the latest version")
+
+    return True

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -371,7 +371,7 @@ def test_version_and_check_version_mutually_exclusive(script_path):
     )
 
     # Should fail - these flags are mutually exclusive
-    # (or one takes precedence, depending on implementation)
+    # The CLI returns an error if both --version and --check-version are provided together.
     # At minimum, should handle gracefully
     assert result.returncode == 0 or "error" in result.stderr.lower()
 

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -447,11 +447,15 @@ def test_anonymise_consistent_aliases(cli_runner, create_xml_file, tmp_path):
 
     assert exit_code == 0
     output_content = output_file.read_text()
-    # Same IP should get same alias
+
+    # Same IP should get same alias - verify using Counter
     ip_aliases = re.findall(r'IP_\d+', output_content)
-    # 93.184.216.34 appears twice, should have same alias
-    assert len(ip_aliases) >= 2
-    assert ip_aliases[0] == ip_aliases[1]
+    # 93.184.216.34 appears twice, should have same alias (at least one alias appears multiple times)
+    alias_counts = Counter(ip_aliases)
+    assert len(ip_aliases) >= 2, "Expected at least 2 IP aliases"
+    # At least one alias should appear more than once (same IP = same alias)
+    max_count = max(alias_counts.values()) if alias_counts else 0
+    assert max_count >= 2, f"Expected at least one alias to appear twice, got counts: {alias_counts}"
 
     # Same domain should get same alias
     domain_aliases = re.findall(r'domain\d+\.example', output_content)

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -450,7 +450,8 @@ def test_anonymise_consistent_aliases(cli_runner, create_xml_file, tmp_path):
 
     # Same IP should get same alias - verify using Counter
     ip_aliases = re.findall(r'IP_\d+', output_content)
-    # 93.184.216.34 appears twice, should have same alias (at least one alias appears multiple times)
+    # Verify that duplicate IPs receive the same alias by checking that at least one alias appears multiple times
+    # (93.184.216.34 appears twice in the config, so its alias should appear twice in the output)
     alias_counts = Counter(ip_aliases)
     assert len(ip_aliases) >= 2, "Expected at least 2 IP aliases"
     # At least one alias should appear more than once (same IP = same alias)

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -447,7 +447,6 @@ def test_anonymise_consistent_aliases(cli_runner, create_xml_file, tmp_path):
 
     assert exit_code == 0
     output_content = output_file.read_text()
-
     # Same IP should get same alias
     ip_aliases = re.findall(r'IP_\d+', output_content)
     # 93.184.216.34 appears twice, should have same alias

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -448,13 +448,10 @@ def test_anonymise_consistent_aliases(cli_runner, create_xml_file, tmp_path):
     assert exit_code == 0
     output_content = output_file.read_text()
 
-    # Same IP should get same alias - verify using Counter
+    # Verify duplicate IPs (93.184.216.34 appears twice) get the same alias
     ip_aliases = re.findall(r'IP_\d+', output_content)
-    # Verify that duplicate IPs receive the same alias by checking that at least one alias appears multiple times
-    # (93.184.216.34 appears twice in the config, so its alias should appear twice in the output)
     alias_counts = Counter(ip_aliases)
     assert len(ip_aliases) >= 2, "Expected at least 2 IP aliases"
-    # At least one alias should appear more than once (same IP = same alias)
     max_count = max(alias_counts.values()) if alias_counts else 0
     assert max_count >= 2, f"Expected at least one alias to appear twice, got counts: {alias_counts}"
 

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -39,7 +39,7 @@ def test_empty_input_file(cli_runner, tmp_path):
     assert "empty" in stderr.lower() or "error" in stderr.lower()
 
 
-def test_output_required_without_special_modes(script_path, create_xml_file, _tmp_path):
+def test_output_required_without_special_modes(script_path, create_xml_file):
     """Test that output file is auto-generated if not provided"""
     xml_file = create_xml_file("""<?xml version="1.0"?>
 <pfsense>
@@ -100,7 +100,7 @@ def test_stats_stderr_with_stdout(cli_runner, create_xml_file):
     assert "Passwords/keys/secrets:" in stderr
 
 
-def test_inplace_modifies_original(cli_runner, create_xml_file, _tmp_path):
+def test_inplace_modifies_original(cli_runner, create_xml_file):
     """Test --inplace overwrites input file"""
     xml_file = create_xml_file("""<?xml version="1.0"?>
 <pfsense>

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -1,0 +1,255 @@
+"""Unit tests for version checker module"""
+import unittest
+from unittest.mock import patch, Mock, mock_open
+import json
+
+from pfsense_redactor.version_checker import (
+    compare_versions,
+    get_current_version,
+    detect_installation_method,
+    check_pypi_version,
+    get_version_info,
+    COMMON_INSTALL_METHODS
+)
+
+
+class TestCompareVersions(unittest.TestCase):
+    """Test version comparison logic"""
+
+    def test_patch_version_bump(self):
+        """Newer patch version should return True"""
+        self.assertTrue(compare_versions("1.0.8", "1.0.9"))
+
+    def test_minor_version_bump(self):
+        """Newer minor version should return True"""
+        self.assertTrue(compare_versions("1.0.8", "1.1.0"))
+
+    def test_major_version_bump(self):
+        """Newer major version should return True"""
+        self.assertTrue(compare_versions("1.0.8", "2.0.0"))
+
+    def test_same_version(self):
+        """Same version should return False"""
+        self.assertFalse(compare_versions("1.0.8", "1.0.8"))
+
+    def test_older_version(self):
+        """Older version should return False"""
+        self.assertFalse(compare_versions("1.0.9", "1.0.8"))
+
+    def test_unknown_current_version(self):
+        """Unknown current version should return False"""
+        self.assertFalse(compare_versions("unknown", "1.0.9"))
+
+    def test_unknown_latest_version(self):
+        """Unknown latest version should return False"""
+        self.assertFalse(compare_versions("1.0.8", "unknown"))
+
+    def test_malformed_version_string(self):
+        """Malformed version string should return False"""
+        self.assertFalse(compare_versions("1.0.8", "not-a-version"))
+        self.assertFalse(compare_versions("not-a-version", "1.0.8"))
+
+    def test_version_with_extra_components(self):
+        """Version with different number of components"""
+        self.assertTrue(compare_versions("1.0", "1.0.1"))
+        self.assertTrue(compare_versions("1.0.8.0", "1.0.8.1"))
+
+
+class TestGetCurrentVersion(unittest.TestCase):
+    """Test current version retrieval"""
+
+    def test_get_version_from_importlib_metadata(self):
+        """Should get version from importlib.metadata first"""
+        # This test calls the real implementation
+        version = get_current_version()
+        # Should return a version string (will be the actual installed version)
+        self.assertIsInstance(version, str)
+        self.assertNotEqual(version, "unknown")
+
+    @patch('builtins.open', new_callable=mock_open, read_data='__version__ = "1.0.7"\n')
+    def test_fallback_to_init_file(self, _mock_file):
+        """Should fall back to __init__.py when importlib fails"""
+        # Mock importlib.metadata to not exist
+        import sys  # pylint: disable=import-outside-toplevel
+        with patch.dict(sys.modules, {'importlib.metadata': None}):
+            version = get_current_version()
+            # Will use real importlib.metadata since we can't fully mock it
+            # Just verify it doesn't crash
+            self.assertIsInstance(version, str)
+
+    def test_return_unknown_on_error(self):
+        """Should handle errors gracefully"""
+        # This is hard to test without complex mocking
+        # Just verify the function doesn't crash
+        version = get_current_version()
+        self.assertIsInstance(version, str)
+
+
+class TestDetectInstallationMethod(unittest.TestCase):
+    """Test installation method detection"""
+
+    @patch.dict('os.environ', {'PIPX_HOME': '/home/user/.local/pipx'})
+    def test_detect_pipx_via_env_var(self):
+        """Should detect pipx installation via PIPX_HOME env var"""
+        method = detect_installation_method()
+        self.assertEqual(method.method, "pipx")
+        self.assertEqual(method.upgrade_command, "pipx upgrade pfsense-redactor")
+
+    @patch('sys.prefix', '/home/user/.local/pipx/venvs/pfsense-redactor')
+    def test_detect_pipx_via_prefix(self):
+        """Should detect pipx installation via sys.prefix"""
+        method = detect_installation_method()
+        self.assertEqual(method.method, "pipx")
+
+    @patch('sys.base_prefix', '/usr')
+    @patch('sys.prefix', '/home/user/venv')
+    def test_detect_venv(self):
+        """Should detect virtual environment installation"""
+        method = detect_installation_method()
+        self.assertEqual(method.method, "venv")
+        self.assertEqual(method.upgrade_command, "pip install --upgrade pfsense-redactor")
+
+    def test_detect_editable_install(self):
+        """Should detect editable (development) installation"""
+        # This is hard to test without being in an actual editable install
+        # Just verify the function doesn't crash
+        method = detect_installation_method()
+        self.assertIsInstance(method.method, str)
+        self.assertIsInstance(method.upgrade_command, str)
+
+    def test_method_returns_valid_structure(self):
+        """Should always return a valid InstallationMethod"""
+        method = detect_installation_method()
+        self.assertIsInstance(method.method, str)
+        self.assertIsInstance(method.upgrade_command, str)
+        self.assertIn("pfsense-redactor", method.upgrade_command)
+
+
+class TestCheckPyPIVersion(unittest.TestCase):
+    """Test PyPI version checking"""
+
+    @patch('urllib.request.urlopen')
+    def test_successful_pypi_check(self, mock_urlopen):
+        """Should successfully retrieve version from PyPI"""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "info": {"version": "1.0.9"}
+        }).encode('utf-8')
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        version = check_pypi_version()
+        self.assertEqual(version, "1.0.9")
+
+    @patch('urllib.request.urlopen')
+    def test_http_error(self, mock_urlopen):
+        """Should handle HTTP errors gracefully"""
+        from urllib.error import HTTPError  # pylint: disable=import-outside-toplevel
+        mock_urlopen.side_effect = HTTPError(None, 404, "Not Found", None, None)
+
+        version = check_pypi_version()
+        self.assertIsNone(version)
+
+    @patch('urllib.request.urlopen')
+    def test_network_timeout(self, mock_urlopen):
+        """Should handle network timeouts gracefully"""
+        from urllib.error import URLError  # pylint: disable=import-outside-toplevel
+        mock_urlopen.side_effect = URLError("Timeout")
+
+        version = check_pypi_version()
+        self.assertIsNone(version)
+
+    @patch('urllib.request.urlopen')
+    def test_malformed_json_response(self, mock_urlopen):
+        """Should handle malformed JSON responses"""
+        mock_response = Mock()
+        mock_response.read.return_value = b"not json"
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        version = check_pypi_version()
+        self.assertIsNone(version)
+
+    @patch('urllib.request.urlopen')
+    def test_missing_version_key(self, mock_urlopen):
+        """Should handle missing version key in response"""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "info": {}  # Missing version key
+        }).encode('utf-8')
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        version = check_pypi_version()
+        self.assertIsNone(version)
+
+    @patch('urllib.request.urlopen')
+    def test_custom_timeout(self, mock_urlopen):
+        """Should use custom timeout parameter"""
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps({
+            "info": {"version": "1.0.9"}
+        }).encode('utf-8')
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        check_pypi_version(timeout=10)
+        # Verify timeout was passed (check call args)
+        self.assertTrue(mock_urlopen.called)
+
+
+class TestGetVersionInfo(unittest.TestCase):
+    """Test version info retrieval"""
+
+    @patch('pfsense_redactor.version_checker.check_pypi_version')
+    @patch('pfsense_redactor.version_checker.get_current_version')
+    def test_update_available(self, mock_current, mock_pypi):
+        """Should detect when update is available"""
+        mock_current.return_value = "1.0.8"
+        mock_pypi.return_value = "1.0.9"
+
+        info = get_version_info()
+        self.assertIsNotNone(info)
+        self.assertEqual(info.current, "1.0.8")
+        self.assertEqual(info.latest, "1.0.9")
+        self.assertTrue(info.update_available)
+
+    @patch('pfsense_redactor.version_checker.check_pypi_version')
+    @patch('pfsense_redactor.version_checker.get_current_version')
+    def test_no_update_available(self, mock_current, mock_pypi):
+        """Should detect when no update is available"""
+        mock_current.return_value = "1.0.8"
+        mock_pypi.return_value = "1.0.8"
+
+        info = get_version_info()
+        self.assertIsNotNone(info)
+        self.assertFalse(info.update_available)
+
+    @patch('pfsense_redactor.version_checker.check_pypi_version')
+    @patch('pfsense_redactor.version_checker.get_current_version')
+    def test_pypi_check_failed(self, mock_current, mock_pypi):
+        """Should return None when PyPI check fails"""
+        mock_current.return_value = "1.0.8"
+        mock_pypi.return_value = None
+
+        info = get_version_info()
+        self.assertIsNone(info)
+
+
+class TestConstants(unittest.TestCase):
+    """Test module-level constants"""
+
+    def test_common_install_methods_defined(self):
+        """COMMON_INSTALL_METHODS should be defined correctly"""
+        self.assertIsInstance(COMMON_INSTALL_METHODS, tuple)
+        self.assertIn('pipx', COMMON_INSTALL_METHODS)
+        self.assertIn('venv', COMMON_INSTALL_METHODS)
+        self.assertIn('user', COMMON_INSTALL_METHODS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -70,7 +70,7 @@ class TestGetCurrentVersion(unittest.TestCase):
     def test_fallback_to_init_file(self, _mock_file):
         """Should fall back to __init__.py when importlib fails"""
         # Mock importlib.metadata to not exist
-        import sys  # pylint: disable=import-outside-toplevel
+        import sys
         with patch.dict(sys.modules, {'importlib.metadata': None}):
             version = get_current_version()
             # Will use real importlib.metadata since we can't fully mock it
@@ -145,7 +145,7 @@ class TestCheckPyPIVersion(unittest.TestCase):
     @patch('urllib.request.urlopen')
     def test_http_error(self, mock_urlopen):
         """Should handle HTTP errors gracefully"""
-        from urllib.error import HTTPError  # pylint: disable=import-outside-toplevel
+        from urllib.error import HTTPError
         mock_urlopen.side_effect = HTTPError(None, 404, "Not Found", None, None)
 
         version = check_pypi_version()
@@ -154,7 +154,7 @@ class TestCheckPyPIVersion(unittest.TestCase):
     @patch('urllib.request.urlopen')
     def test_network_timeout(self, mock_urlopen):
         """Should handle network timeouts gracefully"""
-        from urllib.error import URLError  # pylint: disable=import-outside-toplevel
+        from urllib.error import URLError
         mock_urlopen.side_effect = URLError("Timeout")
 
         version = check_pypi_version()

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -101,6 +101,7 @@ class TestDetectInstallationMethod(unittest.TestCase):
         method = detect_installation_method()
         self.assertEqual(method.method, "pipx")
 
+    @patch.dict('os.environ', {}, clear=True)  # Clear PIPX_HOME
     @patch('sys.base_prefix', '/usr')
     @patch('sys.prefix', '/home/user/venv')
     def test_detect_venv(self):


### PR DESCRIPTION
This pull request introduces version checking features to the `pfsense-redactor` CLI, including new command-line flags for displaying and checking the program version, as well as context-aware upgrade instructions. It also updates documentation and increments the package version.

### Version checking functionality

* Added `--version` flag to display the current program version and exit instantly, and `--check-version` flag to check PyPI for the latest version and provide upgrade instructions based on the installation method. [[1]](diffhunk://#diff-85f0c70da5ba959e75aa0a66b7363b5cc8a6a3b9f5ff7c8278dd73c73db2e89bL1741-R1753) [[2]](diffhunk://#diff-ba3170b2408c8e287e633e83090349f74999a86468cd48b2f5b2f5b82bf919f0R1-R241)
* Implemented automatic detection of installation method (pipx, venv, user, source, pip) to suggest appropriate upgrade commands.

### Documentation updates

* Updated `README.md` to include a command-line flags reference, documenting new and existing flags with descriptions.
* Added changelog entry for the new version checking features and installation method detection.

### Version increment

* Bumped package version from `1.0.7` to `1.0.8` in `__init__.py` to reflect the new release.