### PR TITLE
Build(deps): Update test tooling and GitHub Actions

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,11 +36,11 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
           cache: 'pip'
@@ -39,7 +39,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -45,9 +45,9 @@ jobs:
         pytest -v --cov=pfsense_redactor --cov-report=term-missing --cov-report=xml
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
-        file: ./tests/coverage.xml
+        files: ./tests/coverage.xml
         flags: unittests
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         fail_ci_if_error: false

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -12,10 +12,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     
     - name: Set up Python 3.9
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.9'
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,10 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "pytest==8.4.2",
-    "pytest-cov==7.0.0",
+    # pytest 9.x requires Python >=3.10; 8.4.2 is the last release supporting 3.9.
+    "pytest==9.1.1; python_version >= '3.10'",
+    "pytest==8.4.2; python_version < '3.10'",
+    "pytest-cov==7.1.0",
     "pytest-xdist==3.8.0",
 ]
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,16 @@
 # Test dependencies for pfSense redactor test suite
 
 # Core testing framework
-pytest==8.4.2
+# pytest 9.x requires Python >=3.10; 8.4.2 is the last release supporting 3.9,
+# so the pin is split by interpreter to keep the 3.9 support matrix installable.
+pytest==9.1.1; python_version >= "3.10"
+pytest==8.4.2; python_version < "3.10"
 
 # Optional: Parallel test execution
 pytest-xdist==3.8.0
 
 # Optional: Coverage reporting
-pytest-cov==7.0.0
+pytest-cov==7.1.0
 
 # Note: No additional dependencies required beyond Python standard library
 # The redactor script itself only uses standard library modules


### PR DESCRIPTION
Updates all dependencies. The package itself has **zero runtime dependencies** (stdlib only), so this covers dev/test tooling and CI actions.

## Python packages

| Package | Was | Now |
|---|---|---|
| pytest | 8.4.2 | 9.1.1 (py>=3.10) / 8.4.2 (py3.9) |
| pytest-cov | 7.0.0 | 7.1.0 |
| pytest-xdist | 3.8.0 | already current |

pytest 9.x requires Python >=3.10 and there is no 8.4.3 — 8.4.2 ends the 8.x line. A flat pin therefore cannot cover the `>=3.9` support matrix, so the pin is split with PEP 508 environment markers rather than dropping 3.9 support.

## GitHub Actions

`actions/checkout` v6→v7, `actions/setup-python` v6→v7, `actions/upload-artifact` v6→v7, `actions/download-artifact` v7→v8, `codecov/codecov-action` v5→v7, `codacy-analysis-cli` 1.1.0→v4.4.7 (kept SHA-pinned). `github/codeql-action` is already on the current v4 major.

Breaking-change review: checkout v7's `allow-unsafe-pr-checkout` change only affects `pull_request_target`, which no workflow here uses. download-artifact v8 now errors on digest mismatch and pairs with upload-artifact v7.

## Bug fix included

The Codecov step in `tests.yml` passed `file:`, which is **not a valid input** in v5, v6 or v7 — they accept `files:`. It was being silently ignored (masked by `fail_ci_if_error: false`); coverage only uploaded because Codecov automatically searches for report files. Now corrected.

## Supersedes these Dependabot PRs

These need closing manually — GitHub's closing keywords only auto-close issues, not pull requests.

- #47 (pytest → 9.0.3) — would break `pip install -r tests/requirements.txt` on Python 3.9
- #44 (pytest-cov → 7.1.0) — included here
- #45 (codecov v5 → 6) — goes to v7 here
- #43 (download-artifact 7 → 8) — included here
- #42 (upload-artifact 6 → 7) — included here
- #29 (codacy-analysis-cli → 4.4.7) — included here

## Worth flagging

**CI does not exercise the pinned versions.** The workflows run `pip install pytest pytest-cov` unpinned, so `tests/requirements.txt` is never installed in CI and pip just resolves whatever is compatible per runner. This is why #47 shows green on the 3.9 job despite pinning a version that cannot install there. Worth a follow-up to install from the pinned file.

**Python 3.9 is EOL** (October 2025) and pytest 9.0.3 fixed CVE-2025-71176 (insecure temp directory), never backported to 8.4.x — so 3.9 runners keep an unpatched pytest. An argument for eventually dropping 3.9, which is a maintainer call and not made here.

**Left alone deliberately:**
- `setuptools>=61.0` (#46 proposes `>=82.0.1`) — it is a build-time *floor* and no setuptools 82 features are used; raising it would gratuitously break distro packagers on older system setuptools. Recommend closing #46. Note 83.0.0 dropped 3.9 anyway.
- `ad-m/github-push-action@master` in `update-snapshots.yml` — an unpinned rolling ref on a third-party action with `contents: write`. Worth pinning to a SHA, but that is a security change rather than a version update.

## Testing

392 passed, 1 skipped on Python 3.9 with the new pins. Markers confirmed to resolve to 8.4.2 on 3.9 and 9.1.1 on 3.12; all 7 workflow YAMLs parse.

Only Python 3.9.6 was available locally, so pytest 9 could not be executed directly — the >=3.10 half is validated by inspection (no deprecated pytest APIs in the suite; the `--strict-markers`-in-`addopts` regression from 9.0 is fixed in 9.1.1) and by this PR's own CI matrix.
