### PR TITLE
Release/v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2025-12-15
+
+### Changed
+- Improved PyPI metadata with additional classifiers
+- Added code quality tool configurations (Black, isort, mypy)
+- Enhanced project URLs (Bug Tracker, Changelog, Source Code)
+- Updated test snapshots for new version
+
 ## [1.0.9] - 2025-11-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced project URLs (Bug Tracker, Changelog, Source Code)
 - Updated test snapshots for new version
 
-## [1.0.9] - 2025-11-08
+## [1.0.9][] - 2025-11-08
 
 ### Added
 - **NEW**: Version checking functionality with `--version` and `--check-version` flags
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--check-version`: Check PyPI for latest version with context-aware upgrade instructions
   - Automatic installation method detection (pipx, venv, user, source, pip)
 
-## [1.0.8] - 2025-11-05
+## [1.0.8][] - 2025-11-05
 
 ### Security
 - **FIX**: Added symlink security check for `--inplace` mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.0.10]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.10
 [1.0.9]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.9
 [1.0.8]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.8
 [1.0.7]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.10] - 2025-12-15
+## [1.0.10][] - 2025-12-15
 
 ### Changed
 - Improved PyPI metadata with additional classifiers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 [![PyPI version](https://badge.fury.io/py/pfsense-redactor.svg)](https://pypi.org/project/pfsense-redactor/)
 
-The **pfSense XML Configuration Redactor** safely removes sensitive information from `config.xml` exports before they are shared with support, consultants, auditors, or AI tools for security analysis.
+The **pfSense XML Configuration Redactor** safely removes secrets and optionally anonymises identifiers in pfSense `config.xml` files before they are shared with support, consultants, auditors, or AI tools.
+
+Unlike generic XML redaction tools, pfsense-redactor understands pfSense-specific configuration structures and VPN formats.
+
+### When should I use pfsense-redactor?
+
+Use pfsense-redactor when you need to share a pfSense `config.xml` file
+outside the firewall (e.g. with vendors, consultants, forums, or AI tools)
+and want to remove secrets and/or anonymise network identifiers without
+breaking topology or routing logic.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ The tool preserves **network architecture and routing logic** whilst sanitising 
 
 ---
 
+## Relationship to pfSense built-in sanitisation
+
+pfSense includes a built-in configuration sanitisation script:
+
+```bash
+/usr/local/sbin/diag_sanitize.php /conf/config.xml > /conf/config_sanitised.xml
+```
+
+This official tool runs **on the firewall itself** and is primarily intended for safely sharing configurations with Netgate support. It removes high-value secrets (password hashes, pre-shared keys, certificates, etc.) while preserving the original network topology.
+
+**pfsense-redactor is complementary, not a replacement.**
+
+| Built-in `diag_sanitize.php` | pfsense-redactor |
+|-----------------------------|------------------|
+| Runs on pfSense only        | Runs anywhere (workstation, CI, automation) |
+| PHP, internal to pfSense    | Python, standalone, MIT-licensed |
+| Fixed sanitisation behaviour | Configurable redaction and anonymisation |
+| Removes secrets             | Removes secrets **and** can anonymise IPs, domains, MACs and URLs |
+| Best suited to Netgate support (TAC) | Best suited to vendors, consultants, AI tools and forums |
+
+pfsense-redactor exists to cover use cases where:
+- the configuration has already been exported,
+- you do not wish to run additional tooling on the firewall,
+- or you require **privacy-preserving anonymisation** in addition to basic secret removal.
+
+Both tools share the same goal: preventing accidental disclosure of sensitive information when sharing pfSense configurations.
+
+---
+
 ## Features
 
 ### Protects real secrets

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-cov",
+    "pytest==8.4.2",
+    "pytest-cov==7.0.0",
+    "pytest-xdist==3.8.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.0.9"
-description = "Safely removes sensitive information from pfSense config.xml exports"
+version = "1.0.10"
+description = "Redacts secrets and optionally anonymises identifiers in pfSense config.xml exports for safe sharing"
 readme = "README.md"
 authors = [
     {name = "pfSense Redactor Contributors"}
 ]
 license = {text = "MIT"}
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -22,11 +25,20 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Security",
+    "Topic :: System :: Networking",
     "Topic :: System :: Networking :: Firewalls",
     "Topic :: System :: Systems Administration",
+    "Topic :: Utilities",
 ]
-keywords = ["pfsense", "firewall", "configuration", "config", "privacy", "security", "redaction", "anonymiser", "anonymizer", "sanitiser", "sanitizer", "xml", "netgate"]
+
+keywords = [
+  "pfsense", "netgate", "firewall", "configuration", "config", "config.xml",
+  "security", "privacy", "redaction", "anonymiser", "anonymizer",
+  "sanitiser", "sanitizer", "xml", "vpn", "wireguard", "openvpn", "ipsec"
+]
+
 requires-python = ">=3.9"
 dependencies = []
 
@@ -39,7 +51,10 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/grounzero/pfsense-redactor"
 Repository = "https://github.com/grounzero/pfsense-redactor"
-Issues = "https://github.com/grounzero/pfsense-redactor/issues"
+"Bug Tracker" = "https://github.com/grounzero/pfsense-redactor/issues"
+Documentation = "https://github.com/grounzero/pfsense-redactor#readme"
+Changelog = "https://github.com/grounzero/pfsense-redactor/blob/main/CHANGELOG.md"
+"Source Code" = "https://github.com/grounzero/pfsense-redactor"
 
 [project.scripts]
 pfsense-redactor = "pfsense_redactor.__main__:main"
@@ -73,3 +88,89 @@ max-branches = 15
 max-locals = 15
 max-statements = 60
 max-returns = 8
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+    "-ra",
+]
+markers = [
+    "slow: marks tests as slow (reference snapshots, full sample processing)",
+    "fast: marks tests as fast (synthetic fixtures, focused tests)",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+]
+norecursedirs = [".git", ".tox", "dist", "build", "*.egg", "reference"]
+
+[tool.coverage.run]
+source = ["pfsense_redactor"]
+omit = [
+    "tests/*",
+    "*/test_*",
+    "*/__pycache__/*",
+    "*/site-packages/*",
+]
+branch = true
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+]
+
+[tool.black]
+line-length = 120
+target-version = ["py39", "py310", "py311", "py312", "py313"]
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+  | venv
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 120
+py_version = "39"
+skip_gitignore = true
+multi_line_mode = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+src_paths = ["pfsense_redactor", "tests"]
+known_third_party = ["pytest"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+exclude = [
+    "tests/",
+    "venv/",
+]

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.0.9 -->
+  <!-- Redacted using pfsense-redactor v1.0.10 -->
   <version>19.1</version>
   <lastchange />
   <system>


### PR DESCRIPTION
This pull request releases version 1.0.10 of `pfsense-redactor` with improvements to project metadata, documentation, and developer tooling. The release also updates test reference snapshots to reflect the new version.

**Project metadata and documentation:**

* Enhanced PyPI metadata with additional classifiers, improved keywords, and expanded project URLs, making the project easier to discover and more informative for users. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R41) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L42-R57) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15)
* Updated the `README.md` with clearer descriptions, usage guidance, and a new section comparing `pfsense-redactor` to the built-in pfSense sanitisation tool. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R100)

**Developer tooling and quality:**

* Added configuration files and settings for code quality tools (Black, isort, mypy) and improved pytest and coverage configuration for more robust testing and code style enforcement. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R91-R176) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15)

**Testing and versioning:**

* Updated test reference snapshots and version strings to 1.0.10 to reflect the new release and ensure consistency across documentation and outputs. [[1]](diffhunk://#diff-0e508264480c70371d524532476e35f4e6d73599eb7f55bab6632bc828bdb74cL16-R16) [[2]](diffhunk://#diff-0bda50d7449131fb4240cdcfd9ba285da21febf575096ec19b8daeb14667f833L3-R3) [[3]](diffhunk://#diff-fd905daad6cdb5197a94886b7bb1bdb752029ac9a70e9552ed06820f2e79bb43L3-R3) [[4]](diffhunk://#diff-5835199699e33e2ce0071ae966e42a9e7bd3f81b971b18d368739b97be160657L3-R3) [[5]](diffhunk://#diff-e5f4b83aa91f503be32720ebb87d5da3d48df10403cae91f9dd63fcf2abd10eeL3-R3) [[6]](diffhunk://#diff-b78fa60112acc587fcfee3ff10f7d8594678132c7b954080a2b9f1967d6b6dbfL3-R3) [[7]](diffhunk://#diff-160ef931ffd85f6e9d7da8caa852fdc6b7c38e3210d56fce7085ef5462579273L3-R3) [[8]](diffhunk://#diff-173ae4d15d6ed5e719160f2c89cd2c1753510b811d30af4984174843109fbd3dL3-R3) [[9]](diffhunk://#diff-eea9c6b724549d5a503c1a622c1f46316e9299d55c08501b4e40e84cdca1847fL3-R3) [[10]](diffhunk://#diff-29d2082b2e7d0d503b4d9291982816c645b9b6c85276a430af0deeebf01cea2fL3-R3) [[11]](diffhunk://#diff-21c31c509cff8129b098b38047666b77a90738031d81fedf2adf611adffe2da3L3-R3) [[12]](diffhunk://#diff-d16b7ed6cf427aff9bfd9d81573c1e5882551a04946d61dc9d655d21c74d0e26L3-R3)