### PR TITLE
1.1.1: close three URL path credential formats; stop rewriting filenames as domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1][] - 2026-07-27
+
+Follow-up to 1.1.0, from a second canary-corpus report. 1.1.0 caught 41/46
+where 1.0.10 caught 15/46; these are the remaining gaps plus one
+over-redaction bug found while confirming them.
+
+### Security
+- **FIX**: Three credential formats bypassed URL path-segment detection:
+  - **AWS access key IDs** (`AKIA...`) are exactly 20 characters, and the
+    length test was `<= 20`, so the entire format was excluded by an
+    off-by-one.
+  - **Telegram bot tokens** are `bot<id>:<secret>`, and the colon failed the
+    base64 character test, so a 47-character credential was treated as an
+    ordinary path segment. Segments are now split on `:` before testing.
+  - **Tokens without digits** were never flagged. The digit requirement exists
+    to protect underscore-joined route names such as `Open_VM_Tools_package`,
+    and is now applied only below 24 characters.
+- **FIX**: `<webhook_url>` and similar elements are now redacted whole. A Slack
+  or Discord webhook URL is a credential in its entirety, not merely a
+  secret-bearing path segment.
+
+### Fixed
+- **FIX**: FQDN substitution rewrote filenames as domains, corrupting output
+  rather than redacting it. `list.txt`, `emerging-block.rules`,
+  `pfblockerng.php` and `haproxy.sh` all became `example.com`.
+
+  This affected **default mode**, not only `--aggressive`: `<url>` is a known
+  URL-bearing element, so pfBlockerNG feed URLs were corrupted without any
+  opt-in. It was also present in this project's own reference snapshots.
+
+  URLs are now protected from the FQDN pass, which has already masked their
+  hosts, and bare filenames are recognised by extension or by filesystem-path
+  context. Context is required because extension alone cannot decide it: `.sh`,
+  `.pl`, `.io` and `.zip` are all real TLDs, so `haproxy.sh` is preserved
+  inside a path but still redacted in prose.
+
+### Known limitation
+- A path segment of 21-23 characters containing no digit is not detected.
+  `Open_VM_Tools_package` (a route name that must be preserved) and a
+  hypothetical 21-character alphabetic token are the same length and shape, so
+  no length threshold separates them. Real Slack and Discord tokens are 24+
+  characters and are detected.
+
 ## [1.1.0][] - 2026-07-27
 
 ### Security
@@ -355,6 +398,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.1.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.1
 [1.1.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.0
 [1.0.10]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.10
 [1.0.9]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.9

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -263,6 +263,10 @@ FILE_EXTENSIONS: frozenset[str] = frozenset({
     'php', 'cgi', 'inc', 'tpl', 'patch', 'diff', 'sample', 'orig', 'dist',
 })
 
+# Placeholder used to hide URLs from later text passes. NUL is not legal in XML
+# content, so a placeholder can only ever be one this module wrote.
+URL_PLACEHOLDER_RE = re.compile(r'\x00URL(\d+)\x00')
+
 # URL path segment credential detection.
 # 20 because AWS access key IDs (AKIA...) are exactly 20 characters.
 SECRETISH_SEGMENT_MIN_LENGTH: int = 20
@@ -1291,7 +1295,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
           segment is far more likely to be a token than a route. Requiring a
           digit unconditionally silently missed alphabetic Slack tokens.
         """
-        for part in segment.split(':') if ':' in segment else [segment]:
+        for part in segment.split(':'):
             if len(part) < SECRETISH_SEGMENT_MIN_LENGTH:
                 continue
             if not BASE64ISH_RE.match(part):
@@ -1500,10 +1504,23 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _restore_urls(text: str, stashed: list[str]) -> str:
-        """Put stashed URLs back after later passes have run"""
-        for index, url in enumerate(stashed):
-            text = text.replace(f'\x00URL{index}\x00', url)
-        return text
+        """Put stashed URLs back after later passes have run
+
+        A single regex pass rather than one str.replace per URL: the latter
+        rescans the whole text for every stashed URL, which is O(urls x text).
+        Measured at ~140x slower with 200 URLs in a large element.
+        """
+        if not stashed:
+            return text
+
+        def restore(match: re.Match) -> str:
+            index = int(match.group(1))
+            # Out of range is unreachable (NUL cannot appear in XML content, so
+            # every placeholder is one we wrote), but return the match rather
+            # than raising if that ever stops being true.
+            return stashed[index] if index < len(stashed) else match.group(0)
+
+        return URL_PLACEHOLDER_RE.sub(restore, text)
 
     def _redact_fqdns_safe(self, text: str) -> str:
         """Redact FQDNs with ReDoS protection via length pre-filtering"""

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -174,7 +174,7 @@ CERT_KEY_ELEMENTS: frozenset[str] = frozenset({
 SECRET_TAG_PATTERN = re.compile(
     r'passw(?:or)?d|passphrase|(?:^|[_-])pass(?:$|[_-])'
     r'|psk|pre-?shared-?key|shared-?key'
-    r'|secret|token|community|credential|bindpw|licen[cs]e'
+    r'|secret|token|community|credential|bindpw|licen[cs]e|webhook'
     r'|api[_-]?key|account-?key|authorized-?keys'
     r'|priv(?:ate)?[_-]?key|key(?:s)?$|[_-]key\d*$',
     re.IGNORECASE
@@ -246,6 +246,30 @@ BLOB_SECRET_DIRECTIVES: frozenset[str] = frozenset({
 BLOB_MIN_SCAN_LENGTH: int = 32
 BASE64ISH_RE = re.compile(r'^[A-Za-z0-9+/=_\-]+$')
 HEXISH_RE = re.compile(r'^[0-9A-Fa-f]+$')
+
+# Final labels that are file extensions rather than TLDs. FQDN_RE is
+# deliberately broad, so without this 'list.txt' and 'backup-2026.tar.gz' are
+# rewritten to example.com - silently corrupting the pfBlockerNG feed names,
+# script paths and cron commands people share a config to get help with.
+#
+# Only unambiguous entries belong here: '.sh', '.pl', '.io', '.zip' and '.mov'
+# are all real TLDs, so 'haproxy.sh' cannot be resolved by extension alone and
+# is handled by the path-context rule in _redact_fqdns_safe instead.
+FILE_EXTENSIONS: frozenset[str] = frozenset({
+    'txt', 'log', 'conf', 'cfg', 'ini', 'yaml', 'yml', 'json', 'xml', 'csv',
+    'rules', 'list', 'lst', 'tar', 'gz', 'tgz', 'bz2', 'xz', 'zst', 'bak',
+    'pem', 'crt', 'cer', 'csr', 'der', 'p12', 'pfx', 'jks', 'keystore',
+    'sql', 'sqlite', 'db', 'dat', 'pid', 'sock', 'lock', 'tmp', 'swp',
+    'php', 'cgi', 'inc', 'tpl', 'patch', 'diff', 'sample', 'orig', 'dist',
+})
+
+# URL path segment credential detection.
+# 20 because AWS access key IDs (AKIA...) are exactly 20 characters.
+SECRETISH_SEGMENT_MIN_LENGTH: int = 20
+# Above this length an all-letter segment is treated as a token even without a
+# digit. Set clear of 'Open_VM_Tools_package' (21), the route name the digit
+# requirement exists to protect.
+DIGITLESS_TOKEN_LENGTH: int = 24
 
 IP_CONTAINING_ELEMENTS: frozenset[str] = frozenset({
     'ipaddr', 'ipaddrv6', 'gateway', 'dnsserver', 'hostname', 'domain',
@@ -1254,18 +1278,33 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         Uses a lower length floor than _is_high_entropy_value: webhook tokens
         sit around 20-24 chars, below the threshold used for key material.
 
-        A digit is required in addition to letters. Without that, long
-        underscore-joined route names ('Open_VM_Tools_package') look identical
-        to tokens; generated credentials essentially always mix in digits.
-        """
-        if len(segment) <= 20:
-            return False
-        if not BASE64ISH_RE.match(segment):
-            return False
+        Boundaries here are load-bearing, so each is justified:
 
-        has_digit = any(c.isdigit() for c in segment)
-        has_letter = any(c.isalpha() for c in segment)
-        return has_digit and has_letter
+        - >= 20, not > 20. AWS access key IDs (AKIA...) are exactly 20
+          characters, so a > 20 test excluded the entire format.
+        - Colon-separated segments are split first. Telegram bot tokens are
+          'bot<id>:<secret>', and the colon fails BASE64ISH_RE, which let a
+          47-character credential through as an ordinary path segment.
+        - A digit is required only below DIGITLESS_TOKEN_LENGTH. The digit rule
+          exists to protect underscore-joined route names such as
+          'Open_VM_Tools_package' (21 chars); beyond that length an all-letter
+          segment is far more likely to be a token than a route. Requiring a
+          digit unconditionally silently missed alphabetic Slack tokens.
+        """
+        for part in segment.split(':') if ':' in segment else [segment]:
+            if len(part) < SECRETISH_SEGMENT_MIN_LENGTH:
+                continue
+            if not BASE64ISH_RE.match(part):
+                continue
+
+            has_letter = any(c.isalpha() for c in part)
+            has_digit = any(c.isdigit() for c in part)
+            if not has_letter:
+                continue
+            if has_digit or len(part) >= DIGITLESS_TOKEN_LENGTH:
+                return True
+
+        return False
 
     @classmethod
     def _build_redacted_path(cls, path: str) -> tuple[str, bool]:
@@ -1443,6 +1482,29 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # Use re.sub directly to preserve whitespace
         return self.EMAIL_RE.sub(email_mask_safe, text)
 
+    def _stash_urls(self, text: str) -> tuple[str, list[str]]:
+        """Replace URLs with placeholders so later passes cannot rewrite them
+
+        Returns (text, stashed). URLs have already been handled by
+        _mask_url/_redact_url_secrets_only by this point; without stashing, the
+        FQDN pass matches filenames inside the path ('/lists/list.txt') and
+        rewrites them to example.com.
+        """
+        stashed: list[str] = []
+
+        def keep(match: re.Match) -> str:
+            stashed.append(match.group(0))
+            return f'\x00URL{len(stashed) - 1}\x00'
+
+        return self.URL_RE.sub(keep, text), stashed
+
+    @staticmethod
+    def _restore_urls(text: str, stashed: list[str]) -> str:
+        """Put stashed URLs back after later passes have run"""
+        for index, url in enumerate(stashed):
+            text = text.replace(f'\x00URL{index}\x00', url)
+        return text
+
     def _redact_fqdns_safe(self, text: str) -> str:
         """Redact FQDNs with ReDoS protection via length pre-filtering"""
         def fqdn_mask_safe(match):
@@ -1450,6 +1512,16 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # Pre-filter: Skip obviously too-long domains
             if len(domain) > self.MAX_FQDN_LENGTH:
                 return domain  # Don't process suspiciously long "domains"
+
+            # A filesystem or URL path component, not a hostname. Checked by
+            # context because the extension alone cannot decide it: '.sh' is
+            # both a shell script and Saint Helena's TLD.
+            if match.start() > 0 and text[match.start() - 1] == '/':
+                return domain
+
+            # Unambiguous file extension: 'list.txt', 'backup-2026.tar.gz'
+            if domain.rsplit('.', 1)[-1].lower() in FILE_EXTENSIONS:
+                return domain
 
             if self._is_domain_allowed(domain):
                 return domain
@@ -1512,10 +1584,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             result = result.replace('XXX.XXX.XXX.XXX', ipv4_mask_placeholder)
             result = result.replace('XXXX.XXXX.XXXX', cisco_mac_placeholder)
 
+            # Protect URLs for the same reason. Their hosts were already masked
+            # by _redact_urls_safe above; leaving them exposed to the FQDN pass
+            # rewrote filenames in the path (/lists/list.txt -> /lists/
+            # example.com), which corrupts the output rather than redacting it.
+            result, stashed_urls = self._stash_urls(result)
+
             # Redact remaining bare FQDNs with ReDoS protection
             result = self._redact_fqdns_safe(result)
 
-            # Restore IPv4 mask and Cisco MAC format
+            # Restore URLs, IPv4 mask and Cisco MAC format
+            result = self._restore_urls(result, stashed_urls)
             result = result.replace(ipv4_mask_placeholder, 'XXX.XXX.XXX.XXX')
             result = result.replace(cisco_mac_placeholder, 'XXXX.XXXX.XXXX')
 
@@ -1692,17 +1771,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if '://' not in text:
             return self._redact_blob_text(text)
 
-        stashed: list[str] = []
-
-        def stash(match: re.Match) -> str:
-            stashed.append(self._redact_url_secrets_only(match.group(0)))
-            return f'\x00URL{len(stashed) - 1}\x00'
-
-        result = self._redact_blob_text(self.URL_RE.sub(stash, text))
-
-        for index, url in enumerate(stashed):
-            result = result.replace(f'\x00URL{index}\x00', url)
-        return result
+        stashed_text, stashed = self._stash_urls(self._redact_url_secrets_only(text))
+        return self._restore_urls(self._redact_blob_text(stashed_text), stashed)
 
     def _redact_blob_text(self, text: str) -> str:
         """Redact the value side of key=value pairs and secret-bearing directives"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.1.0"
+version = "1.1.1"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>
@@ -187,7 +187,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/bin/nice -n20 /etc/example.com</command>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
     </item>
     <item>
       <minute>*/60</minute>
@@ -214,7 +214,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/local/bin/example.com</command>
+      <command>/usr/local/bin/checkreload.sh</command>
     </item>
     <item>
       <minute>*/5</minute>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -69,7 +69,7 @@
       <repositoryurl />
       <branch />
     </gitsync>
-    <pkg_repo_conf_path>/usr/local/share/pfSense/pkg/repos/example.com</pkg_repo_conf_path>
+    <pkg_repo_conf_path>/usr/local/share/pfSense/pkg/repos/pfSense-repo-devel.conf</pkg_repo_conf_path>
     <already_run_config_upgrade />
     <crypto_hardware>cryptodev</crypto_hardware>
     <language>en_US</language>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -746,7 +746,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/bin/nice -n20 /etc/example.com</command>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
     </item>
     <item>
       <minute>*/60</minute>
@@ -809,7 +809,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/local/bin/php /usr/local/www/pfblockerng/example.com dcc &gt;&gt; /var/log/pfblockerng/example.com 2&gt;&amp;1</command>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc &gt;&gt; /var/log/pfblockerng/extras.log 2&gt;&amp;1</command>
     </item>
     <item>
       <minute>0</minute>
@@ -818,7 +818,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/local/bin/php /usr/local/www/pfblockerng/example.com cron &gt;&gt; /var/log/pfblockerng/example.com 2&gt;&amp;1</command>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron &gt;&gt; /var/log/pfblockerng/pfblockerng.log 2&gt;&amp;1</command>
     </item>
     <item>
       <minute>0</minute>
@@ -827,7 +827,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/local/sbin/squid -k rotate -f /usr/local/etc/squid/example.com</command>
+      <command>/usr/local/sbin/squid -k rotate -f /usr/local/etc/squid/squid.conf</command>
     </item>
     <item>
       <minute>15</minute>
@@ -946,13 +946,13 @@
   <installedpackages>
     <package>
       <name>snort</name>
-      <pkginfolink>https://example.com/example.com/Setup_Snort_Package</pkginfolink>
+      <pkginfolink>https://example.com/index.php/Setup_Snort_Package</pkginfolink>
       <website>http://example.com</website>
       <descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
       <version>3.2.9.6_1</version>
-      <configurationfile>/example.com</configurationfile>
+      <configurationfile>/snort.xml</configurationfile>
       <after_install_info>Please visit Services - Snort - Interfaces tab first and select your desired rules. Afterwards visit the Updates tab to download your configured rulesets.</after_install_info>
-      <include_file>/usr/local/pkg/snort/example.com</include_file>
+      <include_file>/usr/local/pkg/snort/snort.inc</include_file>
     </package>
     <package>
       <name>Lightsquid</name>
@@ -960,7 +960,7 @@
 			&amp;lt;strong&amp;gt;Requires Squid package.&amp;lt;/strong&amp;gt;</descr>
       <website>http://example.com/</website>
       <version>3.0.6_4</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>lightsquid.xml</configurationfile>
       <noembedded>true</noembedded>
     </package>
     <package>
@@ -969,17 +969,17 @@
 			Requires Gold Subscription from &amp;lt;a href=&amp;quot;https://example.com Portal&amp;lt;/a&amp;gt;.</descr>
       <website>https://example.com</website>
       <version>1.52</version>
-      <pkginfolink>https://example.com/example.com/AutoConfigBackup</pkginfolink>
-      <configurationfile>example.com</configurationfile>
+      <pkginfolink>https://example.com/index.php/AutoConfigBackup</pkginfolink>
+      <configurationfile>autoconfigbackup.xml</configurationfile>
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/example.com</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -990,24 +990,24 @@
           <url>/autoconfigbackup_stats.php</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/autoconfigbackup.inc</include_file>
     </package>
     <package>
       <name>haproxy-devel</name>
-      <pkginfolink>https://example.com/example.com/haproxy_package</pkginfolink>
+      <pkginfolink>https://example.com/index.php/haproxy_package</pkginfolink>
       <descr>The Reliable, High Performance TCP/HTTP(S) Load Balancer.&amp;lt;br /&amp;gt;
 			This package implements the TCP, HTTP and HTTPS balancing features from haproxy.&amp;lt;br /&amp;gt;
 			Supports ACLs for smart backend switching.</descr>
       <website>http://example.com/</website>
       <version>0.58_2</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>haproxy.xml</configurationfile>
       <logging>
         <logsocket>/tmp/haproxy_chroot/var/run/log</logsocket>
         <facilityname>haproxy</facilityname>
-        <logfilename>example.com</logfilename>
+        <logfilename>haproxy.log</logfilename>
       </logging>
       <filter_rule_function>haproxy_generate_rules</filter_rule_function>
-      <include_file>/usr/local/pkg/haproxy/example.com</include_file>
+      <include_file>/usr/local/pkg/haproxy/haproxy.inc</include_file>
       <plugins>
         <item>
           <type>plugin_carp</type>
@@ -1022,29 +1022,29 @@
       <descr>VMware Tools is a suite of utilities that enhances the performance of the virtual machine's guest operating system and improves management of the virtual machine.</descr>
       <website>http://example.com/</website>
       <version>10.1.0,1</version>
-      <pkginfolink>https://example.com/example.com/Open_VM_Tools_package</pkginfolink>
-      <configurationfile>example.com</configurationfile>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <pkginfolink>https://example.com/index.php/Open_VM_Tools_package</pkginfolink>
+      <configurationfile>open-vm-tools.xml</configurationfile>
+      <include_file>/usr/local/pkg/open-vm-tools.inc</include_file>
     </package>
     <package>
       <name>squid3</name>
       <internal_name>squid</internal_name>
       <descr>High performance web proxy cache (3.4 branch). It combines Squid as a proxy server with its capabilities of acting as a HTTP / HTTPS reverse proxy.&amp;lt;br /&amp;gt;
 			It includes an Exchange-Web-Access (OWA) Assistant, SSL filtering and antivirus integration via C-ICAP.</descr>
-      <pkginfolink>https://example.com/example.com?board=60.0</pkginfolink>
+      <pkginfolink>https://example.com/index.php?board=60.0</pkginfolink>
       <website>http://example.com/</website>
       <version>0.4.44_1</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>squid.xml</configurationfile>
       <filter_rule_function>squid_generate_rules</filter_rule_function>
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/example.com?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1079,7 +1079,7 @@
           <url>/pkg_edit.php?xml=squid_sync.xml</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/squid.inc</include_file>
     </package>
     <package>
       <name>squidGuard</name>
@@ -1087,12 +1087,12 @@
 			&amp;lt;strong&amp;gt;Works with both Squid (2.7 legacy branch) and Squid3 (3.4 branch) packages.&amp;lt;/strong&amp;gt;</descr>
       <website>http://example.com/</website>
       <version>1.16.16</version>
-      <configurationfile>example.com</configurationfile>
-      <after_install_info>Please visit Services - SquidGuard Proxy Filter - Target Categories and set up at least one category there before enabling SquidGuard. See https://example.com/example.com?topic=94312.0 for details.</after_install_info>
+      <configurationfile>squidguard.xml</configurationfile>
+      <after_install_info>Please visit Services - SquidGuard Proxy Filter - Target Categories and set up at least one category there before enabling SquidGuard. See https://example.com/index.php?topic=94312.0 for details.</after_install_info>
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/example.com?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/example.com?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/example.com?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/example.com?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1128,57 +1128,57 @@
           <url>/pkg_edit.php?xml=squidguard_sync.xml</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/squidguard.inc</include_file>
     </package>
     <package>
       <name>Service Watchdog</name>
       <internal_name>Service_Watchdog</internal_name>
       <descr>Monitors for stopped services and restarts them.</descr>
       <version>1.8.5</version>
-      <configurationfile>example.com</configurationfile>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <configurationfile>servicewatchdog.xml</configurationfile>
+      <include_file>/usr/local/pkg/servicewatchdog.inc</include_file>
     </package>
     <package>
       <name>freeradius3</name>
       <website>http://example.com/</website>
       <descr>A free implementation of the RADIUS protocol.&amp;lt;br /&amp;gt;
 			Supports MySQL, PostgreSQL, LDAP, Kerberos.</descr>
-      <pkginfolink>https://example.com/example.com/FreeRADIUS_2.x_package</pkginfolink>
+      <pkginfolink>https://example.com/index.php/FreeRADIUS_2.x_package</pkginfolink>
       <version>0.15.5_1</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>freeradius.xml</configurationfile>
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,10 +1186,10 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/freeradius.inc</include_file>
     </package>
     <package>
       <name>FRR</name>
@@ -1197,24 +1197,24 @@
       <descr>FRR routing daemon for BGP, OSPF, and OSPF6.&amp;lt;br /&amp;gt;
 			&amp;lt;strong&amp;gt;Conflicts with Quagga OSPF and OpenBGPD; these packages cannot be installed at the same time.&amp;lt;/strong&amp;gt;</descr>
       <version>0.2_1</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>frr.xml</configurationfile>
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=example.com</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>example.com?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>example.com?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>example.com?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1237,7 +1237,7 @@
           <url>/status_frr.php</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/frr.inc</include_file>
       <plugins>
         <item>
           <type>plugin_carp</type>
@@ -1248,19 +1248,19 @@
       <name>mailreport</name>
       <descr>Allows you to setup periodic e-mail reports containing command output and log file contents.</descr>
       <version>3.3</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>mailreport.xml</configurationfile>
     </package>
     <package>
       <name>ntopng</name>
       <website>http://example.com/</website>
       <descr>ntopng (replaces ntop) is a network probe that shows network usage in a way similar to what top does for processes. In interactive mode, it displays the network status on the user's terminal. In Web mode it acts as a Web server, creating an HTML dump of the network status. It sports a NetFlow/sFlow emitter/collector, an HTTP-based client interface for creating ntop-centric monitoring applications, and RRD for persistently storing traffic statistics.</descr>
       <version>0.8.12</version>
-      <configurationfile>example.com</configurationfile>
+      <configurationfile>ntopng.xml</configurationfile>
       <noembedded>true</noembedded>
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=example.com</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1268,7 +1268,7 @@
           <url>/ntopng_redirect.php</url>
         </tab>
       </tabs>
-      <include_file>/usr/local/pkg/example.com</include_file>
+      <include_file>/usr/local/pkg/ntopng.inc</include_file>
     </package>
     <package>
       <name>pfBlockerNG-devel</name>
@@ -1279,10 +1279,10 @@
 			Provision to download from diverse List formats.&amp;lt;br /&amp;gt;
 			Advanced Integration for Proofpoint ET IQRisk IP Reputation Threat Sources.&amp;lt;br /&amp;gt;
 			Domain Name (DNSBL) blocking via Unbound DNS Resolver.</descr>
-      <pkginfolink>https://example.com/example.com?topic=102470.0</pkginfolink>
+      <pkginfolink>https://example.com/index.php?topic=102470.0</pkginfolink>
       <version>2.2.1</version>
-      <configurationfile>example.com</configurationfile>
-      <include_file>/usr/local/pkg/pfblockerng/example.com</include_file>
+      <configurationfile>pfblockerng.xml</configurationfile>
+      <include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
     </package>
     <pfblockernglistsv4>
       <config>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1510,13 +1510,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://example.com/example.com</url>
+          <url>https://example.com/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/adservers/example.com?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/downloads/example.com</url>
+          <url>https://example.com/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1568,7 +1568,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/BBcan177/4a8bf37c131be4803cb2/raw</url>
+          <url>https://example.com/BBcan177/[REDACTED]/raw</url>
           <header>MS_2</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/example.com</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2000,37 +2000,37 @@
     <menu>
       <name>FRR Global/Zebra</name>
       <section>Services</section>
-      <configfile>example.com</configfile>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
       <section>Services</section>
-      <configfile>example.com</configfile>
+      <configfile>frr.xml</configfile>
       <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
     </menu>
     <menu>
       <name>FRR OSPF</name>
       <section>Services</section>
-      <configfile>example.com</configfile>
+      <configfile>frr.xml</configfile>
       <url>/pkg_edit.php?xml=frr/frr_ospf.xml</url>
     </menu>
     <menu>
       <name>FRR OSPF6</name>
       <section>Services</section>
-      <configfile>example.com</configfile>
+      <configfile>frr.xml</configfile>
       <url>/pkg_edit.php?xml=frr/frr_ospf6.xml</url>
     </menu>
     <menu>
       <name>FRR</name>
       <section>Status</section>
-      <configfile>example.com</configfile>
+      <configfile>frr.xml</configfile>
       <url>/status_frr.php</url>
     </menu>
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/example.com?xml=example.com</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/domain2.example?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/domain2.example?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/domain2.example?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/domain2.example?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -902,14 +902,14 @@
     <dnssecstripped />
     <hosts>
       <host>pkg</host>
-      <domain>domain3.example</domain>
+      <domain>domain2.example</domain>
       <ip>172.27.10.115</ip>
       <descr />
       <aliases />
     </hosts>
     <hosts>
       <host>release-staging</host>
-      <domain>domain4.example</domain>
+      <domain>domain3.example</domain>
       <ip>172.27.10.115</ip>
       <descr />
       <aliases />
@@ -974,12 +974,12 @@
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=domain5.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/domain6.example</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -1039,12 +1039,12 @@
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=domain7.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/domain8.example?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/domain8.example?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1092,7 +1092,7 @@
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=domain9.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/domain8.example?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/domain8.example?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/domain8.example?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/domain8.example?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1149,36 +1149,36 @@
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/domain8.example?xml=domain10.example</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/domain8.example?xml=domain11.example</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/domain8.example?xml=domain12.example</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/domain8.example?xml=domain13.example</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=domain14.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=domain15.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=domain16.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=domain17.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,7 +1186,7 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=domain18.example&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
       <include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -1201,20 +1201,20 @@
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=domain19.example</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>domain8.example?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>domain8.example?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>domain8.example?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1260,7 +1260,7 @@
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=domain20.example</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://domain22.example/feeds/domain23.example</url>
+          <url>http://domain4.example/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://domain22.example/feeds/domain24.example</url>
+          <url>http://domain4.example/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1389,7 +1389,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://domain26.example/blacklist/dyre_sslipblacklist.csv</url>
+          <url>https://domain5.example/blacklist/dyre_sslipblacklist.csv</url>
           <header>Abuse_DYRE</header>
         </row>
       </config>
@@ -1510,25 +1510,25 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://domain28.example/domain29.example</url>
+          <url>https://domain6.example/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://domain31.example/adservers/domain32.example?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://domain7.example/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://domain34.example/ad_servers.txt</url>
+          <url>http://domain8.example/ad_servers.txt</url>
           <header>hpHosts_ads</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>domain35.example/cameleon/hosts</url>
+          <url>domain9.example/cameleon/hosts</url>
           <header>Cameleon</header>
         </row>
         <action>unbound</action>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://domain37.example/downloads/domain38.example</url>
+          <url>https://domain10.example/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1568,7 +1568,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://domain40.example/BBcan177/4a8bf37c131be4803cb2/raw</url>
+          <url>https://domain11.example/BBcan177/4a8bf37c131be4803cb2/raw</url>
           <header>MS_2</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=domain20.example</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/domain6.example</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=domain9.example&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=domain7.example&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2001,7 +2001,7 @@
       <name>FRR Global/Zebra</name>
       <section>Services</section>
       <configfile>frr.xml</configfile>
-      <url>/pkg_edit.php?xml=domain19.example</url>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
@@ -2030,7 +2030,7 @@
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/domain8.example?xml=domain10.example</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>
@@ -2083,7 +2083,7 @@
         <description />
         <row>
           <state>Enabled</state>
-          <url>https://domain42.example/easylist_noelemhide.txt</url>
+          <url>https://domain12.example/easylist_noelemhide.txt</url>
           <header>HZ</header>
           <easycat>eap,aa,aap</easycat>
         </row>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -974,12 +974,12 @@
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/example.com</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -1039,12 +1039,12 @@
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/example.com?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1092,7 +1092,7 @@
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/example.com?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/example.com?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/example.com?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/example.com?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1149,36 +1149,36 @@
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,7 +1186,7 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
       <include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -1201,20 +1201,20 @@
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=example.com</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>example.com?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>example.com?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>example.com?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1260,7 +1260,7 @@
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=example.com</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1510,13 +1510,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://example.com/example.com</url>
+          <url>https://example.com/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/adservers/example.com?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/downloads/example.com</url>
+          <url>https://example.com/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/example.com</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2001,7 +2001,7 @@
       <name>FRR Global/Zebra</name>
       <section>Services</section>
       <configfile>frr.xml</configfile>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
@@ -2030,7 +2030,7 @@
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/example.com?xml=example.com</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -974,12 +974,12 @@
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/example.com</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -1039,12 +1039,12 @@
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/example.com?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1092,7 +1092,7 @@
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/example.com?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/example.com?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/example.com?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/example.com?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1149,36 +1149,36 @@
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,7 +1186,7 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
       <include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -1201,20 +1201,20 @@
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=example.com</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>example.com?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>example.com?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>example.com?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1260,7 +1260,7 @@
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=example.com</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1510,13 +1510,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://example.com/example.com</url>
+          <url>https://example.com/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/adservers/example.com?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/downloads/example.com</url>
+          <url>https://example.com/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/example.com</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2001,7 +2001,7 @@
       <name>FRR Global/Zebra</name>
       <section>Services</section>
       <configfile>frr.xml</configfile>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
@@ -2030,7 +2030,7 @@
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/example.com?xml=example.com</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://example.com:443/pfblockerng/example.com?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -974,12 +974,12 @@
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/example.com</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -1039,12 +1039,12 @@
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/example.com?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1092,7 +1092,7 @@
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/example.com?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/example.com?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/example.com?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/example.com?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1149,36 +1149,36 @@
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,7 +1186,7 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
       <include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -1201,20 +1201,20 @@
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=example.com</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>example.com?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>example.com?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>example.com?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1260,7 +1260,7 @@
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=example.com</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1510,13 +1510,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://example.com/example.com</url>
+          <url>https://example.com/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/adservers/example.com?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/downloads/example.com</url>
+          <url>https://example.com/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/example.com</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2001,7 +2001,7 @@
       <name>FRR Global/Zebra</name>
       <section>Services</section>
       <configfile>frr.xml</configfile>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
@@ -2030,7 +2030,7 @@
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/example.com?xml=example.com</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>18.2</version>
   <lastchange />
   <system>
@@ -645,7 +645,7 @@
   <aliases>
     <alias>
       <name>pfB_Asia_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
@@ -654,7 +654,7 @@
     </alias>
     <alias>
       <name>pfB_Whitelist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -663,7 +663,7 @@
     </alias>
     <alias>
       <name>pfB_Blacklist_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -672,7 +672,7 @@
     </alias>
     <alias>
       <name>pfB_DNSBLIP_v4</name>
-      <url>https://127.0.0.1:443/pfblockerng/example.com?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <url>https://127.0.0.1:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
       <updatefreq>32</updatefreq>
       <address />
       <descr>pfBlockerNG  Auto  Alias</descr>
@@ -974,12 +974,12 @@
       <tabs>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Restore</text>
-          <url>/example.com</url>
+          <url>/autoconfigbackup.php</url>
         </tab>
         <tab>
           <text>Backup now</text>
@@ -1039,12 +1039,12 @@
       <tabs>
         <tab>
           <text>General</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
           <text>Remote Cache</text>
-          <url>/example.com?xml=squid_upstream.xml</url>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
         </tab>
         <tab>
           <text>Local Cache</text>
@@ -1068,7 +1068,7 @@
         </tab>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=squid_users.xml</url>
+          <url>/pkg.php?xml=squid_users.xml</url>
         </tab>
         <tab>
           <text>Real Time</text>
@@ -1092,7 +1092,7 @@
       <tabs>
         <tab>
           <text>General settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
           <active />
         </tab>
         <tab>
@@ -1101,19 +1101,19 @@
         </tab>
         <tab>
           <text>Groups ACL</text>
-          <url>/example.com?xml=squidguard_acl.xml</url>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
         </tab>
         <tab>
           <text>Target categories</text>
-          <url>/example.com?xml=squidguard_dest.xml</url>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
         </tab>
         <tab>
           <text>Times</text>
-          <url>/example.com?xml=squidguard_time.xml</url>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
         </tab>
         <tab>
           <text>Rewrites</text>
-          <url>/example.com?xml=squidguard_rewr.xml</url>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
         </tab>
         <tab>
           <text>Blacklist</text>
@@ -1149,36 +1149,36 @@
       <tabs>
         <tab>
           <text>Users</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradius.xml</url>
           <active />
         </tab>
         <tab>
           <text>MACs</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
         </tab>
         <tab>
           <text>NAS / Clients</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
         </tab>
         <tab>
           <text>Interfaces</text>
-          <url>/example.com?xml=example.com</url>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
         </tab>
         <tab>
           <text>Settings</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>EAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>SQL</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>LDAP</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
         </tab>
         <tab>
           <text>View config</text>
@@ -1186,7 +1186,7 @@
         </tab>
         <tab>
           <text>XMLRPC Sync</text>
-          <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
         </tab>
       </tabs>
       <include_file>/usr/local/pkg/freeradius.inc</include_file>
@@ -1201,20 +1201,20 @@
       <tabs>
         <tab>
           <text>Global Settings</text>
-          <url>pkg_edit.php?xml=example.com</url>
+          <url>pkg_edit.php?xml=frr.xml</url>
           <active />
         </tab>
         <tab>
           <text>Access Lists</text>
-          <url>example.com?xml=frr/frr_global_acls.xml</url>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
         </tab>
         <tab>
           <text>Prefix Lists</text>
-          <url>example.com?xml=frr/frr_global_prefixes.xml</url>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
         </tab>
         <tab>
           <text>Route Maps</text>
-          <url>example.com?xml=frr/frr_global_routemaps.xml</url>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
         </tab>
         <tab>
           <text>Raw Config</text>
@@ -1260,7 +1260,7 @@
       <tabs>
         <tab>
           <text>ntopng Settings</text>
-          <url>/pkg_edit.php?xml=example.com</url>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
           <active />
         </tab>
         <tab>
@@ -1325,13 +1325,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
           <header>C2_IP_Feed</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/feeds/example.com</url>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
           <header>C2_All_Indicator_Feed</header>
         </row>
         <action>Deny_Inbound</action>
@@ -1510,13 +1510,13 @@
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>https://example.com/example.com</url>
+          <url>https://example.com/hosts.txt</url>
           <header>Adaway</header>
         </row>
         <row>
           <format>auto</format>
           <state>Enabled</state>
-          <url>http://example.com/adservers/example.com?hostformat=hosts&amp;mimetype=plaintext</url>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
           <header>yoyo</header>
         </row>
         <row>
@@ -1551,7 +1551,7 @@
         <row>
           <format>auto</format>
           <state>Disabled</state>
-          <url>https://example.com/downloads/example.com</url>
+          <url>https://example.com/downloads/dg-ads.acl</url>
           <header>SBL_ADs</header>
         </row>
       </config>
@@ -1947,7 +1947,7 @@
       <name>ntopng Settings</name>
       <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
     </menu>
     <menu>
       <name>ntopng</name>
@@ -1959,19 +1959,19 @@
       <name>AutoConfigBackup</name>
       <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
       <section>Diagnostics</section>
-      <url>/example.com</url>
+      <url>/autoconfigbackup.php</url>
     </menu>
     <menu>
       <name>SquidGuard Proxy Filter</name>
       <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Proxy Server</name>
       <tooltiptext>Modify the proxy server settings</tooltiptext>
       <section>Services</section>
-      <url>/pkg_edit.php?xml=example.com&amp;id=0</url>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
     </menu>
     <menu>
       <name>Squid Reverse Proxy</name>
@@ -2001,7 +2001,7 @@
       <name>FRR Global/Zebra</name>
       <section>Services</section>
       <configfile>frr.xml</configfile>
-      <url>/pkg_edit.php?xml=example.com</url>
+      <url>/pkg_edit.php?xml=frr.xml</url>
     </menu>
     <menu>
       <name>FRR BGP</name>
@@ -2030,7 +2030,7 @@
     <menu>
       <name>FreeRADIUS</name>
       <section>Services</section>
-      <url>/example.com?xml=example.com</url>
+      <url>/pkg.php?xml=freeradius.xml</url>
     </menu>
     <menu>
       <name>Service Watchdog</name>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>
@@ -930,7 +930,7 @@
       <month>*</month>
       <wday>*</wday>
       <who>root</who>
-      <command>/usr/bin/nice -n20 /etc/example.com</command>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
     </item>
     <item>
       <minute>*/60</minute>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.0 -->
+  <!-- Redacted using pfsense-redactor v1.1.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_secret_detection.py
+++ b/tests/unit/test_secret_detection.py
@@ -370,3 +370,111 @@ class TestRedactDescriptions:
         redactor.redact_element(root)
 
         assert 'ACME-Corp-WiFi' not in ET.tostring(root, encoding='unicode')
+
+
+class TestURLPathCredentialFormats:
+    """Credential formats embedded in URL path segments
+
+    The boundaries in _is_secretish_path_segment are load-bearing; each case
+    here corresponds to a format that slipped through in 1.1.0.
+    """
+
+    @pytest.mark.parametrize('segment,description', [
+        ('AKIAIOSFODNN7EXAMPLE', 'AWS access key ID - exactly 20 chars'),
+        ('bot123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw', 'Telegram bot token - contains a colon'),
+        ('XXXXXXXXXXXXXXXXXXXXXXXX', '24-char token with no digit'),
+        ('4nBv8kQ2rT9wZxL6mYpJ7dCf', 'Slack webhook token'),
+        ('aB3dE5gH7jK9lM1nO3pQ5rS7tU9vW1xY3zA5bC7dE9fG1hI3jK5lM7nO9pQ1rS3t', 'Discord webhook token'),
+    ])
+    def test_credential_segment_detected(self, segment, description):
+        """Each format is recognised as a credential"""
+        from pfsense_redactor.redactor import PfSenseRedactor
+
+        assert PfSenseRedactor._is_secretish_path_segment(segment), description
+
+    @pytest.mark.parametrize('segment,description', [
+        ('Open_VM_Tools_package', 'route name the digit rule protects (21 chars)'),
+        ('Setup_Snort_Package', 'route name, 19 chars'),
+        ('services', 'short route'),
+        ('webhooks', 'short route'),
+        ('sendMessage', 'short route'),
+        ('T024BE7LD', 'short identifier'),
+    ])
+    def test_route_name_not_flagged(self, segment, description):
+        """Ordinary route names must not be mistaken for credentials"""
+        from pfsense_redactor.redactor import PfSenseRedactor
+
+        assert not PfSenseRedactor._is_secretish_path_segment(segment), description
+
+    def test_aws_key_redacted_in_url(self, aggressive_redactor):
+        """End to end: an AWS key ID in a path is redacted"""
+        result = aggressive_redactor.redact_text('https://example.org/api/AKIAIOSFODNN7EXAMPLE/data')
+
+        assert 'AKIAIOSFODNN7EXAMPLE' not in result
+
+    def test_telegram_token_redacted_in_url(self, aggressive_redactor):
+        """The colon must not shield the secret half of the token"""
+        result = aggressive_redactor.redact_text(
+            'https://api.telegram.org/bot123456789:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw/sendMessage'
+        )
+
+        assert 'AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw' not in result
+        assert 'sendMessage' in result, 'the route should survive'
+
+    def test_webhook_element_redacted_whole(self, basic_redactor):
+        """A webhook URL is a credential in its entirety, not just its last segment"""
+        root = ET.fromstring(
+            '<pfsense><a><webhook_url>'
+            'https://hooks.example.com/services/T00/B00/SomeOpaqueTokenValue'
+            '</webhook_url></a></pfsense>'
+        )
+        basic_redactor.redact_element(root)
+
+        assert 'SomeOpaqueTokenValue' not in ET.tostring(root, encoding='unicode')
+
+
+class TestFilenamesNotTreatedAsDomains:
+    """FQDN substitution must not rewrite filenames and paths
+
+    Rewriting 'haproxy.sh' to 'example.com' corrupts the output rather than
+    redacting it, and pfBlockerNG feed names and cron commands are exactly what
+    people share a config to get help with.
+    """
+
+    @pytest.mark.parametrize('text', [
+        'https://feeds.example.net/lists/emerging-block.rules',
+        'https://updates.example.org/pfblocker/list.txt',
+    ])
+    def test_filename_in_url_path_preserved(self, basic_redactor, text):
+        """The host is masked; the filename in the path is not"""
+        result = basic_redactor.redact_text(text)
+
+        assert 'example.com' in result, 'host should still be masked'
+        assert result.rsplit('/', 1)[-1] == text.rsplit('/', 1)[-1], 'filename should survive'
+
+    @pytest.mark.parametrize('text', [
+        '/usr/local/etc/rc.d/haproxy.sh restart',
+        '/usr/local/etc/snort/snort.conf',
+        'backup-2026.tar.gz',
+        'config.xml',
+    ])
+    def test_filesystem_path_preserved(self, aggressive_redactor, text):
+        """Bare paths and filenames are left alone even under --aggressive"""
+        assert aggressive_redactor.redact_text(text) == text
+
+    @pytest.mark.parametrize('domain', [
+        'host.internal.corp.example',
+        'mail.acme-corp.example',
+        'fw.corp.local',
+    ])
+    def test_real_domains_still_redacted(self, basic_redactor, domain):
+        """The filename rules must not weaken domain redaction"""
+        result = basic_redactor.redact_text(domain)
+
+        assert domain not in result
+        assert 'example.com' in result
+
+    def test_ambiguous_extension_redacted_outside_path_context(self, basic_redactor):
+        """'.sh' is a real TLD, so it is only preserved in path context"""
+        assert basic_redactor.redact_text('/etc/rc.d/haproxy.sh') == '/etc/rc.d/haproxy.sh'
+        assert 'haproxy.sh' not in basic_redactor.redact_text('visit haproxy.sh for details')

--- a/tests/unit/test_secret_detection.py
+++ b/tests/unit/test_secret_detection.py
@@ -12,6 +12,7 @@ Fixtures (basic_redactor, aggressive_redactor, redactor_factory) come from
 tests/conftest.py.
 """
 import xml.etree.ElementTree as ET
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -446,10 +447,15 @@ class TestFilenamesNotTreatedAsDomains:
         'https://updates.example.org/pfblocker/list.txt',
     ])
     def test_filename_in_url_path_preserved(self, basic_redactor, text):
-        """The host is masked; the filename in the path is not"""
+        """The host is masked; the filename in the path is not
+
+        Asserts on the parsed hostname rather than a substring: 'example.com'
+        appearing somewhere in the string would also be satisfied by an
+        unmasked host next to a masked one.
+        """
         result = basic_redactor.redact_text(text)
 
-        assert 'example.com' in result, 'host should still be masked'
+        assert urlsplit(result).hostname == 'example.com', 'host should still be masked'
         assert result.rsplit('/', 1)[-1] == text.rsplit('/', 1)[-1], 'filename should survive'
 
     @pytest.mark.parametrize('text', [
@@ -468,11 +474,14 @@ class TestFilenamesNotTreatedAsDomains:
         'fw.corp.local',
     ])
     def test_real_domains_still_redacted(self, basic_redactor, domain):
-        """The filename rules must not weaken domain redaction"""
+        """The filename rules must not weaken domain redaction
+
+        The input is a bare hostname, so the whole value must be replaced -
+        an equality check, not a substring check.
+        """
         result = basic_redactor.redact_text(domain)
 
-        assert domain not in result
-        assert 'example.com' in result
+        assert result == 'example.com'
 
     def test_ambiguous_extension_redacted_outside_path_context(self, basic_redactor):
         """'.sh' is a real TLD, so it is only preserved in path context"""


### PR DESCRIPTION
Follow-up to #49, from a second canary-corpus report. 1.1.0 caught **41/46** where 1.0.10 caught 15/46; this closes the remaining gaps plus an over-redaction bug the reporter found while confirming them.

All findings reproduced before fixing.

## 1. Three credential formats bypassed URL path detection

| Format | Length | Why it was missed |
|---|---|---|
| AWS access key ID (`AKIA...`) | **exactly 20** | Test was `len(segment) <= 20` — an off-by-one excluded the entire format |
| Telegram bot token | 47 | `bot<id>:<secret>` — the colon failed `BASE64ISH_RE`, so a 47-char credential passed as an ordinary path segment |
| Token with no digits | 24 | The digit requirement is unconditional |

Segments are now split on `:` before testing, the length floor is `>= 20`, and the digit requirement applies only below 24 characters — it exists to protect underscore-joined route names like `Open_VM_Tools_package` (21 chars).

**The reporter corrected me here.** In #49 I dismissed the no-digit case as a canary artefact and asserted that real tokens essentially always contain digits. That was an assumption stated as fact, and it's exactly what the rule rested on.

## 2. `<webhook_url>` is now redacted whole

A Slack or Discord webhook URL is a credential in its entirety, not merely a secret-bearing path segment. Zero occurrences of `webhook` among the 875 element names in the sample configs, so no false-positive surface.

## 3. FQDN substitution rewrote filenames as domains

```
list.txt              -> example.com
emerging-block.rules  -> example.com
pfblockerng.php       -> example.com
haproxy.sh            -> example.com
```

This corrupts output rather than redacting it, and silently — those are exactly the feed names, script paths and cron commands people share a config to get help with.

**Worse than reported.** The reporter described it as `--aggressive`-only, having tested with unrecognised element names. But `<url>` is a known URL-bearing element, so pfBlockerNG feed URLs were corrupted **in default mode**. It was also live in this project's own reference snapshots — that's what the 288-line snapshot diff restores.

Cause: `_redact_fqdns_safe` runs after `_redact_urls_safe` over the whole string, re-matching inside URLs whose hosts were already masked. URLs are now stashed behind placeholders for that pass — the same technique already protecting the IPv4 mask and Cisco MAC format — and bare filenames are recognised by extension or filesystem-path context.

Context is required because extension alone cannot decide it: **`.sh`, `.pl`, `.io` and `.zip` are all real TLDs**. So `haproxy.sh` is preserved inside a path and still redacted in prose.

## Known limitation, documented

A path segment of 21–23 characters with no digit is not detected. `Open_VM_Tools_package` (a route name that must be preserved) and a hypothetical 21-char alphabetic token are the same length and shape, so no length threshold separates them. Real Slack and Discord tokens are 24+ characters and are caught. Recorded in the CHANGELOG rather than papered over.

## Verification

- Canary corpus back to **2/46** under `--aggressive` — both deliberate exclusions (`publickey`, attribute free text)
- False-positive scan **unchanged at 14/875** element names
- **492 tests** pass (+25); 12 of the new tests verified to fail against 1.1.0 logic
- Both pylint runs exit 0, flake8 clean, standalone execution still verified
- Snapshot diff reviewed by hand: every change restores a corrupted filename; no previously-redacted value is newly exposed

## Not addressed

The reporter's item 3 (attribute values with non-secret names) — they note it's probably working as intended, and I agree. `SENSITIVE_ATTR_PATTERN` matches on attribute name by design.
