### PR TITLE
Reduce cyclomatic complexity below 10 and make the CI gate blocking

### DIFF
--- a/--dry-run --aggressive
+++ b/--dry-run --aggressive
@@ -1,0 +1,2354 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
+  <version>18.2</version>
+  <lastchange />
+  <system>
+    <optimization>normal</optimization>
+    <hostname>pf_test</hostname>
+    <domain>example.com</domain>
+    <group>
+      <name>all</name>
+      <description>All Users</description>
+      <scope>system</scope>
+      <gid>1998</gid>
+      <member>0</member>
+    </group>
+    <group>
+      <name>admins</name>
+      <description>System Administrators</description>
+      <scope>system</scope>
+      <gid>1999</gid>
+      <member>0</member>
+      <priv>page-all</priv>
+    </group>
+    <user>
+      <name>admin</name>
+      <descr>System Administrator</descr>
+      <scope>system</scope>
+      <groupname>admins</groupname>
+      <bcrypt-hash>[REDACTED]</bcrypt-hash>
+      <uid>0</uid>
+      <priv>user-shell-access</priv>
+    </user>
+    <nextuid>2000</nextuid>
+    <nextgid>2000</nextgid>
+    <timeservers>0.pfsense.pool.ntp.org</timeservers>
+    <webgui>
+      <protocol>https</protocol>
+      <loginautocomplete />
+      <ssl-certref>59d39fada929c</ssl-certref>
+      <dashboardcolumns>2</dashboardcolumns>
+      <port />
+      <max_procs>5</max_procs>
+      <nohttpreferercheck />
+      <nodnsrebindcheck />
+      <webguicss>pfSense.css</webguicss>
+      <logincss>1e3f75;</logincss>
+    </webgui>
+    <disablenatreflection>yes</disablenatreflection>
+    <disablesegmentationoffloading />
+    <disablelargereceiveoffloading />
+    <ipv6allow />
+    <powerd_ac_mode>hadp</powerd_ac_mode>
+    <powerd_battery_mode>hadp</powerd_battery_mode>
+    <powerd_normal_mode>hadp</powerd_normal_mode>
+    <bogons>
+      <interval>monthly</interval>
+    </bogons>
+    <timezone>Etc/UTC</timezone>
+    <serialspeed>115200</serialspeed>
+    <primaryconsole>serial</primaryconsole>
+    <enablesshd>enabled</enablesshd>
+    <disablechecksumoffloading />
+    <powerd_enable />
+    <use_mfs_tmp_size />
+    <use_mfs_var_size />
+    <maximumtableentries>2000000</maximumtableentries>
+    <gitsync>
+      <repositoryurl />
+      <branch />
+    </gitsync>
+    <pkg_repo_conf_path>/usr/local/share/pfSense/pkg/repos/pfSense-repo-devel.conf</pkg_repo_conf_path>
+    <already_run_config_upgrade />
+    <crypto_hardware>cryptodev</crypto_hardware>
+    <language>en_US</language>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsallowoverride />
+    <dns1gw>none</dns1gw>
+    <dns2gw>none</dns2gw>
+    <scrubnodf>enabled</scrubnodf>
+    <maximumstates />
+    <aliasesresolveinterval />
+    <maximumfrags />
+    <reflectiontimeout />
+  </system>
+  <interfaces>
+    <wan>
+      <enable />
+      <if>vmx0</if>
+      <blockbogons />
+      <descr>WAN</descr>
+      <spoofmac />
+      <alias-address />
+      <alias-subnet>32</alias-subnet>
+      <ipaddr>dhcp</ipaddr>
+      <dhcphostname />
+      <dhcprejectfrom />
+      <adv_dhcp_pt_timeout />
+      <adv_dhcp_pt_retry />
+      <adv_dhcp_pt_select_timeout />
+      <adv_dhcp_pt_reboot />
+      <adv_dhcp_pt_backoff_cutoff />
+      <adv_dhcp_pt_initial_interval />
+      <adv_dhcp_pt_values>SavedCfg</adv_dhcp_pt_values>
+      <adv_dhcp_send_options />
+      <adv_dhcp_request_options />
+      <adv_dhcp_required_options />
+      <adv_dhcp_option_modifiers />
+      <adv_dhcp_config_advanced />
+      <adv_dhcp_config_file_override />
+      <adv_dhcp_config_file_override_path />
+    </wan>
+    <lan>
+      <enable />
+      <if>vmx1</if>
+      <descr>LAN</descr>
+      <spoofmac />
+      <ipaddr>XXX.XXX.XXX.XXX</ipaddr>
+      <subnet>24</subnet>
+    </lan>
+    <opt1>
+      <descr>OPT1</descr>
+      <if>ovpnc2</if>
+      <spoofmac />
+    </opt1>
+  </interfaces>
+  <staticroutes />
+  <dhcpd>
+    <lan>
+      <range>
+        <from>192.168.125.10</from>
+        <to>192.168.125.245</to>
+      </range>
+      <failover_peerip />
+      <dhcpleaseinlocaltime />
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <gateway />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkeyalgorithm>hmac-md5</ddnsdomainkeyalgorithm>
+      <ddnsdomainkey />
+      <mac_allow />
+      <mac_deny />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <nextserver />
+      <filename />
+      <filename32 />
+      <filename64 />
+      <rootpath />
+      <numberoptions />
+      <enable />
+    </lan>
+  </dhcpd>
+  <dhcpdv6>
+    <lan>
+      <range>
+        <from>::1000</from>
+        <to>::2000</to>
+      </range>
+      <ramode>assist</ramode>
+      <rapriority>medium</rapriority>
+      <prefixrange>
+        <from />
+        <to />
+        <prefixlength>48</prefixlength>
+      </prefixrange>
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkey />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <bootfile_url />
+      <dhcpv6leaseinlocaltime />
+      <numberoptions />
+    </lan>
+  </dhcpdv6>
+  <snmpd>
+    <syslocation />
+    <syscontact />
+    <rocommunity>[REDACTED]</rocommunity>
+  </snmpd>
+  <diag>
+    <ipv6nat />
+  </diag>
+  <syslog>
+    <nentries>50</nentries>
+    <sourceip />
+    <ipproto>ipv4</ipproto>
+    <filterdescriptions>1</filterdescriptions>
+  </syslog>
+  <nat>
+    <outbound>
+      <mode>automatic</mode>
+    </outbound>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>80</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8081</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>443</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8443</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+  </nat>
+  <filter>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <address>pfB_Asia_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770009596</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Blacklist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Blacklist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010135</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Whitelist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010396</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Asia_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009093</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_DNSBLIP_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_DNSBLIP_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009235</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Whitelist_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009893</tracker>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617312</tracker>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <protocol>udp</protocol>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <network>(self)</network>
+        <port>1194</port>
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507041729</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507042058</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Default allow LAN to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000101</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet6</ipprotocol>
+      <descr>Default allow LAN IPv6 to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000102</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507626308</tracker>
+      <type>pass</type>
+      <interface>enc0</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617328</tracker>
+      <type>pass</type>
+      <interface>openvpn</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>lan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1525695659</time>
+        <username>Easy Rule</username>
+      </created>
+      <tracker>1525695659</tracker>
+    </rule>
+    <separator>
+      <wan />
+    </separator>
+  </filter>
+  <shaper />
+  <ipsec>
+    <phase1>
+      <ikeid>1</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr />
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>256</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>2</dhgroup>
+        </item>
+      </encryption>
+    </phase1>
+    <phase1>
+      <ikeid>2</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>128</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>14</dhgroup>
+        </item>
+      </encryption>
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr>Tunnel with PB2</descr>
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <rekey_enable />
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+    </phase1>
+    <client />
+    <phase2>
+      <ikeid>1</ikeid>
+      <uniqid>59dc8cdccfa7b</uniqid>
+      <mode>tunnel</mode>
+      <reqid>1</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>XXX.XXX.XXX.XXX</address>
+        <netbits>24</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>auto</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>0</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+    <phase2>
+      <ikeid>2</ikeid>
+      <uniqid>5ab0a8c528fd8</uniqid>
+      <mode>tunnel</mode>
+      <reqid>2</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>0.0.0.0</address>
+        <netbits>0</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>128</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>14</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+  </ipsec>
+  <aliases>
+    <alias>
+      <name>pfB_Asia_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Whitelist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Blacklist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_DNSBLIP_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>Alias_1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX XXX.XXX.XXX.XXX Alias2</address>
+      <descr />
+      <detail>Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX Test1</address>
+      <descr />
+      <detail>Entry added Tue, 27 Feb 2018 14:25:35 +0000||Entry added Wed, 28 Feb 2018 06:49:30 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX</address>
+      <descr />
+      <detail>Entry added Wed, 28 Feb 2018 06:49:16 +0000</detail>
+    </alias>
+  </aliases>
+  <proxyarp />
+  <cron>
+    <item>
+      <minute>1,31</minute>
+      <hour>0-5</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 adjkerntz -a</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>3</hour>
+      <mday>1</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_bogons.sh</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 sshlockout</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 webConfiguratorlockout</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>1</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 virusprot</command>
+    </item>
+    <item>
+      <minute>30</minute>
+      <hour>12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_urltables</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_pkg_metadata</command>
+    </item>
+    <item>
+      <minute>*/5</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_cron_misc.inc</command>
+    </item>
+    <item>
+      <minute>5</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/mail_reports_generate.php 0 &amp;</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>3</hour>
+      <mday>4-10</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc &gt;&gt; /var/log/pfblockerng/extras.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron &gt;&gt; /var/log/pfblockerng/pfblockerng.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/sbin/squid -k rotate -f /usr/local/etc/squid/squid.conf</command>
+    </item>
+    <item>
+      <minute>15</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/pkg/swapstate_check.php</command>
+    </item>
+  </cron>
+  <wol />
+  <rrd>
+    <enable />
+  </rrd>
+  <load_balancer>
+    <monitor_type>
+      <name>ICMP</name>
+      <type>icmp</type>
+      <descr>ICMP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>TCP</name>
+      <type>tcp</type>
+      <descr>Generic TCP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>HTTP</name>
+      <type>http</type>
+      <descr>Generic HTTP</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>HTTPS</name>
+      <type>https</type>
+      <descr>Generic HTTPS</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>SMTP</name>
+      <type>send</type>
+      <descr>Generic SMTP</descr>
+      <options>
+        <send />
+        <expect>220 *</expect>
+      </options>
+    </monitor_type>
+  </load_balancer>
+  <widgets>
+    <sequence>system_information:col1:open:0,interfaces:col2:open:0,pfblockerng:col2:open:0,snort_alerts:col2:open:0,installed_packages:col2:open:0</sequence>
+  </widgets>
+  <openvpn />
+  <dnshaper />
+  <unbound>
+    <enable />
+    <dnssec />
+    <active_interface />
+    <outgoing_interface />
+    <custom_options>c2VydmVyOmluY2x1ZGU6IC92YXIvdW5ib3VuZC9wZmJfZG5zYmwuKmNvbmY=</custom_options>
+    <hideidentity />
+    <hideversion />
+    <dnssecstripped />
+    <hosts>
+      <host>pkg</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+    <hosts>
+      <host>release-staging</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+  </unbound>
+  <revision>
+    <time>1532955144</time>
+    <username>user@example.com</username>
+  </revision>
+  <cert>
+    <refid>59d39fada929c</refid>
+    <descr>webConfigurator default (59d39fada929c)</descr>
+    <type>server</type>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <cert>
+    <refid>5a030fac39e79</refid>
+    <descr>OpenVPNClientCert</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <caref>5a030f8debd96</caref>
+  </cert>
+  <cert>
+    <refid>5a04208c7c65a</refid>
+    <descr>FreeRADIUS Server Certificate</descr>
+    <type>server</type>
+    <caref>5a04208c70f14</caref>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <ppps />
+  <gateways />
+  <installedpackages>
+    <package>
+      <name>snort</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/Setup_Snort_Package</pkginfolink>
+      <website>http://www.snort.org</website>
+      <descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
+      <version>3.2.9.6_1</version>
+      <configurationfile>/snort.xml</configurationfile>
+      <after_install_info>Please visit Services - Snort - Interfaces tab first and select your desired rules. Afterwards visit the Updates tab to download your configured rulesets.</after_install_info>
+      <include_file>/usr/local/pkg/snort/snort.inc</include_file>
+    </package>
+    <package>
+      <name>Lightsquid</name>
+      <descr>LightSquid is a high performance web proxy reporting tool. Includes proxy realtime statistics (SQStat).
+			&amp;lt;strong&amp;gt;Requires Squid package.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://lightsquid.sf.net/</website>
+      <version>3.0.6_4</version>
+      <configurationfile>lightsquid.xml</configurationfile>
+      <noembedded>true</noembedded>
+    </package>
+    <package>
+      <name>AutoConfigBackup</name>
+      <descr>Automatically backs up your pfSense configuration. All contents are encrypted before being sent to the server.&amp;lt;br /&amp;gt;
+			Requires Gold Subscription from &amp;lt;a href=&amp;quot;https://portal.pfsense.org&amp;quot;&amp;gt;pfSense Portal&amp;lt;/a&amp;gt;.</descr>
+      <website>https://portal.pfsense.org</website>
+      <version>1.52</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/AutoConfigBackup</pkginfolink>
+      <configurationfile>autoconfigbackup.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Restore</text>
+          <url>/autoconfigbackup.php</url>
+        </tab>
+        <tab>
+          <text>Backup now</text>
+          <url>/autoconfigbackup_backup.php</url>
+        </tab>
+        <tab>
+          <text>Stats</text>
+          <url>/autoconfigbackup_stats.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/autoconfigbackup.inc</include_file>
+    </package>
+    <package>
+      <name>haproxy-devel</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
+      <descr>The Reliable, High Performance TCP/HTTP(S) Load Balancer.&amp;lt;br /&amp;gt;
+			This package implements the TCP, HTTP and HTTPS balancing features from haproxy.&amp;lt;br /&amp;gt;
+			Supports ACLs for smart backend switching.</descr>
+      <website>http://haproxy.1wt.eu/</website>
+      <version>0.58_2</version>
+      <configurationfile>haproxy.xml</configurationfile>
+      <logging>
+        <logsocket>/tmp/haproxy_chroot/var/run/log</logsocket>
+        <facilityname>haproxy</facilityname>
+        <logfilename>haproxy.log</logfilename>
+      </logging>
+      <filter_rule_function>haproxy_generate_rules</filter_rule_function>
+      <include_file>/usr/local/pkg/haproxy/haproxy.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+        <item>
+          <type>plugin_certificates</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>Open-VM-Tools</name>
+      <descr>VMware Tools is a suite of utilities that enhances the performance of the virtual machine's guest operating system and improves management of the virtual machine.</descr>
+      <website>http://open-vm-tools.sourceforge.net/</website>
+      <version>10.1.0,1</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/Open_VM_Tools_package</pkginfolink>
+      <configurationfile>open-vm-tools.xml</configurationfile>
+      <include_file>/usr/local/pkg/open-vm-tools.inc</include_file>
+    </package>
+    <package>
+      <name>squid3</name>
+      <internal_name>squid</internal_name>
+      <descr>High performance web proxy cache (3.4 branch). It combines Squid as a proxy server with its capabilities of acting as a HTTP / HTTPS reverse proxy.&amp;lt;br /&amp;gt;
+			It includes an Exchange-Web-Access (OWA) Assistant, SSL filtering and antivirus integration via C-ICAP.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?board=60.0</pkginfolink>
+      <website>http://www.squid-cache.org/</website>
+      <version>0.4.44_1</version>
+      <configurationfile>squid.xml</configurationfile>
+      <filter_rule_function>squid_generate_rules</filter_rule_function>
+      <tabs>
+        <tab>
+          <text>General</text>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Remote Cache</text>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
+        </tab>
+        <tab>
+          <text>Local Cache</text>
+          <url>/pkg_edit.php?xml=squid_cache.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Antivirus</text>
+          <url>/pkg_edit.php?xml=squid_antivirus.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>ACLs</text>
+          <url>/pkg_edit.php?xml=squid_nac.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Traffic Mgmt</text>
+          <url>/pkg_edit.php?xml=squid_traffic.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Authentication</text>
+          <url>/pkg_edit.php?xml=squid_auth.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=squid_users.xml</url>
+        </tab>
+        <tab>
+          <text>Real Time</text>
+          <url>/squid_monitor.php</url>
+        </tab>
+        <tab>
+          <text>Sync</text>
+          <url>/pkg_edit.php?xml=squid_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squid.inc</include_file>
+    </package>
+    <package>
+      <name>squidGuard</name>
+      <descr>High performance web proxy URL filter.&amp;lt;br/&amp;gt;
+			&amp;lt;strong&amp;gt;Works with both Squid (2.7 legacy branch) and Squid3 (3.4 branch) packages.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://www.squidGuard.org/</website>
+      <version>1.16.16</version>
+      <configurationfile>squidguard.xml</configurationfile>
+      <after_install_info>Please visit Services - SquidGuard Proxy Filter - Target Categories and set up at least one category there before enabling SquidGuard. See https://forum.pfsense.org/index.php?topic=94312.0 for details.</after_install_info>
+      <tabs>
+        <tab>
+          <text>General settings</text>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Common ACL</text>
+          <url>/pkg_edit.php?xml=squidguard_default.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Groups ACL</text>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
+        </tab>
+        <tab>
+          <text>Target categories</text>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
+        </tab>
+        <tab>
+          <text>Times</text>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
+        </tab>
+        <tab>
+          <text>Rewrites</text>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
+        </tab>
+        <tab>
+          <text>Blacklist</text>
+          <url>/squidGuard/squidguard_blacklist.php</url>
+        </tab>
+        <tab>
+          <text>Log</text>
+          <url>/squidGuard/squidguard_log.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=squidguard_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squidguard.inc</include_file>
+    </package>
+    <package>
+      <name>Service Watchdog</name>
+      <internal_name>Service_Watchdog</internal_name>
+      <descr>Monitors for stopped services and restarts them.</descr>
+      <version>1.8.5</version>
+      <configurationfile>servicewatchdog.xml</configurationfile>
+      <include_file>/usr/local/pkg/servicewatchdog.inc</include_file>
+    </package>
+    <package>
+      <name>freeradius3</name>
+      <website>http://www.freeradius.org/</website>
+      <descr>A free implementation of the RADIUS protocol.&amp;lt;br /&amp;gt;
+			Supports MySQL, PostgreSQL, LDAP, Kerberos.</descr>
+      <pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
+      <version>0.15.5_1</version>
+      <configurationfile>freeradius.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=freeradius.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>MACs</text>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
+        </tab>
+        <tab>
+          <text>NAS / Clients</text>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
+        </tab>
+        <tab>
+          <text>Interfaces</text>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
+        </tab>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>EAP</text>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>SQL</text>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>LDAP</text>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>View config</text>
+          <url>/freeradius_view_config.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/freeradius.inc</include_file>
+    </package>
+    <package>
+      <name>FRR</name>
+      <internal_name>frr</internal_name>
+      <descr>FRR routing daemon for BGP, OSPF, and OSPF6.&amp;lt;br /&amp;gt;
+			&amp;lt;strong&amp;gt;Conflicts with Quagga OSPF and OpenBGPD; these packages cannot be installed at the same time.&amp;lt;/strong&amp;gt;</descr>
+      <version>0.2_1</version>
+      <configurationfile>frr.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Global Settings</text>
+          <url>pkg_edit.php?xml=frr.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access Lists</text>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
+        </tab>
+        <tab>
+          <text>Prefix Lists</text>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
+        </tab>
+        <tab>
+          <text>Route Maps</text>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
+        </tab>
+        <tab>
+          <text>Raw Config</text>
+          <url>pkg_edit.php?xml=frr/frr_global_raw.xml</url>
+        </tab>
+        <tab>
+          <text>[BGP]</text>
+          <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF6]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+        </tab>
+        <tab>
+          <text>Status</text>
+          <url>/status_frr.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/frr.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>mailreport</name>
+      <descr>Allows you to setup periodic e-mail reports containing command output and log file contents.</descr>
+      <version>3.3</version>
+      <configurationfile>mailreport.xml</configurationfile>
+    </package>
+    <package>
+      <name>ntopng</name>
+      <website>http://www.ntop.org/</website>
+      <descr>ntopng (replaces ntop) is a network probe that shows network usage in a way similar to what top does for processes. In interactive mode, it displays the network status on the user's terminal. In Web mode it acts as a Web server, creating an HTML dump of the network status. It sports a NetFlow/sFlow emitter/collector, an HTTP-based client interface for creating ntop-centric monitoring applications, and RRD for persistently storing traffic statistics.</descr>
+      <version>0.8.12</version>
+      <configurationfile>ntopng.xml</configurationfile>
+      <noembedded>true</noembedded>
+      <tabs>
+        <tab>
+          <text>ntopng Settings</text>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access ntopng</text>
+          <url>/ntopng_redirect.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/ntopng.inc</include_file>
+    </package>
+    <package>
+      <name>pfBlockerNG-devel</name>
+      <descr>pfBlockerNG is the Next Generation of pfBlocker.&amp;lt;br /&amp;gt;
+			Manage IPv4/v6 List Sources into 'Deny, Permit or Match' formats.&amp;lt;br /&amp;gt;
+			GeoIP database by MaxMind Inc. (GeoLite2 Free version).&amp;lt;br /&amp;gt;
+			De-Duplication, Suppression, and Reputation enhancements.&amp;lt;br /&amp;gt;
+			Provision to download from diverse List formats.&amp;lt;br /&amp;gt;
+			Advanced Integration for Proofpoint ET IQRisk IP Reputation Threat Sources.&amp;lt;br /&amp;gt;
+			Domain Name (DNSBL) blocking via Unbound DNS Resolver.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?topic=102470.0</pkginfolink>
+      <version>2.2.1</version>
+      <configurationfile>pfblockerng.xml</configurationfile>
+      <include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+    </package>
+    <pfblockernglistsv4>
+      <config>
+        <aliasname>Whitelist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url />
+          <header />
+        </row>
+        <action>Permit_Both</action>
+        <cron>Never</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom>OC44LjguOA==</custom>
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
+          <header>C2_IP_Feed</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
+          <header>C2_All_Indicator_Feed</header>
+        </row>
+        <action>Deny_Inbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>PRI1</aliasname>
+        <description>PRI1 - Collection of Feeds from the most reputable blocklist providers. (Primary tier)</description>
+        <action>Disabled</action>
+        <cron>01hour</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <suppression_cidr>Disabled</suppression_cidr>
+        <whois_convert />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/blacklist/dyre_sslipblacklist.csv</url>
+          <header>Abuse_DYRE</header>
+        </row>
+      </config>
+    </pfblockernglistsv4>
+    <pfblockernglistsv6>
+      <config />
+    </pfblockernglistsv6>
+    <pfblockerngdnsblsettings>
+      <config>
+        <pfb_dnsbl>on</pfb_dnsbl>
+        <pfb_tld />
+        <pfb_dnsvip>10.10.10.1</pfb_dnsvip>
+        <pfb_dnsport>8081</pfb_dnsport>
+        <pfb_dnsport_ssl>8443</pfb_dnsport_ssl>
+        <dnsbl_interface>lan</dnsbl_interface>
+        <pfb_dnsbl_rule />
+        <dnsbl_allow_int />
+        <action>Deny_Outbound</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <alexa_enable>on</alexa_enable>
+        <alexa_count>1000</alexa_count>
+        <alexa_inclusion>ca,co,com,io,net,org</alexa_inclusion>
+        <suppression />
+        <tldexclusion />
+        <tldblacklist />
+        <tldwhitelist />
+      </config>
+    </pfblockerngdnsblsettings>
+    <pfblockerngafrica>
+      <config />
+    </pfblockerngafrica>
+    <pfblockerngantarctica>
+      <config />
+    </pfblockerngantarctica>
+    <pfblockerngasia>
+      <config>
+        <countries4>6255147,6255147_rep,CN,CN_rep</countries4>
+        <countries6 />
+        <action>Deny_Both</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+      </config>
+    </pfblockerngasia>
+    <pfblockerngeurope>
+      <config />
+    </pfblockerngeurope>
+    <pfblockerngnorthamerica>
+      <config />
+    </pfblockerngnorthamerica>
+    <pfblockerngoceania>
+      <config />
+    </pfblockerngoceania>
+    <pfblockerngsouthamerica>
+      <config />
+    </pfblockerngsouthamerica>
+    <pfblockerngtopspammers>
+      <config />
+    </pfblockerngtopspammers>
+    <pfblockerngproxyandsatellite>
+      <config />
+    </pfblockerngproxyandsatellite>
+    <pfblockerng>
+      <config>
+        <enable_cb>on</enable_cb>
+        <pfb_keep>on</pfb_keep>
+        <pfb_interval>12</pfb_interval>
+        <pfb_min />
+        <pfb_hour />
+        <pfb_dailystart />
+        <skipfeed />
+        <credits />
+        <log_max_log>20000</log_max_log>
+        <log_max_errlog>20000</log_max_errlog>
+        <log_max_extraslog>20000</log_max_extraslog>
+        <log_max_ip_blocklog>20000</log_max_ip_blocklog>
+        <log_max_ip_permitlog>20000</log_max_ip_permitlog>
+        <log_max_ip_matchlog>20000</log_max_ip_matchlog>
+        <log_max_dnslog>20000</log_max_dnslog>
+        <log_max_dnsbl_parse_err>20000</log_max_dnsbl_parse_err>
+      </config>
+    </pfblockerng>
+    <pfblockerngdnsbl>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <infolists />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>https://example.com/hosts.txt</url>
+          <header>Adaway</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
+          <header>yoyo</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/ad_servers.txt</url>
+          <header>hpHosts_ads</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>example.com/cameleon/hosts</url>
+          <header>Cameleon</header>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>ADs</aliasname>
+        <description>ADs - Collection of ADvertisement Domain Feeds.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/downloads/dg-ads.acl</url>
+          <header>SBL_ADs</header>
+        </row>
+      </config>
+      <config>
+        <aliasname>BBcan177</aliasname>
+        <description>BBcan177 - Feed as provided by BBcan177.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/BBcan177/4a8bf37c131be4803cb2/raw</url>
+          <header>MS_2</header>
+        </row>
+      </config>
+    </pfblockerngdnsbl>
+    <snortglobal>
+      <snort_config_ver>3.2.9.6_1</snort_config_ver>
+      <snortdownload>on</snortdownload>
+      <snortcommunityrules>off</snortcommunityrules>
+      <emergingthreats>off</emergingthreats>
+      <emergingthreats_pro>off</emergingthreats_pro>
+      <clearblocks>on</clearblocks>
+      <verbose_logging>off</verbose_logging>
+      <openappid_detectors>on</openappid_detectors>
+      <openappid_rules_detectors>on</openappid_rules_detectors>
+      <hide_deprecated_rules>off</hide_deprecated_rules>
+      <curl_no_verify_ssl_peer>off</curl_no_verify_ssl_peer>
+      <oinkmastercode>c4e000842278df905ba5795132288ddc7c996d14</oinkmastercode>
+      <etpro_code />
+      <rm_blocked>never_b</rm_blocked>
+      <autorulesupdate7>12h_up</autorulesupdate7>
+      <rule_update_starttime>00:05</rule_update_starttime>
+      <forcekeepsettings>on</forcekeepsettings>
+      <last_rule_upd_status>success</last_rule_upd_status>
+      <last_rule_upd_time>1532952490</last_rule_upd_time>
+      <rule>
+        <interface>wan</interface>
+        <enable>on</enable>
+        <uuid>53250</uuid>
+        <descr>WAN</descr>
+        <performance>ac-bnfa</performance>
+        <blockoffenders7>off</blockoffenders7>
+        <blockoffenderskill>on</blockoffenderskill>
+        <blockoffendersip>both</blockoffendersip>
+        <whitelistname>default</whitelistname>
+        <homelistname>default</homelistname>
+        <externallistname>default</externallistname>
+        <suppresslistname>wansuppress_5a82ea740612f</suppresslistname>
+        <alertsystemlog>on</alertsystemlog>
+        <alertsystemlog_facility>log_auth</alertsystemlog_facility>
+        <alertsystemlog_priority>log_alert</alertsystemlog_priority>
+        <cksumcheck>on</cksumcheck>
+        <fpm_split_any_any>off</fpm_split_any_any>
+        <fpm_search_optimize>off</fpm_search_optimize>
+        <fpm_no_stream_inserts>off</fpm_no_stream_inserts>
+        <max_attribute_hosts>10000</max_attribute_hosts>
+        <max_attribute_services_per_host>10</max_attribute_services_per_host>
+        <max_paf>16000</max_paf>
+        <ftp_preprocessor>on</ftp_preprocessor>
+        <ftp_telnet_inspection_type>stateful</ftp_telnet_inspection_type>
+        <ftp_telnet_alert_encrypted>off</ftp_telnet_alert_encrypted>
+        <ftp_telnet_check_encrypted>on</ftp_telnet_check_encrypted>
+        <ftp_telnet_normalize>on</ftp_telnet_normalize>
+        <ftp_telnet_detect_anomalies>on</ftp_telnet_detect_anomalies>
+        <ftp_telnet_ayt_attack_threshold>20</ftp_telnet_ayt_attack_threshold>
+        <ftp_client_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <max_resp_len>256</max_resp_len>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <bounce>yes</bounce>
+            <bounce_to_net />
+            <bounce_to_port />
+          </item>
+        </ftp_client_engine>
+        <ftp_server_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <ports>default</ports>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <ignore_data_chan>no</ignore_data_chan>
+            <def_max_param_len>100</def_max_param_len>
+          </item>
+        </ftp_server_engine>
+        <smtp_preprocessor>on</smtp_preprocessor>
+        <smtp_memcap>838860</smtp_memcap>
+        <smtp_max_mime_mem>838860</smtp_max_mime_mem>
+        <smtp_b64_decode_depth>0</smtp_b64_decode_depth>
+        <smtp_qp_decode_depth>0</smtp_qp_decode_depth>
+        <smtp_bitenc_decode_depth>0</smtp_bitenc_decode_depth>
+        <smtp_uu_decode_depth>0</smtp_uu_decode_depth>
+        <smtp_email_hdrs_log_depth>1464</smtp_email_hdrs_log_depth>
+        <smtp_ignore_data>off</smtp_ignore_data>
+        <smtp_ignore_tls_data>on</smtp_ignore_tls_data>
+        <smtp_log_mail_from>on</smtp_log_mail_from>
+        <smtp_log_rcpt_to>on</smtp_log_rcpt_to>
+        <smtp_log_filename>on</smtp_log_filename>
+        <smtp_log_email_hdrs>on</smtp_log_email_hdrs>
+        <dce_rpc_2>on</dce_rpc_2>
+        <dns_preprocessor>on</dns_preprocessor>
+        <ssl_preproc>on</ssl_preproc>
+        <pop_preproc>on</pop_preproc>
+        <pop_memcap>838860</pop_memcap>
+        <pop_b64_decode_depth>0</pop_b64_decode_depth>
+        <pop_qp_decode_depth>0</pop_qp_decode_depth>
+        <pop_bitenc_decode_depth>0</pop_bitenc_decode_depth>
+        <pop_uu_decode_depth>0</pop_uu_decode_depth>
+        <imap_preproc>on</imap_preproc>
+        <imap_memcap>838860</imap_memcap>
+        <imap_b64_decode_depth>0</imap_b64_decode_depth>
+        <imap_qp_decode_depth>0</imap_qp_decode_depth>
+        <imap_bitenc_decode_depth>0</imap_bitenc_decode_depth>
+        <imap_uu_decode_depth>0</imap_uu_decode_depth>
+        <sip_preproc>on</sip_preproc>
+        <other_preprocs>on</other_preprocs>
+        <pscan_protocol>all</pscan_protocol>
+        <pscan_type>all</pscan_type>
+        <pscan_memcap>10000000</pscan_memcap>
+        <pscan_sense_level>medium</pscan_sense_level>
+        <http_inspect>on</http_inspect>
+        <http_inspect_proxy_alert>off</http_inspect_proxy_alert>
+        <http_inspect_memcap>150994944</http_inspect_memcap>
+        <http_inspect_max_gzip_mem>838860</http_inspect_max_gzip_mem>
+        <http_inspect_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <server_profile>all</server_profile>
+            <enable_xff>off</enable_xff>
+            <log_uri>off</log_uri>
+            <log_hostname>off</log_hostname>
+            <server_flow_depth>65535</server_flow_depth>
+            <enable_cookie>on</enable_cookie>
+            <client_flow_depth>1460</client_flow_depth>
+            <extended_response_inspection>on</extended_response_inspection>
+            <no_alerts>off</no_alerts>
+            <unlimited_decompress>on</unlimited_decompress>
+            <inspect_gzip>on</inspect_gzip>
+            <normalize_cookies>on</normalize_cookies>
+            <normalize_headers>on</normalize_headers>
+            <normalize_utf>on</normalize_utf>
+            <normalize_javascript>on</normalize_javascript>
+            <allow_proxy_use>off</allow_proxy_use>
+            <inspect_uri_only>off</inspect_uri_only>
+            <max_javascript_whitespaces>200</max_javascript_whitespaces>
+            <post_depth>-1</post_depth>
+            <max_headers>0</max_headers>
+            <max_spaces>0</max_spaces>
+            <max_header_length>0</max_header_length>
+            <ports>default</ports>
+            <decompress_swf>off</decompress_swf>
+            <decompress_pdf>off</decompress_pdf>
+          </item>
+        </http_inspect_engine>
+        <frag3_max_frags>8192</frag3_max_frags>
+        <frag3_memcap>4194304</frag3_memcap>
+        <frag3_detection>on</frag3_detection>
+        <frag3_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>60</timeout>
+            <min_ttl>1</min_ttl>
+            <detect_anomalies>on</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <min_frag_len>0</min_frag_len>
+          </item>
+        </frag3_engine>
+        <stream5_reassembly>on</stream5_reassembly>
+        <stream5_flush_on_alert>off</stream5_flush_on_alert>
+        <stream5_prune_log_max>1048576</stream5_prune_log_max>
+        <stream5_track_tcp>on</stream5_track_tcp>
+        <stream5_max_tcp>262144</stream5_max_tcp>
+        <stream5_track_udp>on</stream5_track_udp>
+        <stream5_max_udp>131072</stream5_max_udp>
+        <stream5_udp_timeout>30</stream5_udp_timeout>
+        <stream5_track_icmp>off</stream5_track_icmp>
+        <stream5_max_icmp>65536</stream5_max_icmp>
+        <stream5_icmp_timeout>30</stream5_icmp_timeout>
+        <stream5_mem_cap>8388608</stream5_mem_cap>
+        <stream5_tcp_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>30</timeout>
+            <max_queued_bytes>1048576</max_queued_bytes>
+            <detect_anomalies>off</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <max_queued_segs>2621</max_queued_segs>
+            <require_3whs>off</require_3whs>
+            <startup_3whs_timeout>0</startup_3whs_timeout>
+            <no_reassemble_async>off</no_reassemble_async>
+            <max_window>0</max_window>
+            <use_static_footprint_sizes>off</use_static_footprint_sizes>
+            <check_session_hijacking>off</check_session_hijacking>
+            <dont_store_lg_pkts>off</dont_store_lg_pkts>
+            <ports_client>default</ports_client>
+            <ports_both>default</ports_both>
+            <ports_server>none</ports_server>
+          </item>
+        </stream5_tcp_engine>
+        <appid_preproc>on</appid_preproc>
+        <sf_appid_mem_cap>256</sf_appid_mem_cap>
+        <sf_appid_statslog>on</sf_appid_statslog>
+        <sf_appid_stats_period>300</sf_appid_stats_period>
+        <sdf_alert_data_type>Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers</sdf_alert_data_type>
+        <sdf_alert_threshold>25</sdf_alert_threshold>
+        <sdf_mask_output>off</sdf_mask_output>
+        <ssh_preproc>on</ssh_preproc>
+        <pscan_ignore_scanners />
+        <pscan_ignore_scanned />
+        <perform_stat>off</perform_stat>
+        <host_attribute_table>off</host_attribute_table>
+        <sf_portscan>on</sf_portscan>
+        <sensitive_data>off</sensitive_data>
+        <dnp3_preproc>off</dnp3_preproc>
+        <modbus_preproc>off</modbus_preproc>
+        <gtp_preproc>off</gtp_preproc>
+        <preproc_auto_rule_disable>off</preproc_auto_rule_disable>
+        <protect_preproc_rules>off</protect_preproc_rules>
+        <ips_policy_enable>on</ips_policy_enable>
+        <rulesets />
+        <autoflowbitrules>on</autoflowbitrules>
+        <ips_policy>connectivity</ips_policy>
+        <arp_spoof_engine />
+        <arpspoof_preproc>off</arpspoof_preproc>
+        <arp_unicast_detection>off</arp_unicast_detection>
+      </rule>
+      <dashboard_widget>snort_alerts:col2:open:0</dashboard_widget>
+      <auto_manage_sids>off</auto_manage_sids>
+      <enable_log_mgmt>on</enable_log_mgmt>
+      <alert_log_limit_size>500</alert_log_limit_size>
+      <alert_log_retention>336</alert_log_retention>
+      <appid_stats_log_limit_size>1000</appid_stats_log_limit_size>
+      <appid_stats_log_retention>168</appid_stats_log_retention>
+      <event_pkts_log_limit_size>0</event_pkts_log_limit_size>
+      <event_pkts_log_retention>336</event_pkts_log_retention>
+      <sid_changes_log_limit_size>250</sid_changes_log_limit_size>
+      <sid_changes_log_retention>336</sid_changes_log_retention>
+      <stats_log_limit_size>500</stats_log_limit_size>
+      <stats_log_retention>168</stats_log_retention>
+      <suppress />
+      <whitelist>
+        <item>
+          <name>passlist_40695</name>
+          <uuid>38194</uuid>
+          <localnets>no</localnets>
+          <wangateips>no</wangateips>
+          <wandnsips>no</wandnsips>
+          <vips>no</vips>
+          <vpnips>no</vpnips>
+          <address>Test</address>
+          <descr />
+        </item>
+      </whitelist>
+    </snortglobal>
+    <autoconfigbackup>
+      <config>
+        <enable_acb>enabled</enable_acb>
+        <username>azamat</username>
+        <password>[REDACTED]</password>
+        <passwordagain>[REDACTED]</passwordagain>
+        <crypto_password>[REDACTED]</crypto_password>
+        <crypto_password2>[REDACTED]</crypto_password2>
+      </config>
+    </autoconfigbackup>
+    <haproxy>
+      <configversion>00.32</configversion>
+      <ha_backends />
+      <ha_pools />
+      <email_mailers />
+      <dns_resolvers />
+      <files>
+        <item />
+      </files>
+    </haproxy>
+    <service />
+    <service>
+      <name>vmware-guestd</name>
+      <rcfile>vmware-guestd.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-guestd status") == 0;</custom_php_service_status_command>
+      <description>VMware Guest Daemon</description>
+    </service>
+    <service>
+      <name>vmware-kmod</name>
+      <rcfile>vmware-kmod.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-kmod status") == 0;</custom_php_service_status_command>
+      <description>VMware Kernel Modules</description>
+    </service>
+    <service>
+      <name>snort</name>
+      <rcfile>snort.sh</rcfile>
+      <executable>snort</executable>
+      <description>Snort IDS/IPS Daemon</description>
+    </service>
+    <service>
+      <name>ntopng</name>
+      <rcfile>ntopng.sh</rcfile>
+      <executable>ntopng</executable>
+      <description>ntopng Network Traffic Monitor</description>
+    </service>
+    <service>
+      <name>squidGuard</name>
+      <description>Proxy server filter Service</description>
+      <executable>squidGuard</executable>
+    </service>
+    <service>
+      <name>squid</name>
+      <rcfile>squid.sh</rcfile>
+      <executable>squid</executable>
+      <description>Squid Proxy Server Service</description>
+    </service>
+    <service>
+      <name>clamd</name>
+      <rcfile>clamd.sh</rcfile>
+      <executable>clamd</executable>
+      <description>ClamAV Antivirus</description>
+    </service>
+    <service>
+      <name>c-icap</name>
+      <rcfile>c-icap.sh</rcfile>
+      <executable>c-icap</executable>
+      <description>ICAP Inteface for Squid and ClamAV integration</description>
+    </service>
+    <service>
+      <name>haproxy</name>
+      <rcfile>haproxy.sh</rcfile>
+      <executable>haproxy</executable>
+      <description>TCP/HTTP(S) Load Balancer</description>
+    </service>
+    <service>
+      <name>FRR zebra</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>zebra</executable>
+      <description>FRR core/abstraction daemon</description>
+    </service>
+    <service>
+      <name>FRR bgpd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>bgpd</executable>
+      <description>FRR BGP routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospfd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospfd</executable>
+      <description>FRR OSPF routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospf6d</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospf6d</executable>
+      <description>FRR OSPF6 routing daemon</description>
+    </service>
+    <service>
+      <name>radiusd</name>
+      <rcfile>radiusd.sh</rcfile>
+      <executable>radiusd</executable>
+      <description>FreeRADIUS Server</description>
+    </service>
+    <service>
+      <name>pfb_dnsbl</name>
+      <rcfile>pfb_dnsbl.sh</rcfile>
+      <executable>lighttpd_pfb</executable>
+      <description>pfBlockerNG DNSBL service</description>
+    </service>
+    <service>
+      <name>pfb_filter</name>
+      <rcfile>pfb_filter.sh</rcfile>
+      <executable>php_pfb</executable>
+      <description>pfBlockerNG firewall filter service</description>
+    </service>
+    <menu />
+    <menu>
+      <name>Snort</name>
+      <tooltiptext>Set up snort specific settings</tooltiptext>
+      <section>Services</section>
+      <url>/snort/snort_interfaces.php</url>
+    </menu>
+    <menu>
+      <name>ntopng Settings</name>
+      <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
+    </menu>
+    <menu>
+      <name>ntopng</name>
+      <tooltiptext>Access ntopng</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/ntopng_redirect.php</url>
+    </menu>
+    <menu>
+      <name>AutoConfigBackup</name>
+      <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/autoconfigbackup.php</url>
+    </menu>
+    <menu>
+      <name>SquidGuard Proxy Filter</name>
+      <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Proxy Server</name>
+      <tooltiptext>Modify the proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Reverse Proxy</name>
+      <tooltiptext>Modify the reverse proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid_reverse_general.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Email Reports</name>
+      <tooltiptext>Setup periodic email reports.</tooltiptext>
+      <section>Status</section>
+      <url>/status_mail_report.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/haproxy/haproxy_listeners.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy Stats</name>
+      <tooltiptext>Stats of HAProxy</tooltiptext>
+      <section>Status</section>
+      <url>/haproxy/haproxy_stats.php?haproxystats=1</url>
+    </menu>
+    <menu>
+      <name>FRR Global/Zebra</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr.xml</url>
+    </menu>
+    <menu>
+      <name>FRR BGP</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF6</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+    </menu>
+    <menu>
+      <name>FRR</name>
+      <section>Status</section>
+      <configfile>frr.xml</configfile>
+      <url>/status_frr.php</url>
+    </menu>
+    <menu>
+      <name>FreeRADIUS</name>
+      <section>Services</section>
+      <url>/pkg.php?xml=freeradius.xml</url>
+    </menu>
+    <menu>
+      <name>Service Watchdog</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/services_servicewatchdog.php</url>
+    </menu>
+    <menu>
+      <name>pfBlockerNG</name>
+      <section>Firewall</section>
+      <url>/pfblockerng/pfblockerng_general.php</url>
+    </menu>
+    <squidcache>
+      <config>
+        <cache_replacement_policy>heap LFUDA</cache_replacement_policy>
+        <cache_swap_low>90</cache_swap_low>
+        <cache_swap_high>95</cache_swap_high>
+        <donotcache />
+        <enable_offline />
+        <ext_cachemanager />
+        <harddisk_cache_size>1000</harddisk_cache_size>
+        <harddisk_cache_system>ufs</harddisk_cache_system>
+        <level1_subdirs>16</level1_subdirs>
+        <harddisk_cache_location>/var/squid/cache</harddisk_cache_location>
+        <minimum_object_size>0</minimum_object_size>
+        <maximum_object_size>4</maximum_object_size>
+        <memory_cache_size>64</memory_cache_size>
+        <maximum_objsize_in_mem>256</maximum_objsize_in_mem>
+        <memory_replacement_policy>heap GDSF</memory_replacement_policy>
+        <cache_dynamic_content />
+        <custom_refresh_patterns />
+      </config>
+    </squidcache>
+    <squidremote />
+    <squidauth>
+      <config>
+        <auth_method>none</auth_method>
+      </config>
+    </squidauth>
+    <servicewatchdog />
+    <freeradiuseapconf>
+      <config>
+        <ssl_ca_cert>5a04208c70f14</ssl_ca_cert>
+        <ssl_server_cert>5a04208c7c65a</ssl_server_cert>
+      </config>
+    </freeradiuseapconf>
+    <pfblockerngdnsbleasylist>
+      <config>
+        <aliasname />
+        <description />
+        <row>
+          <state>Enabled</state>
+          <url>https://example.com/easylist_noelemhide.txt</url>
+          <header>HZ</header>
+          <easycat>eap,aa,aap</easycat>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+      </config>
+    </pfblockerngdnsbleasylist>
+    <frrbgp>
+      <config>
+        <enable>on</enable>
+        <adjacencylog />
+        <asnum>65002</asnum>
+        <routerid />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_updatedelay />
+        <timers_peerwait />
+        <redistributeconnectedsubnets>no</redistributeconnectedsubnets>
+        <redistributestatic>no</redistributestatic>
+        <redistributekernel>no</redistributekernel>
+        <redistributeospf>no</redistributeospf>
+        <row>
+          <distributeroutevalue>192.168.125.0/24</distributeroutevalue>
+          <distributeroutemap>none</distributeroutemap>
+        </row>
+      </config>
+    </frrbgp>
+    <frrbgpneighbors>
+      <config>
+        <peer>XXX.XXX.XXX.XXX</peer>
+        <descr />
+        <peergroup>none</peergroup>
+        <password />
+        <password_type>none</password_type>
+        <asnum>65001</asnum>
+        <updatesource_type>ipv4</updatesource_type>
+        <updatesource>default</updatesource>
+        <defaultoriginate>no</defaultoriginate>
+        <sendcommunity>disabled</sendcommunity>
+        <nexthopself>disabled</nexthopself>
+        <softreconfigurationinbound />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_connect />
+        <distribute_in>none</distribute_in>
+        <distribute_out>none</distribute_out>
+        <prefixfilter_in>none</prefixfilter_in>
+        <prefixfilter_out>none</prefixfilter_out>
+        <aspathfilter_in>none</aspathfilter_in>
+        <aspathfilter_out>none</aspathfilter_out>
+        <routemap_in>none</routemap_in>
+        <routemap_out>none</routemap_out>
+        <unsuppressmap>none</unsuppressmap>
+        <weight />
+        <passive />
+        <addpathtxallpaths />
+        <addpathtxbestpathperas />
+        <advertisementinterval />
+        <allowasin>disabled</allowasin>
+        <asoverride />
+        <attributeunchanged />
+        <attributeunchanged_aspath />
+        <attributeunchanged_med />
+        <attributeunchanged_nexthop />
+        <bfd_multiplier />
+        <bfd_minrx />
+        <bfd_mintx />
+        <capability>disabled</capability>
+        <dontcapabilitynegotiate />
+        <overridecapability />
+        <ttlsecurityhops />
+        <disableconnectedcheck />
+        <ebgpmultihop />
+        <enforcemultihop />
+        <localas_num />
+        <localas_noprepend />
+        <localas_replaceas />
+        <maximumprefix_num />
+        <maximumprefix_threshold />
+        <maximumprefix_warnonly />
+        <maximumprefix_restart />
+        <removeprivateas />
+        <removeprivateas_all />
+        <removeprivateas_replace />
+        <routeclient_reflector />
+        <routeclient_server />
+        <solo />
+      </config>
+    </frrbgpneighbors>
+    <frr>
+      <config>
+        <enable>on</enable>
+        <password>[REDACTED]</password>
+        <carpstatusvid>none</carpstatusvid>
+        <logging />
+        <routerid />
+        <row>
+          <routevalue />
+          <routetarget>none</routetarget>
+        </row>
+      </config>
+    </frr>
+    <ntopng>
+      <config>
+        <enable>on</enable>
+        <keepdata>on</keepdata>
+        <redis_password>[REDACTED]</redis_password>
+        <redis_passwordagain>[REDACTED]</redis_passwordagain>
+        <interface_array>lan</interface_array>
+        <interface_array>opt1</interface_array>
+        <interface_array>wan</interface_array>
+        <dns_mode>0</dns_mode>
+        <disable_alerts />
+        <local_networks>rfc1918</local_networks>
+        <row>
+          <cidr />
+        </row>
+      </config>
+    </ntopng>
+    <pfblockerngreputation>
+      <config />
+    </pfblockerngreputation>
+    <pfblockerngipsettings>
+      <config>
+        <enable_dup>on</enable_dup>
+        <enable_agg />
+        <suppression />
+        <enable_log>on</enable_log>
+        <maxmind_locale>en</maxmind_locale>
+        <database_cc />
+        <inbound_interface>wan</inbound_interface>
+        <inbound_deny_action>block</inbound_deny_action>
+        <outbound_interface>lan</outbound_interface>
+        <outbound_deny_action>reject</outbound_deny_action>
+        <enable_float />
+        <pass_order>order_0</pass_order>
+        <autorule_suffix>autorule</autorule_suffix>
+        <killstates />
+      </config>
+    </pfblockerngipsettings>
+    <squidguarddest>
+      <config>
+        <name>my</name>
+        <domains />
+        <urls />
+        <expressions />
+        <redirect_mode>rmod_none</redirect_mode>
+        <redirect />
+        <description />
+        <enablelog />
+      </config>
+    </squidguarddest>
+    <squid>
+      <config>
+        <enable_squid>on</enable_squid>
+        <keep_squid_data>on</keep_squid_data>
+        <active_interface>lan,lo0</active_interface>
+        <proxy_port>3128</proxy_port>
+        <icp_port />
+        <allow_interface>on</allow_interface>
+        <dns_v4_first />
+        <disable_pinger />
+        <dns_nameservers />
+        <transparent_proxy>on</transparent_proxy>
+        <transparent_active_interface>lan</transparent_active_interface>
+        <private_subnet_proxy_off />
+        <defined_ip_proxy_off />
+        <defined_ip_proxy_off_dest />
+        <ssl_proxy>on</ssl_proxy>
+        <sslproxy_mitm_mode>spliceall</sslproxy_mitm_mode>
+        <ssl_active_interface>lan</ssl_active_interface>
+        <ssl_proxy_port />
+        <sslproxy_compatibility_mode>modern</sslproxy_compatibility_mode>
+        <dhparams_size>2048</dhparams_size>
+        <dca>5b5f09f433185</dca>
+        <sslcrtd_children />
+        <interception_checks />
+        <interception_adapt />
+        <log_enabled>on</log_enabled>
+        <log_dir>/var/squid/logs</log_dir>
+        <log_rotate>7</log_rotate>
+        <log_sqd />
+        <visible_hostname>localhost</visible_hostname>
+        <admin_email>admin@localhost</admin_email>
+        <error_language>en</error_language>
+        <xforward_mode>delete</xforward_mode>
+        <disable_via>on</disable_via>
+        <uri_whitespace>strip</uri_whitespace>
+        <disable_squidversion>on</disable_squidversion>
+        <custom_options />
+        <custom_options_squid3 />
+        <custom_options2_squid3 />
+        <custom_options3_squid3 />
+      </config>
+    </squid>
+  </installedpackages>
+  <virtualip>
+    <vip>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <type>single</type>
+      <subnet_bits>32</subnet_bits>
+      <subnet>XXX.XXX.XXX.XXX</subnet>
+      <mode>ipalias</mode>
+    </vip>
+  </virtualip>
+  <dyndnses />
+  <ca>
+    <refid>5a030f8debd96</refid>
+    <descr>OpenVPNCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <serial>0</serial>
+  </ca>
+  <ca>
+    <refid>5a04208c70f14</refid>
+    <descr>FreeRADIUS CA</descr>
+    <serial>1</serial>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </ca>
+  <ca>
+    <refid>5b5f09f433185</refid>
+    <descr>SquidProxyCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <serial>0</serial>
+  </ca>
+  <dhcrelay>
+    <interface>lan</interface>
+    <server />
+  </dhcrelay>
+  <ezshaper>
+    <step1>
+      <numberofconnections>1</numberofconnections>
+      <numberoflocalinterfaces>1</numberoflocalinterfaces>
+    </step1>
+    <step2>
+      <local0downloadscheduler>CBQ</local0downloadscheduler>
+      <local0interface>lan</local0interface>
+      <conn0uploadscheduler>CBQ</conn0uploadscheduler>
+      <conn0upload>100</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+      <conn0download>100</conn0download>
+      <conn0downloadspeed>Mb</conn0downloadspeed>
+      <conn0interface>wan</conn0interface>
+    </step2>
+    <step3>
+      <address>XXX.XXX.XXX.XXX</address>
+      <enable>on</enable>
+      <provider>Generic</provider>
+      <local0download>4</local0download>
+      <local0downloadspeed>Mb</local0downloadspeed>
+      <conn0upload>4</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+    </step3>
+  </ezshaper>
+  <mailreports>
+    <schedule>
+      <descr>as</descr>
+      <frequency>daily</frequency>
+      <timeofday>0</timeofday>
+      <submit>Save</submit>
+      <schedule_friendly>Daily at 00:00</schedule_friendly>
+    </schedule>
+  </mailreports>
+</pfsense>

--- a/--dry-run --aggressive --dry-run-verbose
+++ b/--dry-run --aggressive --dry-run-verbose
@@ -1,0 +1,243 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
+  <version>2.9</version>
+  <lastchange />
+  <theme>nervecenter</theme>
+  <system>
+    <optimization>normal</optimization>
+    <hostname>pfSense</hostname>
+    <domain>local</domain>
+    <dnsserver />
+    <dnsallowoverride />
+    <username>admin</username>
+    <password>[REDACTED]</password>
+    <timezone>Etc/UTC</timezone>
+    <time-update-interval>300</time-update-interval>
+    <timeservers>0.pfsense.pool.ntp.org</timeservers>
+    <webgui>
+      <protocol>http</protocol>
+    </webgui>
+    <disablenatreflection>yes</disablenatreflection>
+  </system>
+  <interfaces>
+    <lan>
+      <if>sis0</if>
+      <ipaddr>XXX.XXX.XXX.XXX</ipaddr>
+      <subnet>24</subnet>
+      <media />
+      <mediaopt />
+      <bandwidth>100</bandwidth>
+      <bandwidthtype>Mb</bandwidthtype>
+    </lan>
+    <wan>
+      <if>sis1</if>
+      <mtu />
+      <ipaddr>dhcp</ipaddr>
+      <subnet />
+      <gateway />
+      <blockpriv />
+      <disableftpproxy />
+      <dhcphostname />
+      <media />
+      <mediaopt />
+      <bandwidth>100</bandwidth>
+      <bandwidthtype>Mb</bandwidthtype>
+    </wan>
+  </interfaces>
+  <staticroutes>
+		
+	</staticroutes>
+  <pppoe>
+    <username />
+    <password />
+    <provider />
+  </pppoe>
+  <pptp>
+    <username />
+    <password />
+    <local />
+    <subnet />
+    <remote />
+  </pptp>
+  <bigpond>
+    <username />
+    <password />
+    <authserver />
+    <authdomain />
+    <minheartbeatinterval />
+  </bigpond>
+  <dyndns>
+    <type>dyndns</type>
+    <username />
+    <password />
+    <host />
+    <mx />
+  </dyndns>
+  <dhcpd>
+    <lan>
+      <enable />
+      <range>
+        <from>192.168.1.100</from>
+        <to>192.168.1.199</to>
+      </range>
+    </lan>
+  </dhcpd>
+  <pptpd>
+    <mode />
+    <redir />
+    <localip />
+    <remoteip />
+  </pptpd>
+  <ovpn>
+		
+	</ovpn>
+  <dnsmasq>
+    <enable />
+  </dnsmasq>
+  <snmpd>
+    <syslocation />
+    <syscontact />
+    <rocommunity>[REDACTED]</rocommunity>
+  </snmpd>
+  <diag>
+    <ipv6nat>
+      <ipaddr />
+    </ipv6nat>
+  </diag>
+  <bridge>
+		
+	</bridge>
+  <syslog>
+		
+	</syslog>
+  <nat>
+    <ipsecpassthru>
+      <enable />
+    </ipsecpassthru>
+  </nat>
+  <filter>
+    <rule>
+      <type>pass</type>
+      <descr>Default LAN -&gt; any</descr>
+      <interface>lan</interface>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+  </filter>
+  <shaper>
+		
+		
+		
+	</shaper>
+  <ipsec>
+    <preferredoldsa />
+  </ipsec>
+  <aliases>
+		
+	</aliases>
+  <proxyarp>
+		
+	</proxyarp>
+  <cron>
+    <item>
+      <minute>0</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 newsyslog</command>
+    </item>
+    <item>
+      <minute>1,31</minute>
+      <hour>0-5</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 adjkerntz -a</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>3</hour>
+      <mday>1</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_bogons.sh</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 sshlockout</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>1</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 virusprot</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -t 3600 snort2c</command>
+    </item>
+    <item>
+      <minute>*/5</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/checkreload.sh</command>
+    </item>
+    <item>
+      <minute>*/5</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/etc/ping_hosts.sh</command>
+    </item>
+    <item>
+      <minute>*/140</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/sbin/reset_slbd.sh</command>
+    </item>
+  </cron>
+  <wol>
+		
+	</wol>
+  <installedpackages>
+	</installedpackages>
+</pfsense>

--- a/--dry-run --anonymise --dry-run-verbose
+++ b/--dry-run --anonymise --dry-run-verbose
@@ -1,0 +1,2354 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
+  <version>18.2</version>
+  <lastchange />
+  <system>
+    <optimization>normal</optimization>
+    <hostname>pf_test</hostname>
+    <domain>example.com</domain>
+    <group>
+      <name>all</name>
+      <description>All Users</description>
+      <scope>system</scope>
+      <gid>1998</gid>
+      <member>0</member>
+    </group>
+    <group>
+      <name>admins</name>
+      <description>System Administrators</description>
+      <scope>system</scope>
+      <gid>1999</gid>
+      <member>0</member>
+      <priv>page-all</priv>
+    </group>
+    <user>
+      <name>admin</name>
+      <descr>System Administrator</descr>
+      <scope>system</scope>
+      <groupname>admins</groupname>
+      <bcrypt-hash>[REDACTED]</bcrypt-hash>
+      <uid>0</uid>
+      <priv>user-shell-access</priv>
+    </user>
+    <nextuid>2000</nextuid>
+    <nextgid>2000</nextgid>
+    <timeservers>0.pfsense.pool.ntp.org</timeservers>
+    <webgui>
+      <protocol>https</protocol>
+      <loginautocomplete />
+      <ssl-certref>59d39fada929c</ssl-certref>
+      <dashboardcolumns>2</dashboardcolumns>
+      <port />
+      <max_procs>5</max_procs>
+      <nohttpreferercheck />
+      <nodnsrebindcheck />
+      <webguicss>pfSense.css</webguicss>
+      <logincss>1e3f75;</logincss>
+    </webgui>
+    <disablenatreflection>yes</disablenatreflection>
+    <disablesegmentationoffloading />
+    <disablelargereceiveoffloading />
+    <ipv6allow />
+    <powerd_ac_mode>hadp</powerd_ac_mode>
+    <powerd_battery_mode>hadp</powerd_battery_mode>
+    <powerd_normal_mode>hadp</powerd_normal_mode>
+    <bogons>
+      <interval>monthly</interval>
+    </bogons>
+    <timezone>Etc/UTC</timezone>
+    <serialspeed>115200</serialspeed>
+    <primaryconsole>serial</primaryconsole>
+    <enablesshd>enabled</enablesshd>
+    <disablechecksumoffloading />
+    <powerd_enable />
+    <use_mfs_tmp_size />
+    <use_mfs_var_size />
+    <maximumtableentries>2000000</maximumtableentries>
+    <gitsync>
+      <repositoryurl />
+      <branch />
+    </gitsync>
+    <pkg_repo_conf_path>/usr/local/share/pfSense/pkg/repos/pfSense-repo-devel.conf</pkg_repo_conf_path>
+    <already_run_config_upgrade />
+    <crypto_hardware>cryptodev</crypto_hardware>
+    <language>en_US</language>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsallowoverride />
+    <dns1gw>none</dns1gw>
+    <dns2gw>none</dns2gw>
+    <scrubnodf>enabled</scrubnodf>
+    <maximumstates />
+    <aliasesresolveinterval />
+    <maximumfrags />
+    <reflectiontimeout />
+  </system>
+  <interfaces>
+    <wan>
+      <enable />
+      <if>vmx0</if>
+      <blockbogons />
+      <descr>WAN</descr>
+      <spoofmac />
+      <alias-address />
+      <alias-subnet>32</alias-subnet>
+      <ipaddr>dhcp</ipaddr>
+      <dhcphostname />
+      <dhcprejectfrom />
+      <adv_dhcp_pt_timeout />
+      <adv_dhcp_pt_retry />
+      <adv_dhcp_pt_select_timeout />
+      <adv_dhcp_pt_reboot />
+      <adv_dhcp_pt_backoff_cutoff />
+      <adv_dhcp_pt_initial_interval />
+      <adv_dhcp_pt_values>SavedCfg</adv_dhcp_pt_values>
+      <adv_dhcp_send_options />
+      <adv_dhcp_request_options />
+      <adv_dhcp_required_options />
+      <adv_dhcp_option_modifiers />
+      <adv_dhcp_config_advanced />
+      <adv_dhcp_config_file_override />
+      <adv_dhcp_config_file_override_path />
+    </wan>
+    <lan>
+      <enable />
+      <if>vmx1</if>
+      <descr>LAN</descr>
+      <spoofmac />
+      <ipaddr>XXX.XXX.XXX.XXX</ipaddr>
+      <subnet>24</subnet>
+    </lan>
+    <opt1>
+      <descr>OPT1</descr>
+      <if>ovpnc2</if>
+      <spoofmac />
+    </opt1>
+  </interfaces>
+  <staticroutes />
+  <dhcpd>
+    <lan>
+      <range>
+        <from>192.168.125.10</from>
+        <to>192.168.125.245</to>
+      </range>
+      <failover_peerip />
+      <dhcpleaseinlocaltime />
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <gateway />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkeyalgorithm>hmac-md5</ddnsdomainkeyalgorithm>
+      <ddnsdomainkey />
+      <mac_allow />
+      <mac_deny />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <nextserver />
+      <filename />
+      <filename32 />
+      <filename64 />
+      <rootpath />
+      <numberoptions />
+      <enable />
+    </lan>
+  </dhcpd>
+  <dhcpdv6>
+    <lan>
+      <range>
+        <from>::1000</from>
+        <to>::2000</to>
+      </range>
+      <ramode>assist</ramode>
+      <rapriority>medium</rapriority>
+      <prefixrange>
+        <from />
+        <to />
+        <prefixlength>48</prefixlength>
+      </prefixrange>
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkey />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <bootfile_url />
+      <dhcpv6leaseinlocaltime />
+      <numberoptions />
+    </lan>
+  </dhcpdv6>
+  <snmpd>
+    <syslocation />
+    <syscontact />
+    <rocommunity>[REDACTED]</rocommunity>
+  </snmpd>
+  <diag>
+    <ipv6nat />
+  </diag>
+  <syslog>
+    <nentries>50</nentries>
+    <sourceip />
+    <ipproto>ipv4</ipproto>
+    <filterdescriptions>1</filterdescriptions>
+  </syslog>
+  <nat>
+    <outbound>
+      <mode>automatic</mode>
+    </outbound>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>80</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8081</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>443</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8443</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+  </nat>
+  <filter>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <address>pfB_Asia_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770009596</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Blacklist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Blacklist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010135</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Whitelist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010396</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Asia_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009093</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_DNSBLIP_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_DNSBLIP_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009235</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Whitelist_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009893</tracker>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617312</tracker>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <protocol>udp</protocol>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <network>(self)</network>
+        <port>1194</port>
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507041729</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507042058</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Default allow LAN to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000101</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet6</ipprotocol>
+      <descr>Default allow LAN IPv6 to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000102</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507626308</tracker>
+      <type>pass</type>
+      <interface>enc0</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617328</tracker>
+      <type>pass</type>
+      <interface>openvpn</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>lan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1525695659</time>
+        <username>Easy Rule</username>
+      </created>
+      <tracker>1525695659</tracker>
+    </rule>
+    <separator>
+      <wan />
+    </separator>
+  </filter>
+  <shaper />
+  <ipsec>
+    <phase1>
+      <ikeid>1</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr />
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>256</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>2</dhgroup>
+        </item>
+      </encryption>
+    </phase1>
+    <phase1>
+      <ikeid>2</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>128</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>14</dhgroup>
+        </item>
+      </encryption>
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr>Tunnel with PB2</descr>
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <rekey_enable />
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+    </phase1>
+    <client />
+    <phase2>
+      <ikeid>1</ikeid>
+      <uniqid>59dc8cdccfa7b</uniqid>
+      <mode>tunnel</mode>
+      <reqid>1</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>XXX.XXX.XXX.XXX</address>
+        <netbits>24</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>auto</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>0</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+    <phase2>
+      <ikeid>2</ikeid>
+      <uniqid>5ab0a8c528fd8</uniqid>
+      <mode>tunnel</mode>
+      <reqid>2</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>0.0.0.0</address>
+        <netbits>0</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>128</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>14</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+  </ipsec>
+  <aliases>
+    <alias>
+      <name>pfB_Asia_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Whitelist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Blacklist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_DNSBLIP_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>Alias_1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX XXX.XXX.XXX.XXX Alias2</address>
+      <descr />
+      <detail>Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX Test1</address>
+      <descr />
+      <detail>Entry added Tue, 27 Feb 2018 14:25:35 +0000||Entry added Wed, 28 Feb 2018 06:49:30 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX</address>
+      <descr />
+      <detail>Entry added Wed, 28 Feb 2018 06:49:16 +0000</detail>
+    </alias>
+  </aliases>
+  <proxyarp />
+  <cron>
+    <item>
+      <minute>1,31</minute>
+      <hour>0-5</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 adjkerntz -a</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>3</hour>
+      <mday>1</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_bogons.sh</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 sshlockout</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 webConfiguratorlockout</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>1</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 virusprot</command>
+    </item>
+    <item>
+      <minute>30</minute>
+      <hour>12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_urltables</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_pkg_metadata</command>
+    </item>
+    <item>
+      <minute>*/5</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_cron_misc.inc</command>
+    </item>
+    <item>
+      <minute>5</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/mail_reports_generate.php 0 &amp;</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>3</hour>
+      <mday>4-10</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc &gt;&gt; /var/log/pfblockerng/extras.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron &gt;&gt; /var/log/pfblockerng/pfblockerng.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/sbin/squid -k rotate -f /usr/local/etc/squid/squid.conf</command>
+    </item>
+    <item>
+      <minute>15</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/pkg/swapstate_check.php</command>
+    </item>
+  </cron>
+  <wol />
+  <rrd>
+    <enable />
+  </rrd>
+  <load_balancer>
+    <monitor_type>
+      <name>ICMP</name>
+      <type>icmp</type>
+      <descr>ICMP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>TCP</name>
+      <type>tcp</type>
+      <descr>Generic TCP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>HTTP</name>
+      <type>http</type>
+      <descr>Generic HTTP</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>HTTPS</name>
+      <type>https</type>
+      <descr>Generic HTTPS</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>SMTP</name>
+      <type>send</type>
+      <descr>Generic SMTP</descr>
+      <options>
+        <send />
+        <expect>220 *</expect>
+      </options>
+    </monitor_type>
+  </load_balancer>
+  <widgets>
+    <sequence>system_information:col1:open:0,interfaces:col2:open:0,pfblockerng:col2:open:0,snort_alerts:col2:open:0,installed_packages:col2:open:0</sequence>
+  </widgets>
+  <openvpn />
+  <dnshaper />
+  <unbound>
+    <enable />
+    <dnssec />
+    <active_interface />
+    <outgoing_interface />
+    <custom_options>c2VydmVyOmluY2x1ZGU6IC92YXIvdW5ib3VuZC9wZmJfZG5zYmwuKmNvbmY=</custom_options>
+    <hideidentity />
+    <hideversion />
+    <dnssecstripped />
+    <hosts>
+      <host>pkg</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+    <hosts>
+      <host>release-staging</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+  </unbound>
+  <revision>
+    <time>1532955144</time>
+    <username>user@example.com</username>
+  </revision>
+  <cert>
+    <refid>59d39fada929c</refid>
+    <descr>webConfigurator default (59d39fada929c)</descr>
+    <type>server</type>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <cert>
+    <refid>5a030fac39e79</refid>
+    <descr>OpenVPNClientCert</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <caref>5a030f8debd96</caref>
+  </cert>
+  <cert>
+    <refid>5a04208c7c65a</refid>
+    <descr>FreeRADIUS Server Certificate</descr>
+    <type>server</type>
+    <caref>5a04208c70f14</caref>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <ppps />
+  <gateways />
+  <installedpackages>
+    <package>
+      <name>snort</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/Setup_Snort_Package</pkginfolink>
+      <website>http://www.snort.org</website>
+      <descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
+      <version>3.2.9.6_1</version>
+      <configurationfile>/snort.xml</configurationfile>
+      <after_install_info>Please visit Services - Snort - Interfaces tab first and select your desired rules. Afterwards visit the Updates tab to download your configured rulesets.</after_install_info>
+      <include_file>/usr/local/pkg/snort/snort.inc</include_file>
+    </package>
+    <package>
+      <name>Lightsquid</name>
+      <descr>LightSquid is a high performance web proxy reporting tool. Includes proxy realtime statistics (SQStat).
+			&amp;lt;strong&amp;gt;Requires Squid package.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://lightsquid.sf.net/</website>
+      <version>3.0.6_4</version>
+      <configurationfile>lightsquid.xml</configurationfile>
+      <noembedded>true</noembedded>
+    </package>
+    <package>
+      <name>AutoConfigBackup</name>
+      <descr>Automatically backs up your pfSense configuration. All contents are encrypted before being sent to the server.&amp;lt;br /&amp;gt;
+			Requires Gold Subscription from &amp;lt;a href=&amp;quot;https://portal.pfsense.org&amp;quot;&amp;gt;pfSense Portal&amp;lt;/a&amp;gt;.</descr>
+      <website>https://portal.pfsense.org</website>
+      <version>1.52</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/AutoConfigBackup</pkginfolink>
+      <configurationfile>autoconfigbackup.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Restore</text>
+          <url>/autoconfigbackup.php</url>
+        </tab>
+        <tab>
+          <text>Backup now</text>
+          <url>/autoconfigbackup_backup.php</url>
+        </tab>
+        <tab>
+          <text>Stats</text>
+          <url>/autoconfigbackup_stats.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/autoconfigbackup.inc</include_file>
+    </package>
+    <package>
+      <name>haproxy-devel</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
+      <descr>The Reliable, High Performance TCP/HTTP(S) Load Balancer.&amp;lt;br /&amp;gt;
+			This package implements the TCP, HTTP and HTTPS balancing features from haproxy.&amp;lt;br /&amp;gt;
+			Supports ACLs for smart backend switching.</descr>
+      <website>http://haproxy.1wt.eu/</website>
+      <version>0.58_2</version>
+      <configurationfile>haproxy.xml</configurationfile>
+      <logging>
+        <logsocket>/tmp/haproxy_chroot/var/run/log</logsocket>
+        <facilityname>haproxy</facilityname>
+        <logfilename>haproxy.log</logfilename>
+      </logging>
+      <filter_rule_function>haproxy_generate_rules</filter_rule_function>
+      <include_file>/usr/local/pkg/haproxy/haproxy.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+        <item>
+          <type>plugin_certificates</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>Open-VM-Tools</name>
+      <descr>VMware Tools is a suite of utilities that enhances the performance of the virtual machine's guest operating system and improves management of the virtual machine.</descr>
+      <website>http://open-vm-tools.sourceforge.net/</website>
+      <version>10.1.0,1</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/Open_VM_Tools_package</pkginfolink>
+      <configurationfile>open-vm-tools.xml</configurationfile>
+      <include_file>/usr/local/pkg/open-vm-tools.inc</include_file>
+    </package>
+    <package>
+      <name>squid3</name>
+      <internal_name>squid</internal_name>
+      <descr>High performance web proxy cache (3.4 branch). It combines Squid as a proxy server with its capabilities of acting as a HTTP / HTTPS reverse proxy.&amp;lt;br /&amp;gt;
+			It includes an Exchange-Web-Access (OWA) Assistant, SSL filtering and antivirus integration via C-ICAP.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?board=60.0</pkginfolink>
+      <website>http://www.squid-cache.org/</website>
+      <version>0.4.44_1</version>
+      <configurationfile>squid.xml</configurationfile>
+      <filter_rule_function>squid_generate_rules</filter_rule_function>
+      <tabs>
+        <tab>
+          <text>General</text>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Remote Cache</text>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
+        </tab>
+        <tab>
+          <text>Local Cache</text>
+          <url>/pkg_edit.php?xml=squid_cache.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Antivirus</text>
+          <url>/pkg_edit.php?xml=squid_antivirus.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>ACLs</text>
+          <url>/pkg_edit.php?xml=squid_nac.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Traffic Mgmt</text>
+          <url>/pkg_edit.php?xml=squid_traffic.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Authentication</text>
+          <url>/pkg_edit.php?xml=squid_auth.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=squid_users.xml</url>
+        </tab>
+        <tab>
+          <text>Real Time</text>
+          <url>/squid_monitor.php</url>
+        </tab>
+        <tab>
+          <text>Sync</text>
+          <url>/pkg_edit.php?xml=squid_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squid.inc</include_file>
+    </package>
+    <package>
+      <name>squidGuard</name>
+      <descr>High performance web proxy URL filter.&amp;lt;br/&amp;gt;
+			&amp;lt;strong&amp;gt;Works with both Squid (2.7 legacy branch) and Squid3 (3.4 branch) packages.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://www.squidGuard.org/</website>
+      <version>1.16.16</version>
+      <configurationfile>squidguard.xml</configurationfile>
+      <after_install_info>Please visit Services - SquidGuard Proxy Filter - Target Categories and set up at least one category there before enabling SquidGuard. See https://forum.pfsense.org/index.php?topic=94312.0 for details.</after_install_info>
+      <tabs>
+        <tab>
+          <text>General settings</text>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Common ACL</text>
+          <url>/pkg_edit.php?xml=squidguard_default.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Groups ACL</text>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
+        </tab>
+        <tab>
+          <text>Target categories</text>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
+        </tab>
+        <tab>
+          <text>Times</text>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
+        </tab>
+        <tab>
+          <text>Rewrites</text>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
+        </tab>
+        <tab>
+          <text>Blacklist</text>
+          <url>/squidGuard/squidguard_blacklist.php</url>
+        </tab>
+        <tab>
+          <text>Log</text>
+          <url>/squidGuard/squidguard_log.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=squidguard_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squidguard.inc</include_file>
+    </package>
+    <package>
+      <name>Service Watchdog</name>
+      <internal_name>Service_Watchdog</internal_name>
+      <descr>Monitors for stopped services and restarts them.</descr>
+      <version>1.8.5</version>
+      <configurationfile>servicewatchdog.xml</configurationfile>
+      <include_file>/usr/local/pkg/servicewatchdog.inc</include_file>
+    </package>
+    <package>
+      <name>freeradius3</name>
+      <website>http://www.freeradius.org/</website>
+      <descr>A free implementation of the RADIUS protocol.&amp;lt;br /&amp;gt;
+			Supports MySQL, PostgreSQL, LDAP, Kerberos.</descr>
+      <pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
+      <version>0.15.5_1</version>
+      <configurationfile>freeradius.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=freeradius.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>MACs</text>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
+        </tab>
+        <tab>
+          <text>NAS / Clients</text>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
+        </tab>
+        <tab>
+          <text>Interfaces</text>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
+        </tab>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>EAP</text>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>SQL</text>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>LDAP</text>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>View config</text>
+          <url>/freeradius_view_config.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/freeradius.inc</include_file>
+    </package>
+    <package>
+      <name>FRR</name>
+      <internal_name>frr</internal_name>
+      <descr>FRR routing daemon for BGP, OSPF, and OSPF6.&amp;lt;br /&amp;gt;
+			&amp;lt;strong&amp;gt;Conflicts with Quagga OSPF and OpenBGPD; these packages cannot be installed at the same time.&amp;lt;/strong&amp;gt;</descr>
+      <version>0.2_1</version>
+      <configurationfile>frr.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Global Settings</text>
+          <url>pkg_edit.php?xml=frr.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access Lists</text>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
+        </tab>
+        <tab>
+          <text>Prefix Lists</text>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
+        </tab>
+        <tab>
+          <text>Route Maps</text>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
+        </tab>
+        <tab>
+          <text>Raw Config</text>
+          <url>pkg_edit.php?xml=frr/frr_global_raw.xml</url>
+        </tab>
+        <tab>
+          <text>[BGP]</text>
+          <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF6]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+        </tab>
+        <tab>
+          <text>Status</text>
+          <url>/status_frr.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/frr.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>mailreport</name>
+      <descr>Allows you to setup periodic e-mail reports containing command output and log file contents.</descr>
+      <version>3.3</version>
+      <configurationfile>mailreport.xml</configurationfile>
+    </package>
+    <package>
+      <name>ntopng</name>
+      <website>http://www.ntop.org/</website>
+      <descr>ntopng (replaces ntop) is a network probe that shows network usage in a way similar to what top does for processes. In interactive mode, it displays the network status on the user's terminal. In Web mode it acts as a Web server, creating an HTML dump of the network status. It sports a NetFlow/sFlow emitter/collector, an HTTP-based client interface for creating ntop-centric monitoring applications, and RRD for persistently storing traffic statistics.</descr>
+      <version>0.8.12</version>
+      <configurationfile>ntopng.xml</configurationfile>
+      <noembedded>true</noembedded>
+      <tabs>
+        <tab>
+          <text>ntopng Settings</text>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access ntopng</text>
+          <url>/ntopng_redirect.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/ntopng.inc</include_file>
+    </package>
+    <package>
+      <name>pfBlockerNG-devel</name>
+      <descr>pfBlockerNG is the Next Generation of pfBlocker.&amp;lt;br /&amp;gt;
+			Manage IPv4/v6 List Sources into 'Deny, Permit or Match' formats.&amp;lt;br /&amp;gt;
+			GeoIP database by MaxMind Inc. (GeoLite2 Free version).&amp;lt;br /&amp;gt;
+			De-Duplication, Suppression, and Reputation enhancements.&amp;lt;br /&amp;gt;
+			Provision to download from diverse List formats.&amp;lt;br /&amp;gt;
+			Advanced Integration for Proofpoint ET IQRisk IP Reputation Threat Sources.&amp;lt;br /&amp;gt;
+			Domain Name (DNSBL) blocking via Unbound DNS Resolver.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?topic=102470.0</pkginfolink>
+      <version>2.2.1</version>
+      <configurationfile>pfblockerng.xml</configurationfile>
+      <include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+    </package>
+    <pfblockernglistsv4>
+      <config>
+        <aliasname>Whitelist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url />
+          <header />
+        </row>
+        <action>Permit_Both</action>
+        <cron>Never</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom>OC44LjguOA==</custom>
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
+          <header>C2_IP_Feed</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
+          <header>C2_All_Indicator_Feed</header>
+        </row>
+        <action>Deny_Inbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>PRI1</aliasname>
+        <description>PRI1 - Collection of Feeds from the most reputable blocklist providers. (Primary tier)</description>
+        <action>Disabled</action>
+        <cron>01hour</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <suppression_cidr>Disabled</suppression_cidr>
+        <whois_convert />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/blacklist/dyre_sslipblacklist.csv</url>
+          <header>Abuse_DYRE</header>
+        </row>
+      </config>
+    </pfblockernglistsv4>
+    <pfblockernglistsv6>
+      <config />
+    </pfblockernglistsv6>
+    <pfblockerngdnsblsettings>
+      <config>
+        <pfb_dnsbl>on</pfb_dnsbl>
+        <pfb_tld />
+        <pfb_dnsvip>10.10.10.1</pfb_dnsvip>
+        <pfb_dnsport>8081</pfb_dnsport>
+        <pfb_dnsport_ssl>8443</pfb_dnsport_ssl>
+        <dnsbl_interface>lan</dnsbl_interface>
+        <pfb_dnsbl_rule />
+        <dnsbl_allow_int />
+        <action>Deny_Outbound</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <alexa_enable>on</alexa_enable>
+        <alexa_count>1000</alexa_count>
+        <alexa_inclusion>ca,co,com,io,net,org</alexa_inclusion>
+        <suppression />
+        <tldexclusion />
+        <tldblacklist />
+        <tldwhitelist />
+      </config>
+    </pfblockerngdnsblsettings>
+    <pfblockerngafrica>
+      <config />
+    </pfblockerngafrica>
+    <pfblockerngantarctica>
+      <config />
+    </pfblockerngantarctica>
+    <pfblockerngasia>
+      <config>
+        <countries4>6255147,6255147_rep,CN,CN_rep</countries4>
+        <countries6 />
+        <action>Deny_Both</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+      </config>
+    </pfblockerngasia>
+    <pfblockerngeurope>
+      <config />
+    </pfblockerngeurope>
+    <pfblockerngnorthamerica>
+      <config />
+    </pfblockerngnorthamerica>
+    <pfblockerngoceania>
+      <config />
+    </pfblockerngoceania>
+    <pfblockerngsouthamerica>
+      <config />
+    </pfblockerngsouthamerica>
+    <pfblockerngtopspammers>
+      <config />
+    </pfblockerngtopspammers>
+    <pfblockerngproxyandsatellite>
+      <config />
+    </pfblockerngproxyandsatellite>
+    <pfblockerng>
+      <config>
+        <enable_cb>on</enable_cb>
+        <pfb_keep>on</pfb_keep>
+        <pfb_interval>12</pfb_interval>
+        <pfb_min />
+        <pfb_hour />
+        <pfb_dailystart />
+        <skipfeed />
+        <credits />
+        <log_max_log>20000</log_max_log>
+        <log_max_errlog>20000</log_max_errlog>
+        <log_max_extraslog>20000</log_max_extraslog>
+        <log_max_ip_blocklog>20000</log_max_ip_blocklog>
+        <log_max_ip_permitlog>20000</log_max_ip_permitlog>
+        <log_max_ip_matchlog>20000</log_max_ip_matchlog>
+        <log_max_dnslog>20000</log_max_dnslog>
+        <log_max_dnsbl_parse_err>20000</log_max_dnsbl_parse_err>
+      </config>
+    </pfblockerng>
+    <pfblockerngdnsbl>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <infolists />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>https://example.com/hosts.txt</url>
+          <header>Adaway</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
+          <header>yoyo</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/ad_servers.txt</url>
+          <header>hpHosts_ads</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>example.com/cameleon/hosts</url>
+          <header>Cameleon</header>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>ADs</aliasname>
+        <description>ADs - Collection of ADvertisement Domain Feeds.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/downloads/dg-ads.acl</url>
+          <header>SBL_ADs</header>
+        </row>
+      </config>
+      <config>
+        <aliasname>BBcan177</aliasname>
+        <description>BBcan177 - Feed as provided by BBcan177.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/BBcan177/4a8bf37c131be4803cb2/raw</url>
+          <header>MS_2</header>
+        </row>
+      </config>
+    </pfblockerngdnsbl>
+    <snortglobal>
+      <snort_config_ver>3.2.9.6_1</snort_config_ver>
+      <snortdownload>on</snortdownload>
+      <snortcommunityrules>off</snortcommunityrules>
+      <emergingthreats>off</emergingthreats>
+      <emergingthreats_pro>off</emergingthreats_pro>
+      <clearblocks>on</clearblocks>
+      <verbose_logging>off</verbose_logging>
+      <openappid_detectors>on</openappid_detectors>
+      <openappid_rules_detectors>on</openappid_rules_detectors>
+      <hide_deprecated_rules>off</hide_deprecated_rules>
+      <curl_no_verify_ssl_peer>off</curl_no_verify_ssl_peer>
+      <oinkmastercode>c4e000842278df905ba5795132288ddc7c996d14</oinkmastercode>
+      <etpro_code />
+      <rm_blocked>never_b</rm_blocked>
+      <autorulesupdate7>12h_up</autorulesupdate7>
+      <rule_update_starttime>00:05</rule_update_starttime>
+      <forcekeepsettings>on</forcekeepsettings>
+      <last_rule_upd_status>success</last_rule_upd_status>
+      <last_rule_upd_time>1532952490</last_rule_upd_time>
+      <rule>
+        <interface>wan</interface>
+        <enable>on</enable>
+        <uuid>53250</uuid>
+        <descr>WAN</descr>
+        <performance>ac-bnfa</performance>
+        <blockoffenders7>off</blockoffenders7>
+        <blockoffenderskill>on</blockoffenderskill>
+        <blockoffendersip>both</blockoffendersip>
+        <whitelistname>default</whitelistname>
+        <homelistname>default</homelistname>
+        <externallistname>default</externallistname>
+        <suppresslistname>wansuppress_5a82ea740612f</suppresslistname>
+        <alertsystemlog>on</alertsystemlog>
+        <alertsystemlog_facility>log_auth</alertsystemlog_facility>
+        <alertsystemlog_priority>log_alert</alertsystemlog_priority>
+        <cksumcheck>on</cksumcheck>
+        <fpm_split_any_any>off</fpm_split_any_any>
+        <fpm_search_optimize>off</fpm_search_optimize>
+        <fpm_no_stream_inserts>off</fpm_no_stream_inserts>
+        <max_attribute_hosts>10000</max_attribute_hosts>
+        <max_attribute_services_per_host>10</max_attribute_services_per_host>
+        <max_paf>16000</max_paf>
+        <ftp_preprocessor>on</ftp_preprocessor>
+        <ftp_telnet_inspection_type>stateful</ftp_telnet_inspection_type>
+        <ftp_telnet_alert_encrypted>off</ftp_telnet_alert_encrypted>
+        <ftp_telnet_check_encrypted>on</ftp_telnet_check_encrypted>
+        <ftp_telnet_normalize>on</ftp_telnet_normalize>
+        <ftp_telnet_detect_anomalies>on</ftp_telnet_detect_anomalies>
+        <ftp_telnet_ayt_attack_threshold>20</ftp_telnet_ayt_attack_threshold>
+        <ftp_client_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <max_resp_len>256</max_resp_len>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <bounce>yes</bounce>
+            <bounce_to_net />
+            <bounce_to_port />
+          </item>
+        </ftp_client_engine>
+        <ftp_server_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <ports>default</ports>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <ignore_data_chan>no</ignore_data_chan>
+            <def_max_param_len>100</def_max_param_len>
+          </item>
+        </ftp_server_engine>
+        <smtp_preprocessor>on</smtp_preprocessor>
+        <smtp_memcap>838860</smtp_memcap>
+        <smtp_max_mime_mem>838860</smtp_max_mime_mem>
+        <smtp_b64_decode_depth>0</smtp_b64_decode_depth>
+        <smtp_qp_decode_depth>0</smtp_qp_decode_depth>
+        <smtp_bitenc_decode_depth>0</smtp_bitenc_decode_depth>
+        <smtp_uu_decode_depth>0</smtp_uu_decode_depth>
+        <smtp_email_hdrs_log_depth>1464</smtp_email_hdrs_log_depth>
+        <smtp_ignore_data>off</smtp_ignore_data>
+        <smtp_ignore_tls_data>on</smtp_ignore_tls_data>
+        <smtp_log_mail_from>on</smtp_log_mail_from>
+        <smtp_log_rcpt_to>on</smtp_log_rcpt_to>
+        <smtp_log_filename>on</smtp_log_filename>
+        <smtp_log_email_hdrs>on</smtp_log_email_hdrs>
+        <dce_rpc_2>on</dce_rpc_2>
+        <dns_preprocessor>on</dns_preprocessor>
+        <ssl_preproc>on</ssl_preproc>
+        <pop_preproc>on</pop_preproc>
+        <pop_memcap>838860</pop_memcap>
+        <pop_b64_decode_depth>0</pop_b64_decode_depth>
+        <pop_qp_decode_depth>0</pop_qp_decode_depth>
+        <pop_bitenc_decode_depth>0</pop_bitenc_decode_depth>
+        <pop_uu_decode_depth>0</pop_uu_decode_depth>
+        <imap_preproc>on</imap_preproc>
+        <imap_memcap>838860</imap_memcap>
+        <imap_b64_decode_depth>0</imap_b64_decode_depth>
+        <imap_qp_decode_depth>0</imap_qp_decode_depth>
+        <imap_bitenc_decode_depth>0</imap_bitenc_decode_depth>
+        <imap_uu_decode_depth>0</imap_uu_decode_depth>
+        <sip_preproc>on</sip_preproc>
+        <other_preprocs>on</other_preprocs>
+        <pscan_protocol>all</pscan_protocol>
+        <pscan_type>all</pscan_type>
+        <pscan_memcap>10000000</pscan_memcap>
+        <pscan_sense_level>medium</pscan_sense_level>
+        <http_inspect>on</http_inspect>
+        <http_inspect_proxy_alert>off</http_inspect_proxy_alert>
+        <http_inspect_memcap>150994944</http_inspect_memcap>
+        <http_inspect_max_gzip_mem>838860</http_inspect_max_gzip_mem>
+        <http_inspect_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <server_profile>all</server_profile>
+            <enable_xff>off</enable_xff>
+            <log_uri>off</log_uri>
+            <log_hostname>off</log_hostname>
+            <server_flow_depth>65535</server_flow_depth>
+            <enable_cookie>on</enable_cookie>
+            <client_flow_depth>1460</client_flow_depth>
+            <extended_response_inspection>on</extended_response_inspection>
+            <no_alerts>off</no_alerts>
+            <unlimited_decompress>on</unlimited_decompress>
+            <inspect_gzip>on</inspect_gzip>
+            <normalize_cookies>on</normalize_cookies>
+            <normalize_headers>on</normalize_headers>
+            <normalize_utf>on</normalize_utf>
+            <normalize_javascript>on</normalize_javascript>
+            <allow_proxy_use>off</allow_proxy_use>
+            <inspect_uri_only>off</inspect_uri_only>
+            <max_javascript_whitespaces>200</max_javascript_whitespaces>
+            <post_depth>-1</post_depth>
+            <max_headers>0</max_headers>
+            <max_spaces>0</max_spaces>
+            <max_header_length>0</max_header_length>
+            <ports>default</ports>
+            <decompress_swf>off</decompress_swf>
+            <decompress_pdf>off</decompress_pdf>
+          </item>
+        </http_inspect_engine>
+        <frag3_max_frags>8192</frag3_max_frags>
+        <frag3_memcap>4194304</frag3_memcap>
+        <frag3_detection>on</frag3_detection>
+        <frag3_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>60</timeout>
+            <min_ttl>1</min_ttl>
+            <detect_anomalies>on</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <min_frag_len>0</min_frag_len>
+          </item>
+        </frag3_engine>
+        <stream5_reassembly>on</stream5_reassembly>
+        <stream5_flush_on_alert>off</stream5_flush_on_alert>
+        <stream5_prune_log_max>1048576</stream5_prune_log_max>
+        <stream5_track_tcp>on</stream5_track_tcp>
+        <stream5_max_tcp>262144</stream5_max_tcp>
+        <stream5_track_udp>on</stream5_track_udp>
+        <stream5_max_udp>131072</stream5_max_udp>
+        <stream5_udp_timeout>30</stream5_udp_timeout>
+        <stream5_track_icmp>off</stream5_track_icmp>
+        <stream5_max_icmp>65536</stream5_max_icmp>
+        <stream5_icmp_timeout>30</stream5_icmp_timeout>
+        <stream5_mem_cap>8388608</stream5_mem_cap>
+        <stream5_tcp_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>30</timeout>
+            <max_queued_bytes>1048576</max_queued_bytes>
+            <detect_anomalies>off</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <max_queued_segs>2621</max_queued_segs>
+            <require_3whs>off</require_3whs>
+            <startup_3whs_timeout>0</startup_3whs_timeout>
+            <no_reassemble_async>off</no_reassemble_async>
+            <max_window>0</max_window>
+            <use_static_footprint_sizes>off</use_static_footprint_sizes>
+            <check_session_hijacking>off</check_session_hijacking>
+            <dont_store_lg_pkts>off</dont_store_lg_pkts>
+            <ports_client>default</ports_client>
+            <ports_both>default</ports_both>
+            <ports_server>none</ports_server>
+          </item>
+        </stream5_tcp_engine>
+        <appid_preproc>on</appid_preproc>
+        <sf_appid_mem_cap>256</sf_appid_mem_cap>
+        <sf_appid_statslog>on</sf_appid_statslog>
+        <sf_appid_stats_period>300</sf_appid_stats_period>
+        <sdf_alert_data_type>Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers</sdf_alert_data_type>
+        <sdf_alert_threshold>25</sdf_alert_threshold>
+        <sdf_mask_output>off</sdf_mask_output>
+        <ssh_preproc>on</ssh_preproc>
+        <pscan_ignore_scanners />
+        <pscan_ignore_scanned />
+        <perform_stat>off</perform_stat>
+        <host_attribute_table>off</host_attribute_table>
+        <sf_portscan>on</sf_portscan>
+        <sensitive_data>off</sensitive_data>
+        <dnp3_preproc>off</dnp3_preproc>
+        <modbus_preproc>off</modbus_preproc>
+        <gtp_preproc>off</gtp_preproc>
+        <preproc_auto_rule_disable>off</preproc_auto_rule_disable>
+        <protect_preproc_rules>off</protect_preproc_rules>
+        <ips_policy_enable>on</ips_policy_enable>
+        <rulesets />
+        <autoflowbitrules>on</autoflowbitrules>
+        <ips_policy>connectivity</ips_policy>
+        <arp_spoof_engine />
+        <arpspoof_preproc>off</arpspoof_preproc>
+        <arp_unicast_detection>off</arp_unicast_detection>
+      </rule>
+      <dashboard_widget>snort_alerts:col2:open:0</dashboard_widget>
+      <auto_manage_sids>off</auto_manage_sids>
+      <enable_log_mgmt>on</enable_log_mgmt>
+      <alert_log_limit_size>500</alert_log_limit_size>
+      <alert_log_retention>336</alert_log_retention>
+      <appid_stats_log_limit_size>1000</appid_stats_log_limit_size>
+      <appid_stats_log_retention>168</appid_stats_log_retention>
+      <event_pkts_log_limit_size>0</event_pkts_log_limit_size>
+      <event_pkts_log_retention>336</event_pkts_log_retention>
+      <sid_changes_log_limit_size>250</sid_changes_log_limit_size>
+      <sid_changes_log_retention>336</sid_changes_log_retention>
+      <stats_log_limit_size>500</stats_log_limit_size>
+      <stats_log_retention>168</stats_log_retention>
+      <suppress />
+      <whitelist>
+        <item>
+          <name>passlist_40695</name>
+          <uuid>38194</uuid>
+          <localnets>no</localnets>
+          <wangateips>no</wangateips>
+          <wandnsips>no</wandnsips>
+          <vips>no</vips>
+          <vpnips>no</vpnips>
+          <address>Test</address>
+          <descr />
+        </item>
+      </whitelist>
+    </snortglobal>
+    <autoconfigbackup>
+      <config>
+        <enable_acb>enabled</enable_acb>
+        <username>azamat</username>
+        <password>[REDACTED]</password>
+        <passwordagain>[REDACTED]</passwordagain>
+        <crypto_password>[REDACTED]</crypto_password>
+        <crypto_password2>[REDACTED]</crypto_password2>
+      </config>
+    </autoconfigbackup>
+    <haproxy>
+      <configversion>00.32</configversion>
+      <ha_backends />
+      <ha_pools />
+      <email_mailers />
+      <dns_resolvers />
+      <files>
+        <item />
+      </files>
+    </haproxy>
+    <service />
+    <service>
+      <name>vmware-guestd</name>
+      <rcfile>vmware-guestd.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-guestd status") == 0;</custom_php_service_status_command>
+      <description>VMware Guest Daemon</description>
+    </service>
+    <service>
+      <name>vmware-kmod</name>
+      <rcfile>vmware-kmod.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-kmod status") == 0;</custom_php_service_status_command>
+      <description>VMware Kernel Modules</description>
+    </service>
+    <service>
+      <name>snort</name>
+      <rcfile>snort.sh</rcfile>
+      <executable>snort</executable>
+      <description>Snort IDS/IPS Daemon</description>
+    </service>
+    <service>
+      <name>ntopng</name>
+      <rcfile>ntopng.sh</rcfile>
+      <executable>ntopng</executable>
+      <description>ntopng Network Traffic Monitor</description>
+    </service>
+    <service>
+      <name>squidGuard</name>
+      <description>Proxy server filter Service</description>
+      <executable>squidGuard</executable>
+    </service>
+    <service>
+      <name>squid</name>
+      <rcfile>squid.sh</rcfile>
+      <executable>squid</executable>
+      <description>Squid Proxy Server Service</description>
+    </service>
+    <service>
+      <name>clamd</name>
+      <rcfile>clamd.sh</rcfile>
+      <executable>clamd</executable>
+      <description>ClamAV Antivirus</description>
+    </service>
+    <service>
+      <name>c-icap</name>
+      <rcfile>c-icap.sh</rcfile>
+      <executable>c-icap</executable>
+      <description>ICAP Inteface for Squid and ClamAV integration</description>
+    </service>
+    <service>
+      <name>haproxy</name>
+      <rcfile>haproxy.sh</rcfile>
+      <executable>haproxy</executable>
+      <description>TCP/HTTP(S) Load Balancer</description>
+    </service>
+    <service>
+      <name>FRR zebra</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>zebra</executable>
+      <description>FRR core/abstraction daemon</description>
+    </service>
+    <service>
+      <name>FRR bgpd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>bgpd</executable>
+      <description>FRR BGP routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospfd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospfd</executable>
+      <description>FRR OSPF routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospf6d</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospf6d</executable>
+      <description>FRR OSPF6 routing daemon</description>
+    </service>
+    <service>
+      <name>radiusd</name>
+      <rcfile>radiusd.sh</rcfile>
+      <executable>radiusd</executable>
+      <description>FreeRADIUS Server</description>
+    </service>
+    <service>
+      <name>pfb_dnsbl</name>
+      <rcfile>pfb_dnsbl.sh</rcfile>
+      <executable>lighttpd_pfb</executable>
+      <description>pfBlockerNG DNSBL service</description>
+    </service>
+    <service>
+      <name>pfb_filter</name>
+      <rcfile>pfb_filter.sh</rcfile>
+      <executable>php_pfb</executable>
+      <description>pfBlockerNG firewall filter service</description>
+    </service>
+    <menu />
+    <menu>
+      <name>Snort</name>
+      <tooltiptext>Set up snort specific settings</tooltiptext>
+      <section>Services</section>
+      <url>/snort/snort_interfaces.php</url>
+    </menu>
+    <menu>
+      <name>ntopng Settings</name>
+      <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
+    </menu>
+    <menu>
+      <name>ntopng</name>
+      <tooltiptext>Access ntopng</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/ntopng_redirect.php</url>
+    </menu>
+    <menu>
+      <name>AutoConfigBackup</name>
+      <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/autoconfigbackup.php</url>
+    </menu>
+    <menu>
+      <name>SquidGuard Proxy Filter</name>
+      <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Proxy Server</name>
+      <tooltiptext>Modify the proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Reverse Proxy</name>
+      <tooltiptext>Modify the reverse proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid_reverse_general.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Email Reports</name>
+      <tooltiptext>Setup periodic email reports.</tooltiptext>
+      <section>Status</section>
+      <url>/status_mail_report.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/haproxy/haproxy_listeners.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy Stats</name>
+      <tooltiptext>Stats of HAProxy</tooltiptext>
+      <section>Status</section>
+      <url>/haproxy/haproxy_stats.php?haproxystats=1</url>
+    </menu>
+    <menu>
+      <name>FRR Global/Zebra</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr.xml</url>
+    </menu>
+    <menu>
+      <name>FRR BGP</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF6</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+    </menu>
+    <menu>
+      <name>FRR</name>
+      <section>Status</section>
+      <configfile>frr.xml</configfile>
+      <url>/status_frr.php</url>
+    </menu>
+    <menu>
+      <name>FreeRADIUS</name>
+      <section>Services</section>
+      <url>/pkg.php?xml=freeradius.xml</url>
+    </menu>
+    <menu>
+      <name>Service Watchdog</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/services_servicewatchdog.php</url>
+    </menu>
+    <menu>
+      <name>pfBlockerNG</name>
+      <section>Firewall</section>
+      <url>/pfblockerng/pfblockerng_general.php</url>
+    </menu>
+    <squidcache>
+      <config>
+        <cache_replacement_policy>heap LFUDA</cache_replacement_policy>
+        <cache_swap_low>90</cache_swap_low>
+        <cache_swap_high>95</cache_swap_high>
+        <donotcache />
+        <enable_offline />
+        <ext_cachemanager />
+        <harddisk_cache_size>1000</harddisk_cache_size>
+        <harddisk_cache_system>ufs</harddisk_cache_system>
+        <level1_subdirs>16</level1_subdirs>
+        <harddisk_cache_location>/var/squid/cache</harddisk_cache_location>
+        <minimum_object_size>0</minimum_object_size>
+        <maximum_object_size>4</maximum_object_size>
+        <memory_cache_size>64</memory_cache_size>
+        <maximum_objsize_in_mem>256</maximum_objsize_in_mem>
+        <memory_replacement_policy>heap GDSF</memory_replacement_policy>
+        <cache_dynamic_content />
+        <custom_refresh_patterns />
+      </config>
+    </squidcache>
+    <squidremote />
+    <squidauth>
+      <config>
+        <auth_method>none</auth_method>
+      </config>
+    </squidauth>
+    <servicewatchdog />
+    <freeradiuseapconf>
+      <config>
+        <ssl_ca_cert>5a04208c70f14</ssl_ca_cert>
+        <ssl_server_cert>5a04208c7c65a</ssl_server_cert>
+      </config>
+    </freeradiuseapconf>
+    <pfblockerngdnsbleasylist>
+      <config>
+        <aliasname />
+        <description />
+        <row>
+          <state>Enabled</state>
+          <url>https://example.com/easylist_noelemhide.txt</url>
+          <header>HZ</header>
+          <easycat>eap,aa,aap</easycat>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+      </config>
+    </pfblockerngdnsbleasylist>
+    <frrbgp>
+      <config>
+        <enable>on</enable>
+        <adjacencylog />
+        <asnum>65002</asnum>
+        <routerid />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_updatedelay />
+        <timers_peerwait />
+        <redistributeconnectedsubnets>no</redistributeconnectedsubnets>
+        <redistributestatic>no</redistributestatic>
+        <redistributekernel>no</redistributekernel>
+        <redistributeospf>no</redistributeospf>
+        <row>
+          <distributeroutevalue>192.168.125.0/24</distributeroutevalue>
+          <distributeroutemap>none</distributeroutemap>
+        </row>
+      </config>
+    </frrbgp>
+    <frrbgpneighbors>
+      <config>
+        <peer>XXX.XXX.XXX.XXX</peer>
+        <descr />
+        <peergroup>none</peergroup>
+        <password />
+        <password_type>none</password_type>
+        <asnum>65001</asnum>
+        <updatesource_type>ipv4</updatesource_type>
+        <updatesource>default</updatesource>
+        <defaultoriginate>no</defaultoriginate>
+        <sendcommunity>disabled</sendcommunity>
+        <nexthopself>disabled</nexthopself>
+        <softreconfigurationinbound />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_connect />
+        <distribute_in>none</distribute_in>
+        <distribute_out>none</distribute_out>
+        <prefixfilter_in>none</prefixfilter_in>
+        <prefixfilter_out>none</prefixfilter_out>
+        <aspathfilter_in>none</aspathfilter_in>
+        <aspathfilter_out>none</aspathfilter_out>
+        <routemap_in>none</routemap_in>
+        <routemap_out>none</routemap_out>
+        <unsuppressmap>none</unsuppressmap>
+        <weight />
+        <passive />
+        <addpathtxallpaths />
+        <addpathtxbestpathperas />
+        <advertisementinterval />
+        <allowasin>disabled</allowasin>
+        <asoverride />
+        <attributeunchanged />
+        <attributeunchanged_aspath />
+        <attributeunchanged_med />
+        <attributeunchanged_nexthop />
+        <bfd_multiplier />
+        <bfd_minrx />
+        <bfd_mintx />
+        <capability>disabled</capability>
+        <dontcapabilitynegotiate />
+        <overridecapability />
+        <ttlsecurityhops />
+        <disableconnectedcheck />
+        <ebgpmultihop />
+        <enforcemultihop />
+        <localas_num />
+        <localas_noprepend />
+        <localas_replaceas />
+        <maximumprefix_num />
+        <maximumprefix_threshold />
+        <maximumprefix_warnonly />
+        <maximumprefix_restart />
+        <removeprivateas />
+        <removeprivateas_all />
+        <removeprivateas_replace />
+        <routeclient_reflector />
+        <routeclient_server />
+        <solo />
+      </config>
+    </frrbgpneighbors>
+    <frr>
+      <config>
+        <enable>on</enable>
+        <password>[REDACTED]</password>
+        <carpstatusvid>none</carpstatusvid>
+        <logging />
+        <routerid />
+        <row>
+          <routevalue />
+          <routetarget>none</routetarget>
+        </row>
+      </config>
+    </frr>
+    <ntopng>
+      <config>
+        <enable>on</enable>
+        <keepdata>on</keepdata>
+        <redis_password>[REDACTED]</redis_password>
+        <redis_passwordagain>[REDACTED]</redis_passwordagain>
+        <interface_array>lan</interface_array>
+        <interface_array>opt1</interface_array>
+        <interface_array>wan</interface_array>
+        <dns_mode>0</dns_mode>
+        <disable_alerts />
+        <local_networks>rfc1918</local_networks>
+        <row>
+          <cidr />
+        </row>
+      </config>
+    </ntopng>
+    <pfblockerngreputation>
+      <config />
+    </pfblockerngreputation>
+    <pfblockerngipsettings>
+      <config>
+        <enable_dup>on</enable_dup>
+        <enable_agg />
+        <suppression />
+        <enable_log>on</enable_log>
+        <maxmind_locale>en</maxmind_locale>
+        <database_cc />
+        <inbound_interface>wan</inbound_interface>
+        <inbound_deny_action>block</inbound_deny_action>
+        <outbound_interface>lan</outbound_interface>
+        <outbound_deny_action>reject</outbound_deny_action>
+        <enable_float />
+        <pass_order>order_0</pass_order>
+        <autorule_suffix>autorule</autorule_suffix>
+        <killstates />
+      </config>
+    </pfblockerngipsettings>
+    <squidguarddest>
+      <config>
+        <name>my</name>
+        <domains />
+        <urls />
+        <expressions />
+        <redirect_mode>rmod_none</redirect_mode>
+        <redirect />
+        <description />
+        <enablelog />
+      </config>
+    </squidguarddest>
+    <squid>
+      <config>
+        <enable_squid>on</enable_squid>
+        <keep_squid_data>on</keep_squid_data>
+        <active_interface>lan,lo0</active_interface>
+        <proxy_port>3128</proxy_port>
+        <icp_port />
+        <allow_interface>on</allow_interface>
+        <dns_v4_first />
+        <disable_pinger />
+        <dns_nameservers />
+        <transparent_proxy>on</transparent_proxy>
+        <transparent_active_interface>lan</transparent_active_interface>
+        <private_subnet_proxy_off />
+        <defined_ip_proxy_off />
+        <defined_ip_proxy_off_dest />
+        <ssl_proxy>on</ssl_proxy>
+        <sslproxy_mitm_mode>spliceall</sslproxy_mitm_mode>
+        <ssl_active_interface>lan</ssl_active_interface>
+        <ssl_proxy_port />
+        <sslproxy_compatibility_mode>modern</sslproxy_compatibility_mode>
+        <dhparams_size>2048</dhparams_size>
+        <dca>5b5f09f433185</dca>
+        <sslcrtd_children />
+        <interception_checks />
+        <interception_adapt />
+        <log_enabled>on</log_enabled>
+        <log_dir>/var/squid/logs</log_dir>
+        <log_rotate>7</log_rotate>
+        <log_sqd />
+        <visible_hostname>localhost</visible_hostname>
+        <admin_email>admin@localhost</admin_email>
+        <error_language>en</error_language>
+        <xforward_mode>delete</xforward_mode>
+        <disable_via>on</disable_via>
+        <uri_whitespace>strip</uri_whitespace>
+        <disable_squidversion>on</disable_squidversion>
+        <custom_options />
+        <custom_options_squid3 />
+        <custom_options2_squid3 />
+        <custom_options3_squid3 />
+      </config>
+    </squid>
+  </installedpackages>
+  <virtualip>
+    <vip>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <type>single</type>
+      <subnet_bits>32</subnet_bits>
+      <subnet>XXX.XXX.XXX.XXX</subnet>
+      <mode>ipalias</mode>
+    </vip>
+  </virtualip>
+  <dyndnses />
+  <ca>
+    <refid>5a030f8debd96</refid>
+    <descr>OpenVPNCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <serial>0</serial>
+  </ca>
+  <ca>
+    <refid>5a04208c70f14</refid>
+    <descr>FreeRADIUS CA</descr>
+    <serial>1</serial>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </ca>
+  <ca>
+    <refid>5b5f09f433185</refid>
+    <descr>SquidProxyCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <serial>0</serial>
+  </ca>
+  <dhcrelay>
+    <interface>lan</interface>
+    <server />
+  </dhcrelay>
+  <ezshaper>
+    <step1>
+      <numberofconnections>1</numberofconnections>
+      <numberoflocalinterfaces>1</numberoflocalinterfaces>
+    </step1>
+    <step2>
+      <local0downloadscheduler>CBQ</local0downloadscheduler>
+      <local0interface>lan</local0interface>
+      <conn0uploadscheduler>CBQ</conn0uploadscheduler>
+      <conn0upload>100</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+      <conn0download>100</conn0download>
+      <conn0downloadspeed>Mb</conn0downloadspeed>
+      <conn0interface>wan</conn0interface>
+    </step2>
+    <step3>
+      <address>XXX.XXX.XXX.XXX</address>
+      <enable>on</enable>
+      <provider>Generic</provider>
+      <local0download>4</local0download>
+      <local0downloadspeed>Mb</local0downloadspeed>
+      <conn0upload>4</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+    </step3>
+  </ezshaper>
+  <mailreports>
+    <schedule>
+      <descr>as</descr>
+      <frequency>daily</frequency>
+      <timeofday>0</timeofday>
+      <submit>Save</submit>
+      <schedule_friendly>Daily at 00:00</schedule_friendly>
+    </schedule>
+  </mailreports>
+</pfsense>

--- a/--dry-run --dry-run-verbose
+++ b/--dry-run --dry-run-verbose
@@ -1,0 +1,2354 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pfsense>
+  <!-- Redacted using pfsense-redactor vunknown -->
+  <version>18.2</version>
+  <lastchange />
+  <system>
+    <optimization>normal</optimization>
+    <hostname>pf_test</hostname>
+    <domain>example.com</domain>
+    <group>
+      <name>all</name>
+      <description>All Users</description>
+      <scope>system</scope>
+      <gid>1998</gid>
+      <member>0</member>
+    </group>
+    <group>
+      <name>admins</name>
+      <description>System Administrators</description>
+      <scope>system</scope>
+      <gid>1999</gid>
+      <member>0</member>
+      <priv>page-all</priv>
+    </group>
+    <user>
+      <name>admin</name>
+      <descr>System Administrator</descr>
+      <scope>system</scope>
+      <groupname>admins</groupname>
+      <bcrypt-hash>[REDACTED]</bcrypt-hash>
+      <uid>0</uid>
+      <priv>user-shell-access</priv>
+    </user>
+    <nextuid>2000</nextuid>
+    <nextgid>2000</nextgid>
+    <timeservers>0.pfsense.pool.ntp.org</timeservers>
+    <webgui>
+      <protocol>https</protocol>
+      <loginautocomplete />
+      <ssl-certref>59d39fada929c</ssl-certref>
+      <dashboardcolumns>2</dashboardcolumns>
+      <port />
+      <max_procs>5</max_procs>
+      <nohttpreferercheck />
+      <nodnsrebindcheck />
+      <webguicss>pfSense.css</webguicss>
+      <logincss>1e3f75;</logincss>
+    </webgui>
+    <disablenatreflection>yes</disablenatreflection>
+    <disablesegmentationoffloading />
+    <disablelargereceiveoffloading />
+    <ipv6allow />
+    <powerd_ac_mode>hadp</powerd_ac_mode>
+    <powerd_battery_mode>hadp</powerd_battery_mode>
+    <powerd_normal_mode>hadp</powerd_normal_mode>
+    <bogons>
+      <interval>monthly</interval>
+    </bogons>
+    <timezone>Etc/UTC</timezone>
+    <serialspeed>115200</serialspeed>
+    <primaryconsole>serial</primaryconsole>
+    <enablesshd>enabled</enablesshd>
+    <disablechecksumoffloading />
+    <powerd_enable />
+    <use_mfs_tmp_size />
+    <use_mfs_var_size />
+    <maximumtableentries>2000000</maximumtableentries>
+    <gitsync>
+      <repositoryurl />
+      <branch />
+    </gitsync>
+    <pkg_repo_conf_path>/usr/local/share/pfSense/pkg/repos/pfSense-repo-devel.conf</pkg_repo_conf_path>
+    <already_run_config_upgrade />
+    <crypto_hardware>cryptodev</crypto_hardware>
+    <language>en_US</language>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsserver>XXX.XXX.XXX.XXX</dnsserver>
+    <dnsallowoverride />
+    <dns1gw>none</dns1gw>
+    <dns2gw>none</dns2gw>
+    <scrubnodf>enabled</scrubnodf>
+    <maximumstates />
+    <aliasesresolveinterval />
+    <maximumfrags />
+    <reflectiontimeout />
+  </system>
+  <interfaces>
+    <wan>
+      <enable />
+      <if>vmx0</if>
+      <blockbogons />
+      <descr>WAN</descr>
+      <spoofmac />
+      <alias-address />
+      <alias-subnet>32</alias-subnet>
+      <ipaddr>dhcp</ipaddr>
+      <dhcphostname />
+      <dhcprejectfrom />
+      <adv_dhcp_pt_timeout />
+      <adv_dhcp_pt_retry />
+      <adv_dhcp_pt_select_timeout />
+      <adv_dhcp_pt_reboot />
+      <adv_dhcp_pt_backoff_cutoff />
+      <adv_dhcp_pt_initial_interval />
+      <adv_dhcp_pt_values>SavedCfg</adv_dhcp_pt_values>
+      <adv_dhcp_send_options />
+      <adv_dhcp_request_options />
+      <adv_dhcp_required_options />
+      <adv_dhcp_option_modifiers />
+      <adv_dhcp_config_advanced />
+      <adv_dhcp_config_file_override />
+      <adv_dhcp_config_file_override_path />
+    </wan>
+    <lan>
+      <enable />
+      <if>vmx1</if>
+      <descr>LAN</descr>
+      <spoofmac />
+      <ipaddr>XXX.XXX.XXX.XXX</ipaddr>
+      <subnet>24</subnet>
+    </lan>
+    <opt1>
+      <descr>OPT1</descr>
+      <if>ovpnc2</if>
+      <spoofmac />
+    </opt1>
+  </interfaces>
+  <staticroutes />
+  <dhcpd>
+    <lan>
+      <range>
+        <from>192.168.125.10</from>
+        <to>192.168.125.245</to>
+      </range>
+      <failover_peerip />
+      <dhcpleaseinlocaltime />
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <gateway />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkeyalgorithm>hmac-md5</ddnsdomainkeyalgorithm>
+      <ddnsdomainkey />
+      <mac_allow />
+      <mac_deny />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <nextserver />
+      <filename />
+      <filename32 />
+      <filename64 />
+      <rootpath />
+      <numberoptions />
+      <enable />
+    </lan>
+  </dhcpd>
+  <dhcpdv6>
+    <lan>
+      <range>
+        <from>::1000</from>
+        <to>::2000</to>
+      </range>
+      <ramode>assist</ramode>
+      <rapriority>medium</rapriority>
+      <prefixrange>
+        <from />
+        <to />
+        <prefixlength>48</prefixlength>
+      </prefixrange>
+      <defaultleasetime />
+      <maxleasetime />
+      <netmask />
+      <domain />
+      <domainsearchlist />
+      <ddnsdomain />
+      <ddnsdomainprimary />
+      <ddnsdomainkeyname />
+      <ddnsdomainkey />
+      <ddnsclientupdates>allow</ddnsclientupdates>
+      <tftp />
+      <ldap />
+      <bootfile_url />
+      <dhcpv6leaseinlocaltime />
+      <numberoptions />
+    </lan>
+  </dhcpdv6>
+  <snmpd>
+    <syslocation />
+    <syscontact />
+    <rocommunity>[REDACTED]</rocommunity>
+  </snmpd>
+  <diag>
+    <ipv6nat />
+  </diag>
+  <syslog>
+    <nentries>50</nentries>
+    <sourceip />
+    <ipproto>ipv4</ipproto>
+    <filterdescriptions>1</filterdescriptions>
+  </syslog>
+  <nat>
+    <outbound>
+      <mode>automatic</mode>
+    </outbound>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>80</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8081</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+    <rule>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>XXX.XXX.XXX.XXX</address>
+        <port>443</port>
+      </destination>
+      <protocol>tcp</protocol>
+      <target>127.0.0.1</target>
+      <local-port>8443</local-port>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <associated-rule-id>pass</associated-rule-id>
+      <natreflection>purenat</natreflection>
+    </rule>
+  </nat>
+  <filter>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <address>pfB_Asia_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770009596</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>block</type>
+      <descr>pfB_Blacklist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Blacklist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010135</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <address>pfB_Whitelist_v4</address>
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>wan</interface>
+      <tracker>1770010396</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_Asia_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Asia_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156827</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009093</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>reject</type>
+      <descr>pfB_DNSBLIP_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_DNSBLIP_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009235</tracker>
+    </rule>
+    <rule>
+      <ipprotocol>inet</ipprotocol>
+      <type>pass</type>
+      <descr>pfB_Whitelist_v4 auto rule</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <address>pfB_Whitelist_v4</address>
+      </destination>
+      <log />
+      <created>
+        <time>1528156828</time>
+        <username>Auto</username>
+      </created>
+      <interface>lan</interface>
+      <tracker>1770009893</tracker>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617312</tracker>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <protocol>udp</protocol>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <network>(self)</network>
+        <port>1194</port>
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617312</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507041729</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>wan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1507042058</time>
+        <username>Easy Rule</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Default allow LAN to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000101</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <ipprotocol>inet6</ipprotocol>
+      <descr>Default allow LAN IPv6 to any rule</descr>
+      <interface>lan</interface>
+      <tracker>0100000102</tracker>
+      <source>
+        <network>lan</network>
+      </source>
+      <destination>
+        <any />
+      </destination>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507626308</tracker>
+      <type>pass</type>
+      <interface>enc0</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507626308</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <id />
+      <tracker>1507617328</tracker>
+      <type>pass</type>
+      <interface>openvpn</interface>
+      <ipprotocol>inet</ipprotocol>
+      <tag />
+      <tagged />
+      <max />
+      <max-src-nodes />
+      <max-src-conn />
+      <max-src-states />
+      <statetimeout />
+      <statetype>keep state</statetype>
+      <os />
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <descr />
+      <updated>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </updated>
+      <created>
+        <time>1507617328</time>
+        <username>user@example.com</username>
+      </created>
+    </rule>
+    <rule>
+      <type>pass</type>
+      <interface>lan</interface>
+      <ipprotocol>inet</ipprotocol>
+      <descr>Easy Rule: Passed from Firewall Log View</descr>
+      <source>
+        <any />
+      </source>
+      <destination>
+        <any />
+      </destination>
+      <created>
+        <time>1525695659</time>
+        <username>Easy Rule</username>
+      </created>
+      <tracker>1525695659</tracker>
+    </rule>
+    <separator>
+      <wan />
+    </separator>
+  </filter>
+  <shaper />
+  <ipsec>
+    <phase1>
+      <ikeid>1</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr />
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>256</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>2</dhgroup>
+        </item>
+      </encryption>
+    </phase1>
+    <phase1>
+      <ikeid>2</ikeid>
+      <iketype>ikev2</iketype>
+      <interface>wan</interface>
+      <remote-gateway>XXX.XXX.XXX.XXX</remote-gateway>
+      <protocol>inet</protocol>
+      <myid_type>myaddress</myid_type>
+      <myid_data />
+      <peerid_type>peeraddress</peerid_type>
+      <peerid_data />
+      <encryption>
+        <item>
+          <encryption-algorithm>
+            <name>aes</name>
+            <keylen>128</keylen>
+          </encryption-algorithm>
+          <hash-algorithm>sha1</hash-algorithm>
+          <dhgroup>14</dhgroup>
+        </item>
+      </encryption>
+      <lifetime>28800</lifetime>
+      <pre-shared-key>[REDACTED]</pre-shared-key>
+      <private-key />
+      <certref />
+      <caref />
+      <authentication_method>pre_shared_key</authentication_method>
+      <descr>Tunnel with PB2</descr>
+      <nat_traversal>on</nat_traversal>
+      <mobike>off</mobike>
+      <rekey_enable />
+      <dpd_delay>10</dpd_delay>
+      <dpd_maxfail>5</dpd_maxfail>
+      <disabled />
+    </phase1>
+    <client />
+    <phase2>
+      <ikeid>1</ikeid>
+      <uniqid>59dc8cdccfa7b</uniqid>
+      <mode>tunnel</mode>
+      <reqid>1</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>XXX.XXX.XXX.XXX</address>
+        <netbits>24</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>auto</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>0</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+    <phase2>
+      <ikeid>2</ikeid>
+      <uniqid>5ab0a8c528fd8</uniqid>
+      <mode>tunnel</mode>
+      <reqid>2</reqid>
+      <localid>
+        <type>lan</type>
+      </localid>
+      <remoteid>
+        <type>network</type>
+        <address>0.0.0.0</address>
+        <netbits>0</netbits>
+      </remoteid>
+      <protocol>esp</protocol>
+      <encryption-algorithm-option>
+        <name>aes</name>
+        <keylen>128</keylen>
+      </encryption-algorithm-option>
+      <hash-algorithm-option>hmac_sha1</hash-algorithm-option>
+      <pfsgroup>14</pfsgroup>
+      <lifetime>3600</lifetime>
+      <pinghost />
+      <descr />
+    </phase2>
+  </ipsec>
+  <aliases>
+    <alias>
+      <name>pfB_Asia_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Asia_v4 &lt;br /&gt;[ 6255147, 6255147_rep, CN, CN_rep ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  GeoIP Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Whitelist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Whitelist_v4 &lt;br /&gt;[ Whitelist_custom_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_Blacklist_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_Blacklist_v4 &lt;br /&gt;[ C2_IP_Feed_v4, C2_All_Indicator_Feed_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>pfB_DNSBLIP_v4</name>
+      <url>https://example.com:443/pfblockerng/pfblockerng.php?pfb=pfB_DNSBLIP_v4 &lt;br /&gt;[ DNSBLIP_v4 ]</url>
+      <updatefreq>32</updatefreq>
+      <address />
+      <descr>pfBlockerNG  Auto  Alias</descr>
+      <type>urltable</type>
+      <detail>DO NOT EDIT THIS ALIAS</detail>
+    </alias>
+    <alias>
+      <name>Alias_1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX XXX.XXX.XXX.XXX Alias2</address>
+      <descr />
+      <detail>Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000||Entry added Mon, 19 Mar 2018 13:16:33 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX Test1</address>
+      <descr />
+      <detail>Entry added Tue, 27 Feb 2018 14:25:35 +0000||Entry added Wed, 28 Feb 2018 06:49:30 +0000</detail>
+    </alias>
+    <alias>
+      <name>Test1</name>
+      <type>host</type>
+      <address>XXX.XXX.XXX.XXX</address>
+      <descr />
+      <detail>Entry added Wed, 28 Feb 2018 06:49:16 +0000</detail>
+    </alias>
+  </aliases>
+  <proxyarp />
+  <cron>
+    <item>
+      <minute>1,31</minute>
+      <hour>0-5</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 adjkerntz -a</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>3</hour>
+      <mday>1</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_bogons.sh</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 sshlockout</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 webConfiguratorlockout</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>1</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.dyndns.update</command>
+    </item>
+    <item>
+      <minute>*/60</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/sbin/expiretable -v -t 3600 virusprot</command>
+    </item>
+    <item>
+      <minute>30</minute>
+      <hour>12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_urltables</command>
+    </item>
+    <item>
+      <minute>1</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /etc/rc.update_pkg_metadata</command>
+    </item>
+    <item>
+      <minute>*/5</minute>
+      <hour>*</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_cron_misc.inc</command>
+    </item>
+    <item>
+      <minute>5</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/bin/nice -n20 /usr/local/bin/php -f /usr/local/pkg/snort/snort_check_for_rule_updates.php</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/mail_reports_generate.php 0 &amp;</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>3</hour>
+      <mday>4-10</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc &gt;&gt; /var/log/pfblockerng/extras.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0,12</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron &gt;&gt; /var/log/pfblockerng/pfblockerng.log 2&gt;&amp;1</command>
+    </item>
+    <item>
+      <minute>0</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/sbin/squid -k rotate -f /usr/local/etc/squid/squid.conf</command>
+    </item>
+    <item>
+      <minute>15</minute>
+      <hour>0</hour>
+      <mday>*</mday>
+      <month>*</month>
+      <wday>*</wday>
+      <who>root</who>
+      <command>/usr/local/pkg/swapstate_check.php</command>
+    </item>
+  </cron>
+  <wol />
+  <rrd>
+    <enable />
+  </rrd>
+  <load_balancer>
+    <monitor_type>
+      <name>ICMP</name>
+      <type>icmp</type>
+      <descr>ICMP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>TCP</name>
+      <type>tcp</type>
+      <descr>Generic TCP</descr>
+      <options />
+    </monitor_type>
+    <monitor_type>
+      <name>HTTP</name>
+      <type>http</type>
+      <descr>Generic HTTP</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>HTTPS</name>
+      <type>https</type>
+      <descr>Generic HTTPS</descr>
+      <options>
+        <path>/</path>
+        <host />
+        <code>200</code>
+      </options>
+    </monitor_type>
+    <monitor_type>
+      <name>SMTP</name>
+      <type>send</type>
+      <descr>Generic SMTP</descr>
+      <options>
+        <send />
+        <expect>220 *</expect>
+      </options>
+    </monitor_type>
+  </load_balancer>
+  <widgets>
+    <sequence>system_information:col1:open:0,interfaces:col2:open:0,pfblockerng:col2:open:0,snort_alerts:col2:open:0,installed_packages:col2:open:0</sequence>
+  </widgets>
+  <openvpn />
+  <dnshaper />
+  <unbound>
+    <enable />
+    <dnssec />
+    <active_interface />
+    <outgoing_interface />
+    <custom_options>c2VydmVyOmluY2x1ZGU6IC92YXIvdW5ib3VuZC9wZmJfZG5zYmwuKmNvbmY=</custom_options>
+    <hideidentity />
+    <hideversion />
+    <dnssecstripped />
+    <hosts>
+      <host>pkg</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+    <hosts>
+      <host>release-staging</host>
+      <domain>example.com</domain>
+      <ip>172.27.10.115</ip>
+      <descr />
+      <aliases />
+    </hosts>
+  </unbound>
+  <revision>
+    <time>1532955144</time>
+    <username>user@example.com</username>
+  </revision>
+  <cert>
+    <refid>59d39fada929c</refid>
+    <descr>webConfigurator default (59d39fada929c)</descr>
+    <type>server</type>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <cert>
+    <refid>5a030fac39e79</refid>
+    <descr>OpenVPNClientCert</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <caref>5a030f8debd96</caref>
+  </cert>
+  <cert>
+    <refid>5a04208c7c65a</refid>
+    <descr>FreeRADIUS Server Certificate</descr>
+    <type>server</type>
+    <caref>5a04208c70f14</caref>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </cert>
+  <ppps />
+  <gateways />
+  <installedpackages>
+    <package>
+      <name>snort</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/Setup_Snort_Package</pkginfolink>
+      <website>http://www.snort.org</website>
+      <descr>Snort is an open source network intrusion prevention and detection system (IDS/IPS). Combining the benefits of signature, protocol, and anomaly-based inspection.</descr>
+      <version>3.2.9.6_1</version>
+      <configurationfile>/snort.xml</configurationfile>
+      <after_install_info>Please visit Services - Snort - Interfaces tab first and select your desired rules. Afterwards visit the Updates tab to download your configured rulesets.</after_install_info>
+      <include_file>/usr/local/pkg/snort/snort.inc</include_file>
+    </package>
+    <package>
+      <name>Lightsquid</name>
+      <descr>LightSquid is a high performance web proxy reporting tool. Includes proxy realtime statistics (SQStat).
+			&amp;lt;strong&amp;gt;Requires Squid package.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://lightsquid.sf.net/</website>
+      <version>3.0.6_4</version>
+      <configurationfile>lightsquid.xml</configurationfile>
+      <noembedded>true</noembedded>
+    </package>
+    <package>
+      <name>AutoConfigBackup</name>
+      <descr>Automatically backs up your pfSense configuration. All contents are encrypted before being sent to the server.&amp;lt;br /&amp;gt;
+			Requires Gold Subscription from &amp;lt;a href=&amp;quot;https://portal.pfsense.org&amp;quot;&amp;gt;pfSense Portal&amp;lt;/a&amp;gt;.</descr>
+      <website>https://portal.pfsense.org</website>
+      <version>1.52</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/AutoConfigBackup</pkginfolink>
+      <configurationfile>autoconfigbackup.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=autoconfigbackup.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Restore</text>
+          <url>/autoconfigbackup.php</url>
+        </tab>
+        <tab>
+          <text>Backup now</text>
+          <url>/autoconfigbackup_backup.php</url>
+        </tab>
+        <tab>
+          <text>Stats</text>
+          <url>/autoconfigbackup_stats.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/autoconfigbackup.inc</include_file>
+    </package>
+    <package>
+      <name>haproxy-devel</name>
+      <pkginfolink>https://doc.pfsense.org/index.php/haproxy_package</pkginfolink>
+      <descr>The Reliable, High Performance TCP/HTTP(S) Load Balancer.&amp;lt;br /&amp;gt;
+			This package implements the TCP, HTTP and HTTPS balancing features from haproxy.&amp;lt;br /&amp;gt;
+			Supports ACLs for smart backend switching.</descr>
+      <website>http://haproxy.1wt.eu/</website>
+      <version>0.58_2</version>
+      <configurationfile>haproxy.xml</configurationfile>
+      <logging>
+        <logsocket>/tmp/haproxy_chroot/var/run/log</logsocket>
+        <facilityname>haproxy</facilityname>
+        <logfilename>haproxy.log</logfilename>
+      </logging>
+      <filter_rule_function>haproxy_generate_rules</filter_rule_function>
+      <include_file>/usr/local/pkg/haproxy/haproxy.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+        <item>
+          <type>plugin_certificates</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>Open-VM-Tools</name>
+      <descr>VMware Tools is a suite of utilities that enhances the performance of the virtual machine's guest operating system and improves management of the virtual machine.</descr>
+      <website>http://open-vm-tools.sourceforge.net/</website>
+      <version>10.1.0,1</version>
+      <pkginfolink>https://doc.pfsense.org/index.php/Open_VM_Tools_package</pkginfolink>
+      <configurationfile>open-vm-tools.xml</configurationfile>
+      <include_file>/usr/local/pkg/open-vm-tools.inc</include_file>
+    </package>
+    <package>
+      <name>squid3</name>
+      <internal_name>squid</internal_name>
+      <descr>High performance web proxy cache (3.4 branch). It combines Squid as a proxy server with its capabilities of acting as a HTTP / HTTPS reverse proxy.&amp;lt;br /&amp;gt;
+			It includes an Exchange-Web-Access (OWA) Assistant, SSL filtering and antivirus integration via C-ICAP.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?board=60.0</pkginfolink>
+      <website>http://www.squid-cache.org/</website>
+      <version>0.4.44_1</version>
+      <configurationfile>squid.xml</configurationfile>
+      <filter_rule_function>squid_generate_rules</filter_rule_function>
+      <tabs>
+        <tab>
+          <text>General</text>
+          <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Remote Cache</text>
+          <url>/pkg.php?xml=squid_upstream.xml</url>
+        </tab>
+        <tab>
+          <text>Local Cache</text>
+          <url>/pkg_edit.php?xml=squid_cache.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Antivirus</text>
+          <url>/pkg_edit.php?xml=squid_antivirus.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>ACLs</text>
+          <url>/pkg_edit.php?xml=squid_nac.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Traffic Mgmt</text>
+          <url>/pkg_edit.php?xml=squid_traffic.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Authentication</text>
+          <url>/pkg_edit.php?xml=squid_auth.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=squid_users.xml</url>
+        </tab>
+        <tab>
+          <text>Real Time</text>
+          <url>/squid_monitor.php</url>
+        </tab>
+        <tab>
+          <text>Sync</text>
+          <url>/pkg_edit.php?xml=squid_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squid.inc</include_file>
+    </package>
+    <package>
+      <name>squidGuard</name>
+      <descr>High performance web proxy URL filter.&amp;lt;br/&amp;gt;
+			&amp;lt;strong&amp;gt;Works with both Squid (2.7 legacy branch) and Squid3 (3.4 branch) packages.&amp;lt;/strong&amp;gt;</descr>
+      <website>http://www.squidGuard.org/</website>
+      <version>1.16.16</version>
+      <configurationfile>squidguard.xml</configurationfile>
+      <after_install_info>Please visit Services - SquidGuard Proxy Filter - Target Categories and set up at least one category there before enabling SquidGuard. See https://forum.pfsense.org/index.php?topic=94312.0 for details.</after_install_info>
+      <tabs>
+        <tab>
+          <text>General settings</text>
+          <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Common ACL</text>
+          <url>/pkg_edit.php?xml=squidguard_default.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>Groups ACL</text>
+          <url>/pkg.php?xml=squidguard_acl.xml</url>
+        </tab>
+        <tab>
+          <text>Target categories</text>
+          <url>/pkg.php?xml=squidguard_dest.xml</url>
+        </tab>
+        <tab>
+          <text>Times</text>
+          <url>/pkg.php?xml=squidguard_time.xml</url>
+        </tab>
+        <tab>
+          <text>Rewrites</text>
+          <url>/pkg.php?xml=squidguard_rewr.xml</url>
+        </tab>
+        <tab>
+          <text>Blacklist</text>
+          <url>/squidGuard/squidguard_blacklist.php</url>
+        </tab>
+        <tab>
+          <text>Log</text>
+          <url>/squidGuard/squidguard_log.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=squidguard_sync.xml</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/squidguard.inc</include_file>
+    </package>
+    <package>
+      <name>Service Watchdog</name>
+      <internal_name>Service_Watchdog</internal_name>
+      <descr>Monitors for stopped services and restarts them.</descr>
+      <version>1.8.5</version>
+      <configurationfile>servicewatchdog.xml</configurationfile>
+      <include_file>/usr/local/pkg/servicewatchdog.inc</include_file>
+    </package>
+    <package>
+      <name>freeradius3</name>
+      <website>http://www.freeradius.org/</website>
+      <descr>A free implementation of the RADIUS protocol.&amp;lt;br /&amp;gt;
+			Supports MySQL, PostgreSQL, LDAP, Kerberos.</descr>
+      <pkginfolink>https://doc.pfsense.org/index.php/FreeRADIUS_2.x_package</pkginfolink>
+      <version>0.15.5_1</version>
+      <configurationfile>freeradius.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Users</text>
+          <url>/pkg.php?xml=freeradius.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>MACs</text>
+          <url>/pkg.php?xml=freeradiusauthorizedmacs.xml</url>
+        </tab>
+        <tab>
+          <text>NAS / Clients</text>
+          <url>/pkg.php?xml=freeradiusclients.xml</url>
+        </tab>
+        <tab>
+          <text>Interfaces</text>
+          <url>/pkg.php?xml=freeradiusinterfaces.xml</url>
+        </tab>
+        <tab>
+          <text>Settings</text>
+          <url>/pkg_edit.php?xml=freeradiussettings.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>EAP</text>
+          <url>/pkg_edit.php?xml=freeradiuseapconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>SQL</text>
+          <url>/pkg_edit.php?xml=freeradiussqlconf.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>LDAP</text>
+          <url>/pkg_edit.php?xml=freeradiusmodulesldap.xml&amp;id=0</url>
+        </tab>
+        <tab>
+          <text>View config</text>
+          <url>/freeradius_view_config.php</url>
+        </tab>
+        <tab>
+          <text>XMLRPC Sync</text>
+          <url>/pkg_edit.php?xml=freeradiussync.xml&amp;id=0</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/freeradius.inc</include_file>
+    </package>
+    <package>
+      <name>FRR</name>
+      <internal_name>frr</internal_name>
+      <descr>FRR routing daemon for BGP, OSPF, and OSPF6.&amp;lt;br /&amp;gt;
+			&amp;lt;strong&amp;gt;Conflicts with Quagga OSPF and OpenBGPD; these packages cannot be installed at the same time.&amp;lt;/strong&amp;gt;</descr>
+      <version>0.2_1</version>
+      <configurationfile>frr.xml</configurationfile>
+      <tabs>
+        <tab>
+          <text>Global Settings</text>
+          <url>pkg_edit.php?xml=frr.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access Lists</text>
+          <url>pkg.php?xml=frr/frr_global_acls.xml</url>
+        </tab>
+        <tab>
+          <text>Prefix Lists</text>
+          <url>pkg.php?xml=frr/frr_global_prefixes.xml</url>
+        </tab>
+        <tab>
+          <text>Route Maps</text>
+          <url>pkg.php?xml=frr/frr_global_routemaps.xml</url>
+        </tab>
+        <tab>
+          <text>Raw Config</text>
+          <url>pkg_edit.php?xml=frr/frr_global_raw.xml</url>
+        </tab>
+        <tab>
+          <text>[BGP]</text>
+          <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf.xml</url>
+        </tab>
+        <tab>
+          <text>[OSPF6]</text>
+          <url>pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+        </tab>
+        <tab>
+          <text>Status</text>
+          <url>/status_frr.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/frr.inc</include_file>
+      <plugins>
+        <item>
+          <type>plugin_carp</type>
+        </item>
+      </plugins>
+    </package>
+    <package>
+      <name>mailreport</name>
+      <descr>Allows you to setup periodic e-mail reports containing command output and log file contents.</descr>
+      <version>3.3</version>
+      <configurationfile>mailreport.xml</configurationfile>
+    </package>
+    <package>
+      <name>ntopng</name>
+      <website>http://www.ntop.org/</website>
+      <descr>ntopng (replaces ntop) is a network probe that shows network usage in a way similar to what top does for processes. In interactive mode, it displays the network status on the user's terminal. In Web mode it acts as a Web server, creating an HTML dump of the network status. It sports a NetFlow/sFlow emitter/collector, an HTTP-based client interface for creating ntop-centric monitoring applications, and RRD for persistently storing traffic statistics.</descr>
+      <version>0.8.12</version>
+      <configurationfile>ntopng.xml</configurationfile>
+      <noembedded>true</noembedded>
+      <tabs>
+        <tab>
+          <text>ntopng Settings</text>
+          <url>/pkg_edit.php?xml=ntopng.xml</url>
+          <active />
+        </tab>
+        <tab>
+          <text>Access ntopng</text>
+          <url>/ntopng_redirect.php</url>
+        </tab>
+      </tabs>
+      <include_file>/usr/local/pkg/ntopng.inc</include_file>
+    </package>
+    <package>
+      <name>pfBlockerNG-devel</name>
+      <descr>pfBlockerNG is the Next Generation of pfBlocker.&amp;lt;br /&amp;gt;
+			Manage IPv4/v6 List Sources into 'Deny, Permit or Match' formats.&amp;lt;br /&amp;gt;
+			GeoIP database by MaxMind Inc. (GeoLite2 Free version).&amp;lt;br /&amp;gt;
+			De-Duplication, Suppression, and Reputation enhancements.&amp;lt;br /&amp;gt;
+			Provision to download from diverse List formats.&amp;lt;br /&amp;gt;
+			Advanced Integration for Proofpoint ET IQRisk IP Reputation Threat Sources.&amp;lt;br /&amp;gt;
+			Domain Name (DNSBL) blocking via Unbound DNS Resolver.</descr>
+      <pkginfolink>https://forum.pfsense.org/index.php?topic=102470.0</pkginfolink>
+      <version>2.2.1</version>
+      <configurationfile>pfblockerng.xml</configurationfile>
+      <include_file>/usr/local/pkg/pfblockerng/pfblockerng.inc</include_file>
+    </package>
+    <pfblockernglistsv4>
+      <config>
+        <aliasname>Whitelist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url />
+          <header />
+        </row>
+        <action>Permit_Both</action>
+        <cron>Never</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom>OC44LjguOA==</custom>
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-ipmasterlist.txt</url>
+          <header>C2_IP_Feed</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/feeds/c2-masterlist.txt</url>
+          <header>C2_All_Indicator_Feed</header>
+        </row>
+        <action>Deny_Inbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <whois_convert />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>PRI1</aliasname>
+        <description>PRI1 - Collection of Feeds from the most reputable blocklist providers. (Primary tier)</description>
+        <action>Disabled</action>
+        <cron>01hour</cron>
+        <dow>1</dow>
+        <aliaslog>enabled</aliaslog>
+        <stateremoval>enabled</stateremoval>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <suppression_cidr>Disabled</suppression_cidr>
+        <whois_convert />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/blacklist/dyre_sslipblacklist.csv</url>
+          <header>Abuse_DYRE</header>
+        </row>
+      </config>
+    </pfblockernglistsv4>
+    <pfblockernglistsv6>
+      <config />
+    </pfblockernglistsv6>
+    <pfblockerngdnsblsettings>
+      <config>
+        <pfb_dnsbl>on</pfb_dnsbl>
+        <pfb_tld />
+        <pfb_dnsvip>10.10.10.1</pfb_dnsvip>
+        <pfb_dnsport>8081</pfb_dnsport>
+        <pfb_dnsport_ssl>8443</pfb_dnsport_ssl>
+        <dnsbl_interface>lan</dnsbl_interface>
+        <pfb_dnsbl_rule />
+        <dnsbl_allow_int />
+        <action>Deny_Outbound</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+        <alexa_enable>on</alexa_enable>
+        <alexa_count>1000</alexa_count>
+        <alexa_inclusion>ca,co,com,io,net,org</alexa_inclusion>
+        <suppression />
+        <tldexclusion />
+        <tldblacklist />
+        <tldwhitelist />
+      </config>
+    </pfblockerngdnsblsettings>
+    <pfblockerngafrica>
+      <config />
+    </pfblockerngafrica>
+    <pfblockerngantarctica>
+      <config />
+    </pfblockerngantarctica>
+    <pfblockerngasia>
+      <config>
+        <countries4>6255147,6255147_rep,CN,CN_rep</countries4>
+        <countries6 />
+        <action>Deny_Both</action>
+        <aliaslog>enabled</aliaslog>
+        <autoaddrnot_in />
+        <autoports_in />
+        <aliasports_in />
+        <autoaddr_in />
+        <autonot_in />
+        <aliasaddr_in />
+        <autoproto_in />
+        <agateway_in>default</agateway_in>
+        <autoaddrnot_out />
+        <autoports_out />
+        <aliasports_out />
+        <autoaddr_out />
+        <autonot_out />
+        <aliasaddr_out />
+        <autoproto_out />
+        <agateway_out>default</agateway_out>
+      </config>
+    </pfblockerngasia>
+    <pfblockerngeurope>
+      <config />
+    </pfblockerngeurope>
+    <pfblockerngnorthamerica>
+      <config />
+    </pfblockerngnorthamerica>
+    <pfblockerngoceania>
+      <config />
+    </pfblockerngoceania>
+    <pfblockerngsouthamerica>
+      <config />
+    </pfblockerngsouthamerica>
+    <pfblockerngtopspammers>
+      <config />
+    </pfblockerngtopspammers>
+    <pfblockerngproxyandsatellite>
+      <config />
+    </pfblockerngproxyandsatellite>
+    <pfblockerng>
+      <config>
+        <enable_cb>on</enable_cb>
+        <pfb_keep>on</pfb_keep>
+        <pfb_interval>12</pfb_interval>
+        <pfb_min />
+        <pfb_hour />
+        <pfb_dailystart />
+        <skipfeed />
+        <credits />
+        <log_max_log>20000</log_max_log>
+        <log_max_errlog>20000</log_max_errlog>
+        <log_max_extraslog>20000</log_max_extraslog>
+        <log_max_ip_blocklog>20000</log_max_ip_blocklog>
+        <log_max_ip_permitlog>20000</log_max_ip_permitlog>
+        <log_max_ip_matchlog>20000</log_max_ip_matchlog>
+        <log_max_dnslog>20000</log_max_dnslog>
+        <log_max_dnsbl_parse_err>20000</log_max_dnsbl_parse_err>
+      </config>
+    </pfblockerng>
+    <pfblockerngdnsbl>
+      <config>
+        <aliasname>Blacklist</aliasname>
+        <description />
+        <infolists />
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>https://example.com/hosts.txt</url>
+          <header>Adaway</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/adservers/serverlist.php?hostformat=hosts&amp;mimetype=plaintext</url>
+          <header>yoyo</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>http://example.com/ad_servers.txt</url>
+          <header>hpHosts_ads</header>
+        </row>
+        <row>
+          <format>auto</format>
+          <state>Enabled</state>
+          <url>example.com/cameleon/hosts</url>
+          <header>Cameleon</header>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+        <custom />
+        <custom_update>disabled</custom_update>
+      </config>
+      <config>
+        <aliasname>ADs</aliasname>
+        <description>ADs - Collection of ADvertisement Domain Feeds.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/downloads/dg-ads.acl</url>
+          <header>SBL_ADs</header>
+        </row>
+      </config>
+      <config>
+        <aliasname>BBcan177</aliasname>
+        <description>BBcan177 - Feed as provided by BBcan177.</description>
+        <action>Disabled</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <logging>enabled</logging>
+        <order>default</order>
+        <filter_alexa />
+        <custom />
+        <row>
+          <format>auto</format>
+          <state>Disabled</state>
+          <url>https://example.com/BBcan177/4a8bf37c131be4803cb2/raw</url>
+          <header>MS_2</header>
+        </row>
+      </config>
+    </pfblockerngdnsbl>
+    <snortglobal>
+      <snort_config_ver>3.2.9.6_1</snort_config_ver>
+      <snortdownload>on</snortdownload>
+      <snortcommunityrules>off</snortcommunityrules>
+      <emergingthreats>off</emergingthreats>
+      <emergingthreats_pro>off</emergingthreats_pro>
+      <clearblocks>on</clearblocks>
+      <verbose_logging>off</verbose_logging>
+      <openappid_detectors>on</openappid_detectors>
+      <openappid_rules_detectors>on</openappid_rules_detectors>
+      <hide_deprecated_rules>off</hide_deprecated_rules>
+      <curl_no_verify_ssl_peer>off</curl_no_verify_ssl_peer>
+      <oinkmastercode>c4e000842278df905ba5795132288ddc7c996d14</oinkmastercode>
+      <etpro_code />
+      <rm_blocked>never_b</rm_blocked>
+      <autorulesupdate7>12h_up</autorulesupdate7>
+      <rule_update_starttime>00:05</rule_update_starttime>
+      <forcekeepsettings>on</forcekeepsettings>
+      <last_rule_upd_status>success</last_rule_upd_status>
+      <last_rule_upd_time>1532952490</last_rule_upd_time>
+      <rule>
+        <interface>wan</interface>
+        <enable>on</enable>
+        <uuid>53250</uuid>
+        <descr>WAN</descr>
+        <performance>ac-bnfa</performance>
+        <blockoffenders7>off</blockoffenders7>
+        <blockoffenderskill>on</blockoffenderskill>
+        <blockoffendersip>both</blockoffendersip>
+        <whitelistname>default</whitelistname>
+        <homelistname>default</homelistname>
+        <externallistname>default</externallistname>
+        <suppresslistname>wansuppress_5a82ea740612f</suppresslistname>
+        <alertsystemlog>on</alertsystemlog>
+        <alertsystemlog_facility>log_auth</alertsystemlog_facility>
+        <alertsystemlog_priority>log_alert</alertsystemlog_priority>
+        <cksumcheck>on</cksumcheck>
+        <fpm_split_any_any>off</fpm_split_any_any>
+        <fpm_search_optimize>off</fpm_search_optimize>
+        <fpm_no_stream_inserts>off</fpm_no_stream_inserts>
+        <max_attribute_hosts>10000</max_attribute_hosts>
+        <max_attribute_services_per_host>10</max_attribute_services_per_host>
+        <max_paf>16000</max_paf>
+        <ftp_preprocessor>on</ftp_preprocessor>
+        <ftp_telnet_inspection_type>stateful</ftp_telnet_inspection_type>
+        <ftp_telnet_alert_encrypted>off</ftp_telnet_alert_encrypted>
+        <ftp_telnet_check_encrypted>on</ftp_telnet_check_encrypted>
+        <ftp_telnet_normalize>on</ftp_telnet_normalize>
+        <ftp_telnet_detect_anomalies>on</ftp_telnet_detect_anomalies>
+        <ftp_telnet_ayt_attack_threshold>20</ftp_telnet_ayt_attack_threshold>
+        <ftp_client_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <max_resp_len>256</max_resp_len>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <bounce>yes</bounce>
+            <bounce_to_net />
+            <bounce_to_port />
+          </item>
+        </ftp_client_engine>
+        <ftp_server_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <ports>default</ports>
+            <telnet_cmds>no</telnet_cmds>
+            <ignore_telnet_erase_cmds>yes</ignore_telnet_erase_cmds>
+            <ignore_data_chan>no</ignore_data_chan>
+            <def_max_param_len>100</def_max_param_len>
+          </item>
+        </ftp_server_engine>
+        <smtp_preprocessor>on</smtp_preprocessor>
+        <smtp_memcap>838860</smtp_memcap>
+        <smtp_max_mime_mem>838860</smtp_max_mime_mem>
+        <smtp_b64_decode_depth>0</smtp_b64_decode_depth>
+        <smtp_qp_decode_depth>0</smtp_qp_decode_depth>
+        <smtp_bitenc_decode_depth>0</smtp_bitenc_decode_depth>
+        <smtp_uu_decode_depth>0</smtp_uu_decode_depth>
+        <smtp_email_hdrs_log_depth>1464</smtp_email_hdrs_log_depth>
+        <smtp_ignore_data>off</smtp_ignore_data>
+        <smtp_ignore_tls_data>on</smtp_ignore_tls_data>
+        <smtp_log_mail_from>on</smtp_log_mail_from>
+        <smtp_log_rcpt_to>on</smtp_log_rcpt_to>
+        <smtp_log_filename>on</smtp_log_filename>
+        <smtp_log_email_hdrs>on</smtp_log_email_hdrs>
+        <dce_rpc_2>on</dce_rpc_2>
+        <dns_preprocessor>on</dns_preprocessor>
+        <ssl_preproc>on</ssl_preproc>
+        <pop_preproc>on</pop_preproc>
+        <pop_memcap>838860</pop_memcap>
+        <pop_b64_decode_depth>0</pop_b64_decode_depth>
+        <pop_qp_decode_depth>0</pop_qp_decode_depth>
+        <pop_bitenc_decode_depth>0</pop_bitenc_decode_depth>
+        <pop_uu_decode_depth>0</pop_uu_decode_depth>
+        <imap_preproc>on</imap_preproc>
+        <imap_memcap>838860</imap_memcap>
+        <imap_b64_decode_depth>0</imap_b64_decode_depth>
+        <imap_qp_decode_depth>0</imap_qp_decode_depth>
+        <imap_bitenc_decode_depth>0</imap_bitenc_decode_depth>
+        <imap_uu_decode_depth>0</imap_uu_decode_depth>
+        <sip_preproc>on</sip_preproc>
+        <other_preprocs>on</other_preprocs>
+        <pscan_protocol>all</pscan_protocol>
+        <pscan_type>all</pscan_type>
+        <pscan_memcap>10000000</pscan_memcap>
+        <pscan_sense_level>medium</pscan_sense_level>
+        <http_inspect>on</http_inspect>
+        <http_inspect_proxy_alert>off</http_inspect_proxy_alert>
+        <http_inspect_memcap>150994944</http_inspect_memcap>
+        <http_inspect_max_gzip_mem>838860</http_inspect_max_gzip_mem>
+        <http_inspect_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <server_profile>all</server_profile>
+            <enable_xff>off</enable_xff>
+            <log_uri>off</log_uri>
+            <log_hostname>off</log_hostname>
+            <server_flow_depth>65535</server_flow_depth>
+            <enable_cookie>on</enable_cookie>
+            <client_flow_depth>1460</client_flow_depth>
+            <extended_response_inspection>on</extended_response_inspection>
+            <no_alerts>off</no_alerts>
+            <unlimited_decompress>on</unlimited_decompress>
+            <inspect_gzip>on</inspect_gzip>
+            <normalize_cookies>on</normalize_cookies>
+            <normalize_headers>on</normalize_headers>
+            <normalize_utf>on</normalize_utf>
+            <normalize_javascript>on</normalize_javascript>
+            <allow_proxy_use>off</allow_proxy_use>
+            <inspect_uri_only>off</inspect_uri_only>
+            <max_javascript_whitespaces>200</max_javascript_whitespaces>
+            <post_depth>-1</post_depth>
+            <max_headers>0</max_headers>
+            <max_spaces>0</max_spaces>
+            <max_header_length>0</max_header_length>
+            <ports>default</ports>
+            <decompress_swf>off</decompress_swf>
+            <decompress_pdf>off</decompress_pdf>
+          </item>
+        </http_inspect_engine>
+        <frag3_max_frags>8192</frag3_max_frags>
+        <frag3_memcap>4194304</frag3_memcap>
+        <frag3_detection>on</frag3_detection>
+        <frag3_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>60</timeout>
+            <min_ttl>1</min_ttl>
+            <detect_anomalies>on</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <min_frag_len>0</min_frag_len>
+          </item>
+        </frag3_engine>
+        <stream5_reassembly>on</stream5_reassembly>
+        <stream5_flush_on_alert>off</stream5_flush_on_alert>
+        <stream5_prune_log_max>1048576</stream5_prune_log_max>
+        <stream5_track_tcp>on</stream5_track_tcp>
+        <stream5_max_tcp>262144</stream5_max_tcp>
+        <stream5_track_udp>on</stream5_track_udp>
+        <stream5_max_udp>131072</stream5_max_udp>
+        <stream5_udp_timeout>30</stream5_udp_timeout>
+        <stream5_track_icmp>off</stream5_track_icmp>
+        <stream5_max_icmp>65536</stream5_max_icmp>
+        <stream5_icmp_timeout>30</stream5_icmp_timeout>
+        <stream5_mem_cap>8388608</stream5_mem_cap>
+        <stream5_tcp_engine>
+          <item>
+            <name>default</name>
+            <bind_to>all</bind_to>
+            <policy>bsd</policy>
+            <timeout>30</timeout>
+            <max_queued_bytes>1048576</max_queued_bytes>
+            <detect_anomalies>off</detect_anomalies>
+            <overlap_limit>0</overlap_limit>
+            <max_queued_segs>2621</max_queued_segs>
+            <require_3whs>off</require_3whs>
+            <startup_3whs_timeout>0</startup_3whs_timeout>
+            <no_reassemble_async>off</no_reassemble_async>
+            <max_window>0</max_window>
+            <use_static_footprint_sizes>off</use_static_footprint_sizes>
+            <check_session_hijacking>off</check_session_hijacking>
+            <dont_store_lg_pkts>off</dont_store_lg_pkts>
+            <ports_client>default</ports_client>
+            <ports_both>default</ports_both>
+            <ports_server>none</ports_server>
+          </item>
+        </stream5_tcp_engine>
+        <appid_preproc>on</appid_preproc>
+        <sf_appid_mem_cap>256</sf_appid_mem_cap>
+        <sf_appid_statslog>on</sf_appid_statslog>
+        <sf_appid_stats_period>300</sf_appid_stats_period>
+        <sdf_alert_data_type>Credit Card,Email Addresses,U.S. Phone Numbers,U.S. Social Security Numbers</sdf_alert_data_type>
+        <sdf_alert_threshold>25</sdf_alert_threshold>
+        <sdf_mask_output>off</sdf_mask_output>
+        <ssh_preproc>on</ssh_preproc>
+        <pscan_ignore_scanners />
+        <pscan_ignore_scanned />
+        <perform_stat>off</perform_stat>
+        <host_attribute_table>off</host_attribute_table>
+        <sf_portscan>on</sf_portscan>
+        <sensitive_data>off</sensitive_data>
+        <dnp3_preproc>off</dnp3_preproc>
+        <modbus_preproc>off</modbus_preproc>
+        <gtp_preproc>off</gtp_preproc>
+        <preproc_auto_rule_disable>off</preproc_auto_rule_disable>
+        <protect_preproc_rules>off</protect_preproc_rules>
+        <ips_policy_enable>on</ips_policy_enable>
+        <rulesets />
+        <autoflowbitrules>on</autoflowbitrules>
+        <ips_policy>connectivity</ips_policy>
+        <arp_spoof_engine />
+        <arpspoof_preproc>off</arpspoof_preproc>
+        <arp_unicast_detection>off</arp_unicast_detection>
+      </rule>
+      <dashboard_widget>snort_alerts:col2:open:0</dashboard_widget>
+      <auto_manage_sids>off</auto_manage_sids>
+      <enable_log_mgmt>on</enable_log_mgmt>
+      <alert_log_limit_size>500</alert_log_limit_size>
+      <alert_log_retention>336</alert_log_retention>
+      <appid_stats_log_limit_size>1000</appid_stats_log_limit_size>
+      <appid_stats_log_retention>168</appid_stats_log_retention>
+      <event_pkts_log_limit_size>0</event_pkts_log_limit_size>
+      <event_pkts_log_retention>336</event_pkts_log_retention>
+      <sid_changes_log_limit_size>250</sid_changes_log_limit_size>
+      <sid_changes_log_retention>336</sid_changes_log_retention>
+      <stats_log_limit_size>500</stats_log_limit_size>
+      <stats_log_retention>168</stats_log_retention>
+      <suppress />
+      <whitelist>
+        <item>
+          <name>passlist_40695</name>
+          <uuid>38194</uuid>
+          <localnets>no</localnets>
+          <wangateips>no</wangateips>
+          <wandnsips>no</wandnsips>
+          <vips>no</vips>
+          <vpnips>no</vpnips>
+          <address>Test</address>
+          <descr />
+        </item>
+      </whitelist>
+    </snortglobal>
+    <autoconfigbackup>
+      <config>
+        <enable_acb>enabled</enable_acb>
+        <username>azamat</username>
+        <password>[REDACTED]</password>
+        <passwordagain>[REDACTED]</passwordagain>
+        <crypto_password>[REDACTED]</crypto_password>
+        <crypto_password2>[REDACTED]</crypto_password2>
+      </config>
+    </autoconfigbackup>
+    <haproxy>
+      <configversion>00.32</configversion>
+      <ha_backends />
+      <ha_pools />
+      <email_mailers />
+      <dns_resolvers />
+      <files>
+        <item />
+      </files>
+    </haproxy>
+    <service />
+    <service>
+      <name>vmware-guestd</name>
+      <rcfile>vmware-guestd.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-guestd status") == 0;</custom_php_service_status_command>
+      <description>VMware Guest Daemon</description>
+    </service>
+    <service>
+      <name>vmware-kmod</name>
+      <rcfile>vmware-kmod.sh</rcfile>
+      <custom_php_service_status_command>mwexec("/usr/local/etc/rc.d/vmware-kmod status") == 0;</custom_php_service_status_command>
+      <description>VMware Kernel Modules</description>
+    </service>
+    <service>
+      <name>snort</name>
+      <rcfile>snort.sh</rcfile>
+      <executable>snort</executable>
+      <description>Snort IDS/IPS Daemon</description>
+    </service>
+    <service>
+      <name>ntopng</name>
+      <rcfile>ntopng.sh</rcfile>
+      <executable>ntopng</executable>
+      <description>ntopng Network Traffic Monitor</description>
+    </service>
+    <service>
+      <name>squidGuard</name>
+      <description>Proxy server filter Service</description>
+      <executable>squidGuard</executable>
+    </service>
+    <service>
+      <name>squid</name>
+      <rcfile>squid.sh</rcfile>
+      <executable>squid</executable>
+      <description>Squid Proxy Server Service</description>
+    </service>
+    <service>
+      <name>clamd</name>
+      <rcfile>clamd.sh</rcfile>
+      <executable>clamd</executable>
+      <description>ClamAV Antivirus</description>
+    </service>
+    <service>
+      <name>c-icap</name>
+      <rcfile>c-icap.sh</rcfile>
+      <executable>c-icap</executable>
+      <description>ICAP Inteface for Squid and ClamAV integration</description>
+    </service>
+    <service>
+      <name>haproxy</name>
+      <rcfile>haproxy.sh</rcfile>
+      <executable>haproxy</executable>
+      <description>TCP/HTTP(S) Load Balancer</description>
+    </service>
+    <service>
+      <name>FRR zebra</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>zebra</executable>
+      <description>FRR core/abstraction daemon</description>
+    </service>
+    <service>
+      <name>FRR bgpd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>bgpd</executable>
+      <description>FRR BGP routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospfd</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospfd</executable>
+      <description>FRR OSPF routing daemon</description>
+    </service>
+    <service>
+      <name>FRR ospf6d</name>
+      <rcfile>frr.sh</rcfile>
+      <executable>ospf6d</executable>
+      <description>FRR OSPF6 routing daemon</description>
+    </service>
+    <service>
+      <name>radiusd</name>
+      <rcfile>radiusd.sh</rcfile>
+      <executable>radiusd</executable>
+      <description>FreeRADIUS Server</description>
+    </service>
+    <service>
+      <name>pfb_dnsbl</name>
+      <rcfile>pfb_dnsbl.sh</rcfile>
+      <executable>lighttpd_pfb</executable>
+      <description>pfBlockerNG DNSBL service</description>
+    </service>
+    <service>
+      <name>pfb_filter</name>
+      <rcfile>pfb_filter.sh</rcfile>
+      <executable>php_pfb</executable>
+      <description>pfBlockerNG firewall filter service</description>
+    </service>
+    <menu />
+    <menu>
+      <name>Snort</name>
+      <tooltiptext>Set up snort specific settings</tooltiptext>
+      <section>Services</section>
+      <url>/snort/snort_interfaces.php</url>
+    </menu>
+    <menu>
+      <name>ntopng Settings</name>
+      <tooltiptext>Set ntopng settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/pkg_edit.php?xml=ntopng.xml</url>
+    </menu>
+    <menu>
+      <name>ntopng</name>
+      <tooltiptext>Access ntopng</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/ntopng_redirect.php</url>
+    </menu>
+    <menu>
+      <name>AutoConfigBackup</name>
+      <tooltiptext>Set autoconfigbackup settings such as password and port.</tooltiptext>
+      <section>Diagnostics</section>
+      <url>/autoconfigbackup.php</url>
+    </menu>
+    <menu>
+      <name>SquidGuard Proxy Filter</name>
+      <tooltiptext>Modify the proxy server's filter settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squidguard.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Proxy Server</name>
+      <tooltiptext>Modify the proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Squid Reverse Proxy</name>
+      <tooltiptext>Modify the reverse proxy server settings</tooltiptext>
+      <section>Services</section>
+      <url>/pkg_edit.php?xml=squid_reverse_general.xml&amp;id=0</url>
+    </menu>
+    <menu>
+      <name>Email Reports</name>
+      <tooltiptext>Setup periodic email reports.</tooltiptext>
+      <section>Status</section>
+      <url>/status_mail_report.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/haproxy/haproxy_listeners.php</url>
+    </menu>
+    <menu>
+      <name>HAProxy Stats</name>
+      <tooltiptext>Stats of HAProxy</tooltiptext>
+      <section>Status</section>
+      <url>/haproxy/haproxy_stats.php?haproxystats=1</url>
+    </menu>
+    <menu>
+      <name>FRR Global/Zebra</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr.xml</url>
+    </menu>
+    <menu>
+      <name>FRR BGP</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>pkg_edit.php?xml=frr/frr_bgp.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf.xml</url>
+    </menu>
+    <menu>
+      <name>FRR OSPF6</name>
+      <section>Services</section>
+      <configfile>frr.xml</configfile>
+      <url>/pkg_edit.php?xml=frr/frr_ospf6.xml</url>
+    </menu>
+    <menu>
+      <name>FRR</name>
+      <section>Status</section>
+      <configfile>frr.xml</configfile>
+      <url>/status_frr.php</url>
+    </menu>
+    <menu>
+      <name>FreeRADIUS</name>
+      <section>Services</section>
+      <url>/pkg.php?xml=freeradius.xml</url>
+    </menu>
+    <menu>
+      <name>Service Watchdog</name>
+      <tooltiptext />
+      <section>Services</section>
+      <url>/services_servicewatchdog.php</url>
+    </menu>
+    <menu>
+      <name>pfBlockerNG</name>
+      <section>Firewall</section>
+      <url>/pfblockerng/pfblockerng_general.php</url>
+    </menu>
+    <squidcache>
+      <config>
+        <cache_replacement_policy>heap LFUDA</cache_replacement_policy>
+        <cache_swap_low>90</cache_swap_low>
+        <cache_swap_high>95</cache_swap_high>
+        <donotcache />
+        <enable_offline />
+        <ext_cachemanager />
+        <harddisk_cache_size>1000</harddisk_cache_size>
+        <harddisk_cache_system>ufs</harddisk_cache_system>
+        <level1_subdirs>16</level1_subdirs>
+        <harddisk_cache_location>/var/squid/cache</harddisk_cache_location>
+        <minimum_object_size>0</minimum_object_size>
+        <maximum_object_size>4</maximum_object_size>
+        <memory_cache_size>64</memory_cache_size>
+        <maximum_objsize_in_mem>256</maximum_objsize_in_mem>
+        <memory_replacement_policy>heap GDSF</memory_replacement_policy>
+        <cache_dynamic_content />
+        <custom_refresh_patterns />
+      </config>
+    </squidcache>
+    <squidremote />
+    <squidauth>
+      <config>
+        <auth_method>none</auth_method>
+      </config>
+    </squidauth>
+    <servicewatchdog />
+    <freeradiuseapconf>
+      <config>
+        <ssl_ca_cert>5a04208c70f14</ssl_ca_cert>
+        <ssl_server_cert>5a04208c7c65a</ssl_server_cert>
+      </config>
+    </freeradiuseapconf>
+    <pfblockerngdnsbleasylist>
+      <config>
+        <aliasname />
+        <description />
+        <row>
+          <state>Enabled</state>
+          <url>https://example.com/easylist_noelemhide.txt</url>
+          <header>HZ</header>
+          <easycat>eap,aa,aap</easycat>
+        </row>
+        <action>unbound</action>
+        <cron>EveryDay</cron>
+        <dow>1</dow>
+        <filter_alexa />
+      </config>
+    </pfblockerngdnsbleasylist>
+    <frrbgp>
+      <config>
+        <enable>on</enable>
+        <adjacencylog />
+        <asnum>65002</asnum>
+        <routerid />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_updatedelay />
+        <timers_peerwait />
+        <redistributeconnectedsubnets>no</redistributeconnectedsubnets>
+        <redistributestatic>no</redistributestatic>
+        <redistributekernel>no</redistributekernel>
+        <redistributeospf>no</redistributeospf>
+        <row>
+          <distributeroutevalue>192.168.125.0/24</distributeroutevalue>
+          <distributeroutemap>none</distributeroutemap>
+        </row>
+      </config>
+    </frrbgp>
+    <frrbgpneighbors>
+      <config>
+        <peer>XXX.XXX.XXX.XXX</peer>
+        <descr />
+        <peergroup>none</peergroup>
+        <password />
+        <password_type>none</password_type>
+        <asnum>65001</asnum>
+        <updatesource_type>ipv4</updatesource_type>
+        <updatesource>default</updatesource>
+        <defaultoriginate>no</defaultoriginate>
+        <sendcommunity>disabled</sendcommunity>
+        <nexthopself>disabled</nexthopself>
+        <softreconfigurationinbound />
+        <timers_keepalive />
+        <timers_holdtime />
+        <timers_connect />
+        <distribute_in>none</distribute_in>
+        <distribute_out>none</distribute_out>
+        <prefixfilter_in>none</prefixfilter_in>
+        <prefixfilter_out>none</prefixfilter_out>
+        <aspathfilter_in>none</aspathfilter_in>
+        <aspathfilter_out>none</aspathfilter_out>
+        <routemap_in>none</routemap_in>
+        <routemap_out>none</routemap_out>
+        <unsuppressmap>none</unsuppressmap>
+        <weight />
+        <passive />
+        <addpathtxallpaths />
+        <addpathtxbestpathperas />
+        <advertisementinterval />
+        <allowasin>disabled</allowasin>
+        <asoverride />
+        <attributeunchanged />
+        <attributeunchanged_aspath />
+        <attributeunchanged_med />
+        <attributeunchanged_nexthop />
+        <bfd_multiplier />
+        <bfd_minrx />
+        <bfd_mintx />
+        <capability>disabled</capability>
+        <dontcapabilitynegotiate />
+        <overridecapability />
+        <ttlsecurityhops />
+        <disableconnectedcheck />
+        <ebgpmultihop />
+        <enforcemultihop />
+        <localas_num />
+        <localas_noprepend />
+        <localas_replaceas />
+        <maximumprefix_num />
+        <maximumprefix_threshold />
+        <maximumprefix_warnonly />
+        <maximumprefix_restart />
+        <removeprivateas />
+        <removeprivateas_all />
+        <removeprivateas_replace />
+        <routeclient_reflector />
+        <routeclient_server />
+        <solo />
+      </config>
+    </frrbgpneighbors>
+    <frr>
+      <config>
+        <enable>on</enable>
+        <password>[REDACTED]</password>
+        <carpstatusvid>none</carpstatusvid>
+        <logging />
+        <routerid />
+        <row>
+          <routevalue />
+          <routetarget>none</routetarget>
+        </row>
+      </config>
+    </frr>
+    <ntopng>
+      <config>
+        <enable>on</enable>
+        <keepdata>on</keepdata>
+        <redis_password>[REDACTED]</redis_password>
+        <redis_passwordagain>[REDACTED]</redis_passwordagain>
+        <interface_array>lan</interface_array>
+        <interface_array>opt1</interface_array>
+        <interface_array>wan</interface_array>
+        <dns_mode>0</dns_mode>
+        <disable_alerts />
+        <local_networks>rfc1918</local_networks>
+        <row>
+          <cidr />
+        </row>
+      </config>
+    </ntopng>
+    <pfblockerngreputation>
+      <config />
+    </pfblockerngreputation>
+    <pfblockerngipsettings>
+      <config>
+        <enable_dup>on</enable_dup>
+        <enable_agg />
+        <suppression />
+        <enable_log>on</enable_log>
+        <maxmind_locale>en</maxmind_locale>
+        <database_cc />
+        <inbound_interface>wan</inbound_interface>
+        <inbound_deny_action>block</inbound_deny_action>
+        <outbound_interface>lan</outbound_interface>
+        <outbound_deny_action>reject</outbound_deny_action>
+        <enable_float />
+        <pass_order>order_0</pass_order>
+        <autorule_suffix>autorule</autorule_suffix>
+        <killstates />
+      </config>
+    </pfblockerngipsettings>
+    <squidguarddest>
+      <config>
+        <name>my</name>
+        <domains />
+        <urls />
+        <expressions />
+        <redirect_mode>rmod_none</redirect_mode>
+        <redirect />
+        <description />
+        <enablelog />
+      </config>
+    </squidguarddest>
+    <squid>
+      <config>
+        <enable_squid>on</enable_squid>
+        <keep_squid_data>on</keep_squid_data>
+        <active_interface>lan,lo0</active_interface>
+        <proxy_port>3128</proxy_port>
+        <icp_port />
+        <allow_interface>on</allow_interface>
+        <dns_v4_first />
+        <disable_pinger />
+        <dns_nameservers />
+        <transparent_proxy>on</transparent_proxy>
+        <transparent_active_interface>lan</transparent_active_interface>
+        <private_subnet_proxy_off />
+        <defined_ip_proxy_off />
+        <defined_ip_proxy_off_dest />
+        <ssl_proxy>on</ssl_proxy>
+        <sslproxy_mitm_mode>spliceall</sslproxy_mitm_mode>
+        <ssl_active_interface>lan</ssl_active_interface>
+        <ssl_proxy_port />
+        <sslproxy_compatibility_mode>modern</sslproxy_compatibility_mode>
+        <dhparams_size>2048</dhparams_size>
+        <dca>5b5f09f433185</dca>
+        <sslcrtd_children />
+        <interception_checks />
+        <interception_adapt />
+        <log_enabled>on</log_enabled>
+        <log_dir>/var/squid/logs</log_dir>
+        <log_rotate>7</log_rotate>
+        <log_sqd />
+        <visible_hostname>localhost</visible_hostname>
+        <admin_email>admin@localhost</admin_email>
+        <error_language>en</error_language>
+        <xforward_mode>delete</xforward_mode>
+        <disable_via>on</disable_via>
+        <uri_whitespace>strip</uri_whitespace>
+        <disable_squidversion>on</disable_squidversion>
+        <custom_options />
+        <custom_options_squid3 />
+        <custom_options2_squid3 />
+        <custom_options3_squid3 />
+      </config>
+    </squid>
+  </installedpackages>
+  <virtualip>
+    <vip>
+      <interface>lan</interface>
+      <descr>pfB DNSBL - DO NOT EDIT</descr>
+      <type>single</type>
+      <subnet_bits>32</subnet_bits>
+      <subnet>XXX.XXX.XXX.XXX</subnet>
+      <mode>ipalias</mode>
+    </vip>
+  </virtualip>
+  <dyndnses />
+  <ca>
+    <refid>5a030f8debd96</refid>
+    <descr>OpenVPNCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <serial>0</serial>
+  </ca>
+  <ca>
+    <refid>5a04208c70f14</refid>
+    <descr>FreeRADIUS CA</descr>
+    <serial>1</serial>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+  </ca>
+  <ca>
+    <refid>5b5f09f433185</refid>
+    <descr>SquidProxyCA</descr>
+    <crt>[REDACTED_CERT_OR_KEY]</crt>
+    <prv>[REDACTED]</prv>
+    <serial>0</serial>
+  </ca>
+  <dhcrelay>
+    <interface>lan</interface>
+    <server />
+  </dhcrelay>
+  <ezshaper>
+    <step1>
+      <numberofconnections>1</numberofconnections>
+      <numberoflocalinterfaces>1</numberoflocalinterfaces>
+    </step1>
+    <step2>
+      <local0downloadscheduler>CBQ</local0downloadscheduler>
+      <local0interface>lan</local0interface>
+      <conn0uploadscheduler>CBQ</conn0uploadscheduler>
+      <conn0upload>100</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+      <conn0download>100</conn0download>
+      <conn0downloadspeed>Mb</conn0downloadspeed>
+      <conn0interface>wan</conn0interface>
+    </step2>
+    <step3>
+      <address>XXX.XXX.XXX.XXX</address>
+      <enable>on</enable>
+      <provider>Generic</provider>
+      <local0download>4</local0download>
+      <local0downloadspeed>Mb</local0downloadspeed>
+      <conn0upload>4</conn0upload>
+      <conn0uploadspeed>Mb</conn0uploadspeed>
+    </step3>
+  </ezshaper>
+  <mailreports>
+    <schedule>
+      <descr>as</descr>
+      <frequency>daily</frequency>
+      <timeofday>0</timeofday>
+      <submit>Save</submit>
+      <schedule_friendly>Daily at 00:00</schedule_friendly>
+    </schedule>
+  </mailreports>
+</pfsense>

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,6 +32,11 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # Cyclomatic complexity is a hard gate for the package itself. Every
+        # function was brought under 10; without a blocking check that decays.
+        # Scoped to pfsense_redactor/ deliberately - the tests carry pre-existing
+        # style findings that are a separate concern.
+        flake8 pfsense_redactor/ --count --select=C901 --max-complexity=10 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -295,6 +295,22 @@ RFC_DOC_NETWORKS_V4: tuple[IPNetwork, ...] = (
 RFC_DOC_NETWORK_V6: IPNetwork = ipaddress.ip_network('2001:db8::/32')
 
 
+def _has_mixed_character_classes(compact: str, hex_only: bool) -> bool:
+    """Check a candidate blob mixes character classes rather than being uniform
+
+    A long run of a single class - a numeric ID, or a lowercase word - is far
+    more likely to be ordinary content than encoded key material. Hex strings
+    get a looser rule since they cannot contain much variety by definition.
+    """
+    has_digit = any(c.isdigit() for c in compact)
+    has_upper = any(c.isupper() for c in compact)
+    has_lower = any(c.islower() for c in compact)
+
+    if hex_only:
+        return has_digit and (has_upper or has_lower)
+    return has_digit + has_upper + has_lower >= 2
+
+
 def is_rfc_documentation_ip(ip: IPAddress) -> bool:
     """Check whether an address is in a reserved documentation range
 
@@ -1757,14 +1773,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if not (BASE64ISH_RE.match(compact) or HEXISH_RE.match(compact)):
             return False
 
-        # Require some mix of character classes so that long runs of a single
-        # class (e.g. a numeric ID, or a lowercase-only word) are not flagged.
-        has_digit = any(c.isdigit() for c in compact)
-        has_upper = any(c.isupper() for c in compact)
-        has_lower = any(c.islower() for c in compact)
-        if HEXISH_RE.match(compact):
-            return has_digit and (has_upper or has_lower)
-        return has_digit + has_upper + has_lower >= 2
+        return _has_mixed_character_classes(compact, hex_only=bool(HEXISH_RE.match(compact)))
 
     def _redact_blob_text_element(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Scan opaque free-text containers for inline credentials
@@ -1963,6 +1972,40 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                     element.attrib[attr], redact_ips, redact_domains
                 )
 
+    def _redact_element_text(
+        self, tag: str, tag_base: str, element: ET.Element,
+        redact_ips: bool, redact_domains: bool
+    ) -> bool:
+        """Run the text-content passes. Returns whether the text was handled
+
+        The return value gates the later passes, so a pass that fully rewrote
+        the text stops a subsequent one from processing it again. Order matters:
+        the URL pass runs last and only on text nothing else claimed.
+        """
+        # Opaque free-text containers (custom_options, upsd_users, ...) that
+        # carry credentials inline rather than in dedicated elements
+        handled = self._redact_blob_text_element(tag, tag_base, element)
+
+        # Descriptions/identifiers - opt-in via --redact-descriptions
+        if self._redact_description_element(tag, tag_base, element):
+            handled = True
+
+        # Unrecognised high-entropy leaf values (third-party package fields)
+        if self._redact_unknown_blob_element(tag, element):
+            handled = True
+
+        if self._redact_ip_containing_element(tag, tag_base, element, redact_ips, redact_domains):
+            handled = True
+
+        # Credentials embedded in URLs in elements that are not known URL
+        # carriers (e.g. <updateurl>, <webhook_url>). Previously these were
+        # only touched under --aggressive, so the token survived by default.
+        # Host anonymisation deliberately stays out of the default path here.
+        if element.text and not handled and '://' in element.text:
+            element.text = self._redact_url_secrets_only(element.text)
+
+        return handled
+
     def redact_element(self, element: ET.Element, redact_ips: bool = True, redact_domains: bool = True) -> None:
         """Recursively redact sensitive information from XML element"""
 
@@ -1985,28 +2028,9 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # Handle cert/key elements (don't return - continue to process children)
         self._redact_cert_key_element(tag, tag_base, element)
 
-        # Opaque free-text containers (custom_options, upsd_users, ...) that
-        # carry credentials inline rather than in dedicated elements
-        text_already_processed = self._redact_blob_text_element(tag, tag_base, element)
-
-        # Descriptions/identifiers - opt-in via --redact-descriptions
-        if self._redact_description_element(tag, tag_base, element):
-            text_already_processed = True
-
-        # Unrecognised high-entropy leaf values (third-party package fields)
-        if self._redact_unknown_blob_element(tag, element):
-            text_already_processed = True
-
-        # Track whether we already processed text to avoid double processing in aggressive mode
-        if self._redact_ip_containing_element(tag, tag_base, element, redact_ips, redact_domains):
-            text_already_processed = True
-
-        # Credentials embedded in URLs in elements that are not known URL
-        # carriers (e.g. <updateurl>, <webhook_url>). Previously these were
-        # only touched under --aggressive, so the token survived by default.
-        # Host anonymisation deliberately stays out of the default path here.
-        if element.text and not text_already_processed and '://' in element.text:
-            element.text = self._redact_url_secrets_only(element.text)
+        text_already_processed = self._redact_element_text(
+            tag, tag_base, element, redact_ips, redact_domains
+        )
 
         # Redact attributes with sensitive names
         self._redact_sensitive_attributes(element)
@@ -2447,28 +2471,47 @@ def validate_file_path(
             return False, "Path contains directory traversal components (..)", None
 
         resolved, is_absolute_form = _resolve_for_validation(file_path, path)
-        resolved_str = str(resolved).lower()
 
-        # Check if resolved path is in a sensitive directory FIRST
-        # This is the critical security check - do it before the absolute path check
-        # so that even with --allow-absolute-paths, we still block sensitive dirs
-        if is_output and _is_in_sensitive_directory(resolved_str, sensitive_dirs):
-            return False, f"Cannot write to sensitive system directory: {resolved}", None
-
-        # Check if absolute path is allowed (after sensitive dir check)
-        # Allow absolute paths to safe locations (like temp dirs, home, cwd)
-        if is_absolute_form and not allow_absolute:
-            if not _is_safe_absolute_location(resolved_str):
-                return False, f"Absolute paths not allowed (use --allow-absolute-paths): {file_path}", None
-
-        # Additional check: ensure we're not trying to write to system config files
-        if is_output and resolved_str in DANGEROUS_OUTPUT_FILES:
-            return False, f"Cannot write to system configuration file: {resolved}", None
+        # ORDER IS SECURITY-CRITICAL and is asserted by _resolved_path_error:
+        # the sensitive-directory check must run before the absolute-path check,
+        # so --allow-absolute-paths cannot be used to write into a protected
+        # directory.
+        error = _resolved_path_error(
+            file_path, resolved, is_absolute_form, allow_absolute, is_output, sensitive_dirs
+        )
+        if error:
+            return False, error, None
 
         return True, "", resolved
 
     except (OSError, RuntimeError, ValueError) as e:
         return False, f"Error validating path: {e}", None
+
+
+def _resolved_path_error(
+    file_path: str, resolved: Path, is_absolute_form: bool, allow_absolute: bool,
+    is_output: bool, sensitive_dirs: frozenset[str]
+) -> str | None:
+    """Return the first failure among the resolved-path checks, else None
+
+    Checks run in this order deliberately:
+    1. sensitive directory - must precede the absolute check so that
+       --allow-absolute-paths still cannot reach a protected directory
+    2. absolute path outside the safe locations
+    3. specific system configuration files
+    """
+    resolved_str = str(resolved).lower()
+
+    if is_output and _is_in_sensitive_directory(resolved_str, sensitive_dirs):
+        return f"Cannot write to sensitive system directory: {resolved}"
+
+    if is_absolute_form and not allow_absolute and not _is_safe_absolute_location(resolved_str):
+        return f"Absolute paths not allowed (use --allow-absolute-paths): {file_path}"
+
+    if is_output and resolved_str in DANGEROUS_OUTPUT_FILES:
+        return f"Cannot write to system configuration file: {resolved}"
+
+    return None
 
 
 
@@ -2479,8 +2522,8 @@ def validate_file_path(
 def _build_arg_parser(version: str) -> argparse.ArgumentParser:
     """Construct the CLI parser
 
-    Separated from main() purely for size: 25 add_argument calls with no
-    branching, which dominated main's statement count.
+    Split into groups by _add_*_arguments helpers: 25 add_argument calls in
+    one function exceeded the 50-line method limit Codacy enforces.
     """
     parser = argparse.ArgumentParser(
         description='Redact sensitive information from pfSense XML configuration files',
@@ -2517,8 +2560,20 @@ CDATA sections are not preserved.
     parser.add_argument('--check-version', action='store_true',
                         help='Check for updates from PyPI')
 
+    _add_io_arguments(parser)
+    _add_redaction_arguments(parser)
+    _add_output_arguments(parser)
+    _add_allowlist_arguments(parser)
+    return parser
+
+
+def _add_io_arguments(parser: argparse.ArgumentParser) -> None:
+    """Positional input/output paths"""
     parser.add_argument('input', nargs='?', help='Input pfSense config.xml file (required unless --check-version is used)')
     parser.add_argument('output', nargs='?', help='Output redacted config.xml file')
+
+def _add_redaction_arguments(parser: argparse.ArgumentParser) -> None:
+    """Flags controlling what gets redacted and how"""
     parser.add_argument('--no-redact-ips', action='store_true',
                         help='Do not redact IP addresses')
     parser.add_argument('--no-redact-domains', action='store_true',
@@ -2529,6 +2584,9 @@ CDATA sections are not preserved.
                         help='When used with --anonymise, do NOT keep private IPs visible.')
     parser.add_argument('--anonymise', action='store_true',
                         help='Use consistent aliases (IP_1, domain1.example) to preserve topology. Implies --keep-private-ips unless --no-keep-private-ips is specified')
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    """Flags controlling where output goes and how noisy the run is"""
     parser.add_argument('--dry-run', action='store_true',
                         help='Show what would be redacted without writing output')
     parser.add_argument('--stdout', action='store_true',
@@ -2545,6 +2603,9 @@ CDATA sections are not preserved.
                         help='Show detailed debug information')
     parser.add_argument('--fail-on-warn', action='store_true',
                         help='Exit with non-zero code if root tag is not pfsense (useful in CI)')
+
+def _add_allowlist_arguments(parser: argparse.ArgumentParser) -> None:
+    """Allow-list sources and the remaining opt-in redaction flags"""
     parser.add_argument('--allowlist-ip', action='append', dest='allowlist_ips', metavar='IP_OR_CIDR',
                         help='IP or CIDR to never redact (repeatable). Applies to both raw text and URLs.')
     parser.add_argument('--allowlist-domain', action='append', dest='allowlist_domains', metavar='DOMAIN',
@@ -2561,7 +2622,7 @@ CDATA sections are not preserved.
                         help='Redact free-text descriptions and identifiers (descr, detail, hostname, ssid). These often contain personal names, e.g. DHCP static-map descriptions. Off by default as they aid troubleshooting.')
     parser.add_argument('--allow-absolute-paths', action='store_true',
                         help='Allow absolute file paths (e.g., /etc/passwd, C:\\config.xml). By default, only relative paths are permitted for security. Use with caution.')
-    return parser
+
 
 
 def _resolve_input_path(
@@ -2614,47 +2675,42 @@ def _resolve_output_path(
     args: argparse.Namespace, sensitive_dirs: frozenset[str], logger: logging.Logger
 ) -> None:
     """Validate the output path, including the extra --inplace checks"""
-    # Validate output file path (if applicable)
-    # Skip validation in dry-run mode since we won't actually write
-    if args.output and not args.stdout and not args.dry_run:
-        output_valid, output_error, output_resolved = validate_file_path(
-            args.output,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,
-            sensitive_dirs=sensitive_dirs
+    # Validated whenever the path will be used. The only skipped case is
+    # --stdout without --dry-run, where args.output is never written.
+    if args.output and (args.dry_run or not args.stdout):
+        resolved = _validate_as_output_target(
+            args.output, args, sensitive_dirs, logger,
+            "[!] Error: Invalid output path: %s"
         )
-        if not output_valid:
-            logger.error("[!] Error: Invalid output path: %s", output_error)
-            sys.exit(1)
 
-        # Check if output file exists (unless force)
-        if not args.force and output_resolved.exists():
+        # Overwrite protection applies only when a write will actually happen
+        if not args.dry_run and not args.stdout and not args.force and resolved.exists():
             logger.error("[!] Error: Output file '%s' already exists. Use --force to overwrite.", args.output)
             sys.exit(1)
-    elif args.dry_run and args.output:
-        # In dry-run mode, still validate the output path for security
-        output_valid, output_error, _ = validate_file_path(
-            args.output,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,
-            sensitive_dirs=sensitive_dirs
-        )
-        if not output_valid:
-            logger.error("[!] Error: Invalid output path: %s", output_error)
-            sys.exit(1)
 
-    # Validate inplace mode - extra security check
+    # --inplace rewrites the input, so re-validate it under output rules
     if args.inplace:
-        # Re-validate input path with output restrictions
-        inplace_valid, inplace_error, _ = validate_file_path(
-            args.input,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,  # Treat as output for stricter checks
-            sensitive_dirs=sensitive_dirs
+        _validate_as_output_target(
+            args.input, args, sensitive_dirs, logger,
+            "[!] Error: Cannot use --inplace with this file: %s"
         )
-        if not inplace_valid:
-            logger.error("[!] Error: Cannot use --inplace with this file: %s", inplace_error)
-            sys.exit(1)
+
+
+def _validate_as_output_target(
+    candidate: str, args: argparse.Namespace, sensitive_dirs: frozenset[str],
+    logger: logging.Logger, error_template: str
+) -> Path:
+    """Validate a path under output rules, exiting on failure. Returns resolved"""
+    valid, error, resolved = validate_file_path(
+        candidate,
+        allow_absolute=args.allow_absolute_paths,
+        is_output=True,
+        sensitive_dirs=sensitive_dirs
+    )
+    if not valid:
+        logger.error(error_template, error)
+        sys.exit(1)
+    return resolved
 
 
 def _resolve_keep_private_ips(args: argparse.Namespace) -> bool:
@@ -2741,6 +2797,50 @@ def _add_cli_allowlist_ip(
     sys.exit(1)
 
 
+def _handle_early_exit_flags(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Handle argument combinations that exit before any redaction happens"""
+    if not args.check_version and not args.input:
+        parser.error("the following arguments are required: input")
+
+    if args.check_version:
+        from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
+
+        setup_logging(logging.INFO, use_stderr=False)
+        success = print_version_check(verbose=False)
+        sys.exit(0 if success else 1)
+
+    if args.quiet and args.verbose:
+        parser.error("--quiet and --verbose are mutually exclusive")
+
+
+def _configure_logging_from_args(args: argparse.Namespace) -> None:
+    """Set up logging at the verbosity the flags ask for
+
+    --stdout routes everything to stderr so the redacted XML on stdout stays
+    machine-readable.
+    """
+    if args.verbose:
+        log_level = logging.DEBUG
+    elif args.quiet:
+        log_level = logging.WARNING
+    else:
+        log_level = logging.INFO
+
+    setup_logging(log_level, use_stderr=args.stdout)
+
+
+def _apply_argument_defaults(args: argparse.Namespace) -> None:
+    """Fill in values implied by other flags, before any validation"""
+    # --dry-run-verbose is a louder --dry-run
+    if args.dry_run_verbose:
+        args.dry_run = True
+
+    # Auto-generate output filename when one is needed but not given
+    if not args.stdout and not args.inplace and not args.dry_run and not args.output:
+        input_path = Path(args.input)
+        args.output = str(input_path.parent / f"{input_path.stem}-redacted{input_path.suffix}")
+
+
 def main() -> None:
     """Main entry point for the pfSense redactor CLI"""
     # Version for the --version flag. Resolved rather than imported directly so
@@ -2751,47 +2851,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Validate required arguments for normal operation
-    if not args.check_version and not args.input:
-        parser.error("the following arguments are required: input")
-
-    # Handle --check-version flag
-    if args.check_version:
-        # Import version checker
-        from .version_checker import print_version_check
-
-        # Setup basic logging for version check
-        setup_logging(logging.INFO, use_stderr=False)
-
-        # Run version check and exit
-        success = print_version_check(verbose=False)
-        sys.exit(0 if success else 1)
-
-    # Validate mutually exclusive flags
-    if args.quiet and args.verbose:
-        parser.error("--quiet and --verbose are mutually exclusive")
-
-    # Determine log level
-    if args.verbose:
-        log_level = logging.DEBUG
-    elif args.quiet:
-        log_level = logging.WARNING
-    else:
-        log_level = logging.INFO
-
-    # Setup logging (route to stderr when using --stdout)
-    use_stderr = args.stdout
-    setup_logging(log_level, use_stderr)
-
-    # Handle --dry-run-verbose
-    if args.dry_run_verbose:
-        args.dry_run = True
-
-    # Default output filename if not specified
-    if not args.stdout and not args.inplace and not args.dry_run and not args.output:
-        # Auto-generate output filename: input-redacted.xml
-        input_path = Path(args.input)
-        args.output = str(input_path.parent / f"{input_path.stem}-redacted{input_path.suffix}")
+    _handle_early_exit_flags(args, parser)
+    _configure_logging_from_args(args)
+    _apply_argument_defaults(args)
 
     # Get logger for error messages
     logger = logging.getLogger('pfsense_redactor')

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -267,6 +267,22 @@ FILE_EXTENSIONS: frozenset[str] = frozenset({
 # content, so a placeholder can only ever be one this module wrote.
 URL_PLACEHOLDER_RE = re.compile(r'\x00URL(\d+)\x00')
 
+# Summary lines, in print order. Labels are parsed by the StatsParser fixture in
+# tests/conftest.py, so the text must not change.
+STAT_LABELS: tuple[tuple[str, str], ...] = (
+    ('secrets_redacted', 'Passwords/keys/secrets'),
+    ('certs_redacted', 'Certificates'),
+    ('ips_redacted', 'IP addresses'),
+    ('macs_redacted', 'MAC addresses'),
+    ('domains_redacted', 'Domain names'),
+    ('emails_redacted', 'Email addresses'),
+    ('urls_redacted', 'URLs'),
+    ('url_secrets_redacted', 'Secrets in URL paths/queries'),
+)
+
+# Sample categories, in the order they are printed for --dry-run-verbose.
+SAMPLE_CATEGORIES: tuple[str, ...] = ('IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key')
+
 # Documentation ranges reserved for examples: RFC 5737 (IPv4) and RFC 3849
 # (IPv6). In anonymise mode these are the values this tool generates, so seeing
 # one means it has already been masked. Built once at import rather than per
@@ -433,6 +449,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     CERT_MIN_LENGTH: int = 50  # Minimum length to treat text as certificate/key blob
     KEY_BLOB_MIN_LENGTH: int = 64  # Minimum length to treat <key> content as PEM blob
     KEY_SHORT_THRESHOLD: int = 40  # Threshold for short key detection (alphanumeric check)
+    RETAINED_PATHS_SHOWN: int = 10  # Max retained high-entropy paths listed in the summary
 
     # Each argument is an independent, user-facing redaction policy toggle
     # mapped 1:1 from a CLI flag; grouping them into a config object would add
@@ -2063,57 +2080,63 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         """Print redaction statistics using logger"""
         self.logger.info("")
         self.logger.info("[+] Redaction summary:")
-        if self.stats['secrets_redacted']:
-            self.logger.info("    - Passwords/keys/secrets: %d", self.stats['secrets_redacted'])
-        if self.stats['certs_redacted']:
-            self.logger.info("    - Certificates: %d", self.stats['certs_redacted'])
-        if self.stats['ips_redacted']:
-            self.logger.info("    - IP addresses: %d", self.stats['ips_redacted'])
-        if self.stats['macs_redacted']:
-            self.logger.info("    - MAC addresses: %d", self.stats['macs_redacted'])
-        if self.stats['domains_redacted']:
-            self.logger.info("    - Domain names: %d", self.stats['domains_redacted'])
-        if self.stats['emails_redacted']:
-            self.logger.info("    - Email addresses: %d", self.stats['emails_redacted'])
-        if self.stats['urls_redacted']:
-            self.logger.info("    - URLs: %d", self.stats['urls_redacted'])
-        if self.stats['url_secrets_redacted']:
-            self.logger.info("    - Secrets in URL paths/queries: %d", self.stats['url_secrets_redacted'])
+        for key, label in STAT_LABELS:
+            if self.stats[key]:
+                self.logger.info("    - %s: %d", label, self.stats[key])
 
-        # Surface values we deliberately did NOT redact so they can be checked
-        # manually - the summary otherwise only reports what was redacted,
-        # which makes retained secrets impossible to audit.
-        if self.stats['high_entropy_retained']:
-            self.logger.warning("")
+        self._print_retained_warning()
+        self._print_anonymisation_stats()
+        self._print_samples()
+
+    def _print_retained_warning(self) -> None:
+        """Report high-entropy values that were deliberately not redacted
+
+        The summary otherwise only reports what was redacted, which makes
+        retained secrets impossible to audit before sharing.
+        """
+        if not self.stats['high_entropy_retained']:
+            return
+
+        self.logger.warning("")
+        self.logger.warning(
+            "[!] %d unrecognised high-entropy value(s) retained. Review before sharing:",
+            self.stats['high_entropy_retained']
+        )
+        for path in self.high_entropy_paths[:self.RETAINED_PATHS_SHOWN]:
+            self.logger.warning("    - %s", path)
+        if len(self.high_entropy_paths) > self.RETAINED_PATHS_SHOWN:
             self.logger.warning(
-                "[!] %d unrecognised high-entropy value(s) retained. Review before sharing:",
-                self.stats['high_entropy_retained']
+                "    - ... and %d more",
+                len(self.high_entropy_paths) - self.RETAINED_PATHS_SHOWN
             )
-            for path in self.high_entropy_paths[:10]:
-                self.logger.warning("    - %s", path)
-            if len(self.high_entropy_paths) > 10:
-                self.logger.warning("    - ... and %d more", len(self.high_entropy_paths) - 10)
-            self.logger.warning("    Re-run with --aggressive to redact these automatically.")
+        self.logger.warning("    Re-run with --aggressive to redact these automatically.")
 
-        if self.anonymise:
-            self.logger.info("")
-            self.logger.info("[+] Anonymisation stats:")
-            self.logger.info("    - Unique IPs anonymised: %d", len(self.ip_aliases))
-            self.logger.info("    - Unique domains anonymised: %d", len(self.domain_aliases))
+    def _print_anonymisation_stats(self) -> None:
+        """Report how many unique identifiers were aliased"""
+        if not self.anonymise:
+            return
 
-        # Print samples if in dry-run-verbose mode
-        if self.dry_run_verbose:
-            self.logger.info("")
-            self.logger.info("[+] Samples of changes (limit N=%d):", self.sample_limit)
-            has_any = any(self.samples.get(cat) for cat in ['IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key'])
-            if has_any:
-                # Print in consistent order
-                for category in ['IP', 'URL', 'FQDN', 'MAC', 'Secret', 'Cert/Key']:
-                    if category in self.samples and self.samples[category]:
-                        for before_masked, after in self.samples[category]:
-                            self.logger.info("    %s: %s -> %s", category, before_masked, after)
-            else:
-                self.logger.info("    (no examples collected)")
+        self.logger.info("")
+        self.logger.info("[+] Anonymisation stats:")
+        self.logger.info("    - Unique IPs anonymised: %d", len(self.ip_aliases))
+        self.logger.info("    - Unique domains anonymised: %d", len(self.domain_aliases))
+
+    def _print_samples(self) -> None:
+        """Print masked before/after examples for --dry-run-verbose"""
+        if not self.dry_run_verbose:
+            return
+
+        self.logger.info("")
+        self.logger.info("[+] Samples of changes (limit N=%d):", self.sample_limit)
+
+        printed = False
+        for category in SAMPLE_CATEGORIES:
+            for before_masked, after in self.samples.get(category) or ():
+                self.logger.info("    %s: %s -> %s", category, before_masked, after)
+                printed = True
+
+        if not printed:
+            self.logger.info("    (no examples collected)")
 
 
 # ==========================================================================

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -819,34 +819,34 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             str: RFC documentation IP address or fallback private IP
         """
         if is_ipv6:
-            # RFC 3849: 2001:db8::/32
-            # Map counter to last hextet (1..65535)
-            if counter <= 0xFFFF:
-                return f"2001:db8::{counter:x}"
+            return self._counter_to_rfc_ipv6(counter)
+        return self._counter_to_rfc_ipv4(counter)
 
-            # IPv6 overflow: use RFC 4193 Unique Local Addresses (ULA)
-            # fd00::/8 range for overflow addresses
-            # Log warning on first overflow
-            if counter == 0xFFFF + 1:
-                self.logger.warning(
-                    "[!] Warning: Exceeded RFC 3849 IPv6 limit (65535 addresses). "
-                    "Using RFC 4193 ULA range (fd00::/8) for additional addresses."
-                )
+    def _counter_to_rfc_ipv6(self, counter: int) -> str:
+        """Map a counter into RFC 3849 (2001:db8::/32), then RFC 4193 on overflow"""
+        # Map counter to last hextet (1..65535)
+        if counter <= 0xFFFF:
+            return f"2001:db8::{counter:x}"
 
-            # Map overflow to fd00::/8 range
-            # overflow 1 (counter 65536) -> fd00::0:1
-            # overflow 65536 (counter 131071) -> fd00::1:0
-            overflow = counter - 0xFFFF
-            hextet3 = ((overflow - 1) % 0x10000) + 1
-            hextet2 = (overflow - 1) // 0x10000
-            return f"fd00::{hextet2:x}:{hextet3:x}"
+        # IPv6 overflow: use RFC 4193 Unique Local Addresses (ULA)
+        # fd00::/8 range for overflow addresses
+        # Log warning on first overflow
+        if counter == 0xFFFF + 1:
+            self.logger.warning(
+                "[!] Warning: Exceeded RFC 3849 IPv6 limit (65535 addresses). "
+                "Using RFC 4193 ULA range (fd00::/8) for additional addresses."
+            )
 
-        # RFC 5737 IPv4 documentation ranges (762 total addresses):
-        # - 192.0.2.0/24 (TEST-NET-1): 254 usable (.1 to .254)
-        # - 198.51.100.0/24 (TEST-NET-2): 254 usable (.1 to .254)
-        # - 203.0.113.0/24 (TEST-NET-3): 254 usable (.1 to .254)
+        # Map overflow to fd00::/8 range
+        # overflow 1 (counter 65536) -> fd00::0:1
+        # overflow 65536 (counter 131071) -> fd00::1:0
+        overflow = counter - 0xFFFF
+        hextet3 = ((overflow - 1) % 0x10000) + 1
+        hextet2 = (overflow - 1) // 0x10000
+        return f"fd00::{hextet2:x}:{hextet3:x}"
 
-        # Log warnings at approach thresholds
+    def _warn_ipv4_limit(self, counter: int) -> None:
+        """Warn as the RFC 5737 pool is approached and exhausted"""
         if counter == 700:
             self.logger.warning(
                 "[!] Warning: Approaching RFC 5737 IPv4 limit (700/762 addresses used). "
@@ -861,6 +861,16 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 "[!] Warning: Reached RFC 5737 IPv4 limit (762/762 addresses used). "
                 "Next IP will use RFC 1918 private range."
             )
+
+    def _counter_to_rfc_ipv4(self, counter: int) -> str:
+        """Map a counter into the RFC 5737 ranges, then RFC 1918 on overflow
+
+        RFC 5737 IPv4 documentation ranges (762 total addresses):
+        - 192.0.2.0/24 (TEST-NET-1): 254 usable (.1 to .254)
+        - 198.51.100.0/24 (TEST-NET-2): 254 usable (.1 to .254)
+        - 203.0.113.0/24 (TEST-NET-3): 254 usable (.1 to .254)
+        """
+        self._warn_ipv4_limit(counter)
 
         if counter <= 254:
             # First range: 192.0.2.1 to 192.0.2.254

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -267,6 +267,29 @@ FILE_EXTENSIONS: frozenset[str] = frozenset({
 # content, so a placeholder can only ever be one this module wrote.
 URL_PLACEHOLDER_RE = re.compile(r'\x00URL(\d+)\x00')
 
+# Documentation ranges reserved for examples: RFC 5737 (IPv4) and RFC 3849
+# (IPv6). In anonymise mode these are the values this tool generates, so seeing
+# one means it has already been masked. Built once at import rather than per
+# call - the check runs for every IP-like token in the config.
+RFC_DOC_NETWORKS_V4: tuple[IPNetwork, ...] = (
+    ipaddress.ip_network('192.0.2.0/24'),
+    ipaddress.ip_network('198.51.100.0/24'),
+    ipaddress.ip_network('203.0.113.0/24'),
+)
+RFC_DOC_NETWORK_V6: IPNetwork = ipaddress.ip_network('2001:db8::/32')
+
+
+def is_rfc_documentation_ip(ip: IPAddress) -> bool:
+    """Check whether an address is in a reserved documentation range
+
+    Shared by the three places that need it: _mask_ip_like_tokens,
+    _is_already_masked_host and _normalise_masked_url. Each previously inlined
+    its own copy and rebuilt the network objects on every call.
+    """
+    if ip.version == 4:
+        return any(ip in net for net in RFC_DOC_NETWORKS_V4)
+    return ip in RFC_DOC_NETWORK_V6
+
 # URL path segment credential detection.
 # 20 because AWS access key IDs (AKIA...) are exactly 20 characters.
 SECRETISH_SEGMENT_MIN_LENGTH: int = 20
@@ -987,19 +1010,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return original_token
 
             # In anonymise mode, preserve RFC documentation IPs (they're our generated values)
-            if self.anonymise:
-                if ip.version == 4:
-                    rfc5737_ranges = [
-                        ipaddress.ip_network('192.0.2.0/24'),
-                        ipaddress.ip_network('198.51.100.0/24'),
-                        ipaddress.ip_network('203.0.113.0/24'),
-                    ]
-                    if any(ip in net for net in rfc5737_ranges):
-                        return original_token
-                elif ip.version == 6:
-                    rfc3849 = ipaddress.ip_network('2001:db8::/32')
-                    if ip in rfc3849:
-                        return original_token
+            if self.anonymise and is_rfc_documentation_ip(ip):
+                return original_token
 
             # Keep non-global IPs if requested (simplified test for RFC1918, ULA, loopback,
             # link-local, multicast, reserved, and unspecified addresses)
@@ -1082,23 +1094,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # In non-anonymise mode, RFC IPs in original configs should still be redacted
         if self.anonymise:
             try:
-                ip = ipaddress.ip_address(host)
-
-                # RFC 5737 IPv4 documentation ranges
-                if ip.version == 4:
-                    rfc5737_ranges = [
-                        ipaddress.ip_network('192.0.2.0/24'),
-                        ipaddress.ip_network('198.51.100.0/24'),
-                        ipaddress.ip_network('203.0.113.0/24'),
-                    ]
-                    if any(ip in net for net in rfc5737_ranges):
-                        return True
-
-                # RFC 3849 IPv6 documentation range
-                elif ip.version == 6:
-                    rfc3849 = ipaddress.ip_network('2001:db8::/32')
-                    if ip in rfc3849:
-                        return True
+                if is_rfc_documentation_ip(ipaddress.ip_address(host)):
+                    return True
             except ValueError:
                 pass  # Not an IP
 
@@ -1120,16 +1117,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # In anonymise mode, RFC documentation IPs are our own generated values
         if self.anonymise:
             try:
-                ip = ipaddress.ip_address(host)
-                if ip.version == 4:
-                    rfc5737_ranges = [
-                        ipaddress.ip_network('192.0.2.0/24'),
-                        ipaddress.ip_network('198.51.100.0/24'),
-                        ipaddress.ip_network('203.0.113.0/24'),
-                    ]
-                    keep_host = any(ip in net for net in rfc5737_ranges)
-                elif ip.version == 6:
-                    keep_host = ip in ipaddress.ip_network('2001:db8::/32')
+                keep_host = is_rfc_documentation_ip(ipaddress.ip_address(host))
             except ValueError:
                 pass  # Not an IP, continue with domain normalisation
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -996,6 +996,53 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         except ValueError:
             return token, ''
 
+    def _strip_ip_token_port(self, token: str) -> tuple[str, str]:
+        """Split a trailing port off an IP token. Returns (token, port_suffix)
+
+        Handles both unbracketed IPv4 (1.2.3.4:80) and bracketed IPv6 with an
+        optional zone identifier ([fe80::1%em0]:51820). An out-of-range or
+        non-numeric port is left attached, so the token simply fails to parse
+        as an address and is returned unchanged by the caller.
+        """
+        # IPv6 must use brackets to carry a port; only peel :port when unbracketed
+        if not token.startswith('['):
+            return self._validate_and_strip_port(token)
+
+        if ']:' not in token:
+            return token, ''
+
+        bracket_end = token.index(']:')
+        port_str = token[bracket_end + 2:]
+
+        try:
+            port_num = int(port_str)
+        except ValueError:
+            return token, ''
+
+        if not 1 <= port_num <= 65535:
+            return token, ''
+
+        return token[:bracket_end + 1], f':{port_num}'
+
+    def _should_preserve_ip(self, ip: IPAddress) -> bool:
+        """Check whether an address should be left as-is rather than masked"""
+        # Common netmasks and unspecified addresses stay readable regardless of
+        # --keep-private-ips
+        if str(ip) in self.always_preserve_ips:
+            return True
+
+        # Allow-listed IPs (opt-in, including CIDR networks)
+        if self._is_ip_allowed(ip):
+            return True
+
+        # In anonymise mode, RFC documentation IPs are our own generated values
+        if self.anonymise and is_rfc_documentation_ip(ip):
+            return True
+
+        # Non-global addresses if requested: RFC1918, ULA, loopback, link-local,
+        # multicast, reserved and unspecified
+        return self.keep_private_ips and not ip.is_global
+
     def _mask_ip_like_tokens(self, text: str) -> str:
         """IP address masking using ipaddress module"""
         def repl(token: str) -> str:
@@ -1004,55 +1051,13 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return token
             original_token = token
 
-            # Extract optional trailing :port for unbracketed tokens
-            # IPv6 must use brackets to carry a port; we only peel :port when the token contains a dot
-            port_suffix = ''
-            if not token.startswith('['):
-                token, port_suffix = self._validate_and_strip_port(token)
-
-            # Handle bracketed IPv6 with optional zone identifier and port: [fe80::1%em0]:51820
-            # This handles: [IPv6], [IPv6%zone], [IPv6]:port, [IPv6%zone]:port
-            if token.startswith('['):
-                # Pattern match for bracketed IPv6 with port
-                if ']:' in token:
-                    # Extract port from bracketed IPv6
-                    bracket_end = token.index(']:')
-                    port_str = token[bracket_end+2:]  # Port without colon
-
-                    # Validate port range for IPv6
-                    try:
-                        port_num = int(port_str)
-                        if 1 <= port_num <= 65535:
-                            # Valid port, strip and normalise
-                            port_suffix = f':{port_num}'
-                            token = token[:bracket_end+1]  # Keep just [IPv6%zone]
-                        else:
-                            # Invalid port, don't strip
-                            port_suffix = ''
-                    except ValueError:
-                        # Not a valid port number, don't strip
-                        port_suffix = ''
+            token, port_suffix = self._strip_ip_token_port(token)
 
             ip, bracketed, zone = self._parse_ip_token(token)
             if ip is None:
                 return original_token
 
-            # Always preserve common netmasks and unspecified addresses for readability
-            # (regardless of --keep-private-ips setting)
-            if str(ip) in self.always_preserve_ips:
-                return original_token
-
-            # Preserve allow-listed IPs (opt-in, including CIDR networks)
-            if self._is_ip_allowed(ip):
-                return original_token
-
-            # In anonymise mode, preserve RFC documentation IPs (they're our generated values)
-            if self.anonymise and is_rfc_documentation_ip(ip):
-                return original_token
-
-            # Keep non-global IPs if requested (simplified test for RFC1918, ULA, loopback,
-            # link-local, multicast, reserved, and unspecified addresses)
-            if self.keep_private_ips and not ip.is_global:
+            if self._should_preserve_ip(ip):
                 return original_token
 
             # Anonymisation mode

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2031,6 +2031,39 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # Insert comment as first child of root
         root.insert(0, comment)
 
+    def _check_root_tag(self, root: ET.Element) -> bool:
+        """Warn if this does not look like a pfSense config. False means abort
+
+        Namespace-robust. Only --fail-on-warn turns the warning into an abort.
+        """
+        if root.tag.rsplit('}', 1)[-1].lower() == 'pfsense':
+            return True
+
+        msg = f"[!] Warning: Root tag is '{root.tag}', expected 'pfsense'."
+        if self.fail_on_warn:
+            self.logger.error("%s Exiting.", msg)
+            return False
+
+        self.logger.warning("%s Proceeding anyway...", msg)
+        return True
+
+    def _write_output(
+        self, tree: ET.ElementTree, input_file: str, output_file: str | None,
+        stdout_mode: bool, inplace: bool
+    ) -> None:
+        """Write the redacted tree to stdout, over the input, or to a new file"""
+        if stdout_mode:
+            tree.write(sys.stdout.buffer, encoding='utf-8', xml_declaration=True)
+            return
+
+        if inplace:
+            tree.write(input_file, encoding='utf-8', xml_declaration=True)
+            self.logger.info("[+] Redacted configuration written in-place to: %s", input_file)
+            return
+
+        tree.write(output_file, encoding='utf-8', xml_declaration=True)
+        self.logger.info("[+] Redacted configuration written to: %s", output_file)
+
     def redact_config(
         self,
         input_file: str,
@@ -2047,14 +2080,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             tree = ET.parse(input_file)
             root = tree.getroot()
 
-            # G) Sanity check: ensure this is a pfSense config (namespace-robust)
-            root_tag = root.tag.rsplit('}', 1)[-1].lower()
-            if root_tag != 'pfsense':
-                msg = f"[!] Warning: Root tag is '{root.tag}', expected 'pfsense'."
-                if self.fail_on_warn:
-                    self.logger.error("%s Exiting.", msg)
-                    return False
-                self.logger.warning("%s Proceeding anyway...", msg)
+            if not self._check_root_tag(root):
+                return False
 
             if not dry_run and not stdout_mode:
                 self.logger.info("[+] Parsing XML configuration from: %s", input_file)
@@ -2076,15 +2103,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # Pretty print (Python 3.9+)
             ET.indent(tree, space="  ")
 
-            # Write redacted configuration
-            if stdout_mode:
-                tree.write(sys.stdout.buffer, encoding='utf-8', xml_declaration=True)
-            elif inplace:
-                tree.write(input_file, encoding='utf-8', xml_declaration=True)
-                self.logger.info("[+] Redacted configuration written in-place to: %s", input_file)
-            else:
-                tree.write(output_file, encoding='utf-8', xml_declaration=True)
-                self.logger.info("[+] Redacted configuration written to: %s", output_file)
+            self._write_output(tree, input_file, output_file, stdout_mode, inplace)
 
             # Print summary (always print, logger routes to correct stream)
             self._print_stats()

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -637,6 +637,31 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             pass
         return value
 
+    @staticmethod
+    def _mask_sample_host(host: str) -> str:
+        """Mask a URL host for sample display
+
+        IPv6 results are bracketed because they are substituted back into a
+        netloc, which is why this cannot simply reuse _mask_ip_sample.
+        """
+        try:
+            ip = ipaddress.ip_address(host)
+        except (ValueError, ipaddress.AddressValueError):
+            # Domain: keep the first label and the registrable tail
+            host_parts = host.split('.')
+            if len(host_parts) >= 3:
+                return f"{host_parts[0]}.***.{'.'.join(host_parts[-2:])}"
+            if len(host_parts) == 2:
+                return f"***.{host}"
+            return host
+
+        if ip.version == 4:
+            host_parts = host.split('.')
+            return f"{host_parts[0]}.{host_parts[1]}.***.{host_parts[3]}" if len(host_parts) == 4 else host
+
+        host_parts = host.split(':')
+        return f"[{host_parts[0]}:{host_parts[1]}:*:****::{host_parts[-1]}]" if len(host_parts) >= 3 else f"[{host}]"
+
     def _mask_url_sample(self, value: str) -> str:
         """Mask URL for sample display
 
@@ -652,22 +677,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             if not host:
                 return value
 
-            try:
-                ip = ipaddress.ip_address(host)
-                if ip.version == 4:
-                    host_parts = host.split('.')
-                    masked_host = f"{host_parts[0]}.{host_parts[1]}.***.{host_parts[3]}" if len(host_parts) == 4 else host
-                else:
-                    host_parts = host.split(':')
-                    masked_host = f"[{host_parts[0]}:{host_parts[1]}:*:****::{host_parts[-1]}]" if len(host_parts) >= 3 else f"[{host}]"
-            except (ValueError, ipaddress.AddressValueError):
-                host_parts = host.split('.')
-                if len(host_parts) >= 3:
-                    masked_host = f"{host_parts[0]}.***.{'.'.join(host_parts[-2:])}"
-                elif len(host_parts) == 2:
-                    masked_host = f"***.{host}"
-                else:
-                    masked_host = host
+            masked_host = self._mask_sample_host(host)
 
             userinfo = ''
             if parts.username:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -42,7 +42,7 @@ import logging
 from pathlib import Path
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Union
+from typing import NoReturn, Union
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode, SplitResult
 import os
 
@@ -2202,54 +2202,62 @@ def parse_allowlist_file(filepath: str, silent_if_missing: bool = False) -> tupl
     Returns:
         tuple: (set of IP strings, list of IP network objects, set of domains)
     """
-    ips = set()
-    networks = []
-    domains = set()
+    ips: set[str] = set()
+    networks: list[IPNetwork] = []
+    domains: set[str] = set()
 
     try:
         with open(filepath, 'r', encoding='utf-8') as file_handle:
-            for _, line in enumerate(file_handle, 1):
-                line = line.strip()
-                # Skip blank lines and comments
-                if not line or line.startswith('#'):
-                    continue
-
-                # Try to parse as IP address first
-                try:
-                    ipaddress.ip_address(line)
-                    ips.add(line)
-                    continue
-                except ValueError:
-                    pass
-
-                # Try to parse as CIDR network
-                try:
-                    network = ipaddress.ip_network(line, strict=False)
-                    networks.append(network)
-                    continue
-                except ValueError:
-                    pass
-
-                # Not an IP or CIDR, treat as domain (case-insensitive)
-                domains.add(line.lower())
+            for raw_line in file_handle:
+                _classify_allowlist_entry(raw_line.strip(), ips, networks, domains)
 
     except FileNotFoundError:
-        if not silent_if_missing:
-            logger = logging.getLogger('pfsense_redactor')
-            logger.error("[!] Error: Allow-list file '%s' not found", filepath)
-            sys.exit(1)
-        # Silent if missing for default files
-        return set(), [], set()
+        if silent_if_missing:
+            # Default allow-list files are optional
+            return set(), [], set()
+        _exit_allowlist_error("[!] Error: Allow-list file '%s' not found", filepath)
     except (IOError, OSError) as e:
-        logger = logging.getLogger('pfsense_redactor')
-        logger.error("[!] Error reading allow-list file: %s", e)
-        sys.exit(1)
+        _exit_allowlist_error("[!] Error reading allow-list file: %s", e)
     except (ValueError, UnicodeDecodeError) as e:
-        logger = logging.getLogger('pfsense_redactor')
-        logger.error("[!] Error parsing allow-list file: %s", e)
-        sys.exit(1)
+        _exit_allowlist_error("[!] Error parsing allow-list file: %s", e)
 
     return ips, networks, domains
+
+
+def _classify_allowlist_entry(
+    line: str, ips: set[str], networks: list[IPNetwork], domains: set[str]
+) -> None:
+    """Sort one stripped allow-list line into IPs, networks or domains
+
+    Blank lines and whole-line comments are ignored. Anything that parses as
+    neither an address nor a network is treated as a domain, which is why a
+    malformed entry silently becomes a domain rather than an error.
+    """
+    if not line or line.startswith('#'):
+        return
+
+    try:
+        ipaddress.ip_address(line)
+        ips.add(line)
+        return
+    except ValueError:
+        pass
+
+    try:
+        # strict=False so 10.1.2.3/8 is accepted and normalised
+        networks.append(ipaddress.ip_network(line, strict=False))
+        return
+    except ValueError:
+        pass
+
+    # Domain matching is case-insensitive
+    domains.add(line.lower())
+
+
+def _exit_allowlist_error(message: str, detail: object) -> NoReturn:
+    """Report an allow-list failure and exit non-zero"""
+    logging.getLogger('pfsense_redactor').error(message, detail)
+    sys.exit(1)
 
 
 def find_default_allowlist_files() -> list[Path]:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2466,12 +2466,12 @@ def validate_file_path(
 # ==========================================================================
 # 7. CLI
 # ==========================================================================
-def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-    """Main entry point for the pfSense redactor CLI"""
-    # Version for the --version flag. Resolved rather than imported directly so
-    # that running redactor.py as a script still reports the real version.
-    __version__ = resolve_version()
+def _build_arg_parser(version: str) -> argparse.ArgumentParser:
+    """Construct the CLI parser
 
+    Separated from main() purely for size: 25 add_argument calls with no
+    branching, which dominated main's statement count.
+    """
     parser = argparse.ArgumentParser(
         description='Redact sensitive information from pfSense XML configuration files',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -2502,7 +2502,7 @@ CDATA sections are not preserved.
         """
     )
 
-    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}',
+    parser.add_argument('--version', action='version', version=f'%(prog)s {version}',
                         help='Show program version and exit')
     parser.add_argument('--check-version', action='store_true',
                         help='Check for updates from PyPI')
@@ -2551,6 +2551,193 @@ CDATA sections are not preserved.
                         help='Redact free-text descriptions and identifiers (descr, detail, hostname, ssid). These often contain personal names, e.g. DHCP static-map descriptions. Off by default as they aid troubleshooting.')
     parser.add_argument('--allow-absolute-paths', action='store_true',
                         help='Allow absolute file paths (e.g., /etc/passwd, C:\\config.xml). By default, only relative paths are permitted for security. Use with caution.')
+    return parser
+
+
+def _resolve_input_path(
+    args: argparse.Namespace, sensitive_dirs: frozenset[str], logger: logging.Logger
+) -> None:
+    """Validate the input path and its file. Exits non-zero on any failure
+
+    Sets args.input to the resolved path, as the inline version did.
+    """
+    # Validate input file path
+    input_valid, input_error, input_resolved = validate_file_path(
+        args.input,
+        allow_absolute=args.allow_absolute_paths,
+        is_output=False,
+        sensitive_dirs=sensitive_dirs
+    )
+    if not input_valid:
+        logger.error("[!] Error: Invalid input path: %s", input_error)
+        sys.exit(1)
+
+    # Check if input file exists (use resolved path)
+    if not input_resolved.exists():
+        logger.error("[!] Error: Input file '%s' not found", args.input)
+        sys.exit(1)
+
+    # SECURITY: Check if input is a symlink when using --inplace
+    # Must check BEFORE file size check (directories appear empty when read as files)
+    if args.inplace:
+        input_path_original = Path(args.input)
+        if input_path_original.is_symlink():
+            # Get the symlink target for the error message
+            try:
+                target = input_path_original.resolve()
+                logger.error("[!] Error: Cannot use --inplace on symlink: %s", args.input)
+                logger.error("    Symlink target: %s", target)
+                logger.error("    Hint: If you intend to modify the target, specify it directly.")
+            except (OSError, RuntimeError):
+                # If we can't resolve the symlink (broken link), still refuse
+                logger.error("[!] Error: Cannot use --inplace on symlink: %s", args.input)
+                logger.error("    Hint: Symlinks are not allowed with --inplace for security reasons.")
+            sys.exit(1)
+
+    # Check if input file is empty
+    if input_resolved.stat().st_size == 0:
+        logger.error("[!] Error: Input file is empty")
+        sys.exit(1)
+
+
+def _resolve_output_path(
+    args: argparse.Namespace, sensitive_dirs: frozenset[str], logger: logging.Logger
+) -> None:
+    """Validate the output path, including the extra --inplace checks"""
+    # Validate output file path (if applicable)
+    # Skip validation in dry-run mode since we won't actually write
+    if args.output and not args.stdout and not args.dry_run:
+        output_valid, output_error, output_resolved = validate_file_path(
+            args.output,
+            allow_absolute=args.allow_absolute_paths,
+            is_output=True,
+            sensitive_dirs=sensitive_dirs
+        )
+        if not output_valid:
+            logger.error("[!] Error: Invalid output path: %s", output_error)
+            sys.exit(1)
+
+        # Check if output file exists (unless force)
+        if not args.force and output_resolved.exists():
+            logger.error("[!] Error: Output file '%s' already exists. Use --force to overwrite.", args.output)
+            sys.exit(1)
+    elif args.dry_run and args.output:
+        # In dry-run mode, still validate the output path for security
+        output_valid, output_error, _ = validate_file_path(
+            args.output,
+            allow_absolute=args.allow_absolute_paths,
+            is_output=True,
+            sensitive_dirs=sensitive_dirs
+        )
+        if not output_valid:
+            logger.error("[!] Error: Invalid output path: %s", output_error)
+            sys.exit(1)
+
+    # Validate inplace mode - extra security check
+    if args.inplace:
+        # Re-validate input path with output restrictions
+        inplace_valid, inplace_error, _ = validate_file_path(
+            args.input,
+            allow_absolute=args.allow_absolute_paths,
+            is_output=True,  # Treat as output for stricter checks
+            sensitive_dirs=sensitive_dirs
+        )
+        if not inplace_valid:
+            logger.error("[!] Error: Cannot use --inplace with this file: %s", inplace_error)
+            sys.exit(1)
+
+
+def _resolve_keep_private_ips(args: argparse.Namespace) -> bool:
+    """Decide whether non-global IPs are preserved
+
+    --anonymise implies keeping them for better context unless the user was
+    explicit either way.
+    """
+    # Default keep_private_ips to True when anonymise is used (better AI context)
+    # unless explicitly disabled with --no-keep-private-ips
+    if args.anonymise and args.keep_private_ips is None:
+        # --anonymise without explicit --keep-private-ips or --no-keep-private-ips
+        keep_private_ips = True
+    elif args.keep_private_ips is None:
+        # No anonymise, no explicit flag
+        keep_private_ips = False
+    else:
+        # Explicit flag was used
+        keep_private_ips = args.keep_private_ips
+    return keep_private_ips
+
+
+def _collect_allowlists(
+    args: argparse.Namespace, logger: logging.Logger
+) -> tuple[set[str], list[IPNetwork], set[str]]:
+    """Merge allow-list entries from default files, --allowlist-file and CLI flags"""
+    # Build allow-lists from multiple sources (merge all)
+    allowlist_ips = set()
+    allowlist_networks = []
+    allowlist_domains = set()
+
+    # 1. Load default allow-list files (unless disabled)
+    if not getattr(args, 'no_default_allowlist', False):
+        default_files = find_default_allowlist_files()
+        for default_file in default_files:
+            file_ips, file_networks, file_domains = parse_allowlist_file(default_file, silent_if_missing=True)
+            allowlist_ips.update(file_ips)
+            allowlist_networks.extend(file_networks)
+            allowlist_domains.update(file_domains)
+            if not args.dry_run and not args.stdout:
+                logger.info("[+] Loaded default allow-list: %s", default_file)
+
+    # 2. Load explicit allow-list file if provided
+    if args.allowlist_file:
+        file_ips, file_networks, file_domains = parse_allowlist_file(args.allowlist_file, silent_if_missing=False)
+        allowlist_ips.update(file_ips)
+        allowlist_networks.extend(file_networks)
+        allowlist_domains.update(file_domains)
+
+    # 3. Add IPs/CIDRs from CLI
+    for entry in args.allowlist_ips or ():
+        _add_cli_allowlist_ip(entry, allowlist_ips, allowlist_networks, logger)
+
+    # 4. Add domains from CLI (case-insensitive)
+    for domain in args.allowlist_domains or ():
+        allowlist_domains.add(domain.lower())
+
+    return allowlist_ips, allowlist_networks, allowlist_domains
+
+
+def _add_cli_allowlist_ip(
+    entry: str, ips: set[str], networks: list[IPNetwork], logger: logging.Logger
+) -> None:
+    """Add one --allowlist-ip entry, exiting if it is neither an IP nor a CIDR
+
+    Unlike allow-list *files*, where an unparseable line is treated as a
+    domain, an explicit --allowlist-ip that does not parse is a user error and
+    is fatal.
+    """
+    try:
+        ipaddress.ip_address(entry)
+        ips.add(entry)
+        return
+    except ValueError:
+        pass
+
+    try:
+        networks.append(ipaddress.ip_network(entry, strict=False))
+        return
+    except ValueError:
+        pass
+
+    logger.error("[!] Error: Invalid IP or CIDR in --allowlist-ip: %s", entry)
+    sys.exit(1)
+
+
+def main() -> None:
+    """Main entry point for the pfSense redactor CLI"""
+    # Version for the --version flag. Resolved rather than imported directly so
+    # that running redactor.py as a script still reports the real version.
+    __version__ = resolve_version()
+
+    parser = _build_arg_parser(__version__)
 
     args = parser.parse_args()
 
@@ -2602,148 +2789,12 @@ CDATA sections are not preserved.
     # Compute sensitive directories once for efficiency
     sensitive_dirs = _get_sensitive_directories()
 
-    # Validate input file path
-    input_valid, input_error, input_resolved = validate_file_path(
-        args.input,
-        allow_absolute=args.allow_absolute_paths,
-        is_output=False,
-        sensitive_dirs=sensitive_dirs
-    )
-    if not input_valid:
-        logger.error("[!] Error: Invalid input path: %s", input_error)
-        sys.exit(1)
+    _resolve_input_path(args, sensitive_dirs, logger)
+    _resolve_output_path(args, sensitive_dirs, logger)
 
-    # Check if input file exists (use resolved path)
-    if not input_resolved.exists():
-        logger.error("[!] Error: Input file '%s' not found", args.input)
-        sys.exit(1)
+    keep_private_ips = _resolve_keep_private_ips(args)
 
-    # SECURITY: Check if input is a symlink when using --inplace
-    # Must check BEFORE file size check (directories appear empty when read as files)
-    if args.inplace:
-        input_path_original = Path(args.input)
-        if input_path_original.is_symlink():
-            # Get the symlink target for the error message
-            try:
-                target = input_path_original.resolve()
-                logger.error("[!] Error: Cannot use --inplace on symlink: %s", args.input)
-                logger.error("    Symlink target: %s", target)
-                logger.error("    Hint: If you intend to modify the target, specify it directly.")
-            except (OSError, RuntimeError):
-                # If we can't resolve the symlink (broken link), still refuse
-                logger.error("[!] Error: Cannot use --inplace on symlink: %s", args.input)
-                logger.error("    Hint: Symlinks are not allowed with --inplace for security reasons.")
-            sys.exit(1)
-
-    # Check if input file is empty
-    if input_resolved.stat().st_size == 0:
-        logger.error("[!] Error: Input file is empty")
-        sys.exit(1)
-
-    # Validate output file path (if applicable)
-    # Skip validation in dry-run mode since we won't actually write
-    if args.output and not args.stdout and not args.dry_run:
-        output_valid, output_error, output_resolved = validate_file_path(
-            args.output,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,
-            sensitive_dirs=sensitive_dirs
-        )
-        if not output_valid:
-            logger.error("[!] Error: Invalid output path: %s", output_error)
-            sys.exit(1)
-
-        # Check if output file exists (unless force)
-        if not args.force and output_resolved.exists():
-            logger.error("[!] Error: Output file '%s' already exists. Use --force to overwrite.", args.output)
-            sys.exit(1)
-    elif args.dry_run and args.output:
-        # In dry-run mode, still validate the output path for security
-        output_valid, output_error, _ = validate_file_path(
-            args.output,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,
-            sensitive_dirs=sensitive_dirs
-        )
-        if not output_valid:
-            logger.error("[!] Error: Invalid output path: %s", output_error)
-            sys.exit(1)
-
-    # Validate inplace mode - extra security check
-    if args.inplace:
-        # Re-validate input path with output restrictions
-        inplace_valid, inplace_error, _ = validate_file_path(
-            args.input,
-            allow_absolute=args.allow_absolute_paths,
-            is_output=True,  # Treat as output for stricter checks
-            sensitive_dirs=sensitive_dirs
-        )
-        if not inplace_valid:
-            logger.error("[!] Error: Cannot use --inplace with this file: %s", inplace_error)
-            sys.exit(1)
-
-    # Default keep_private_ips to True when anonymise is used (better AI context)
-    # unless explicitly disabled with --no-keep-private-ips
-    if args.anonymise and args.keep_private_ips is None:
-        # --anonymise without explicit --keep-private-ips or --no-keep-private-ips
-        keep_private_ips = True
-    elif args.keep_private_ips is None:
-        # No anonymise, no explicit flag
-        keep_private_ips = False
-    else:
-        # Explicit flag was used
-        keep_private_ips = args.keep_private_ips
-
-    # Build allow-lists from multiple sources (merge all)
-    allowlist_ips = set()
-    allowlist_networks = []
-    allowlist_domains = set()
-
-    # 1. Load default allow-list files (unless disabled)
-    if not getattr(args, 'no_default_allowlist', False):
-        default_files = find_default_allowlist_files()
-        for default_file in default_files:
-            file_ips, file_networks, file_domains = parse_allowlist_file(default_file, silent_if_missing=True)
-            allowlist_ips.update(file_ips)
-            allowlist_networks.extend(file_networks)
-            allowlist_domains.update(file_domains)
-            if not args.dry_run and not args.stdout:
-                logger.info("[+] Loaded default allow-list: %s", default_file)
-
-    # 2. Load explicit allow-list file if provided
-    if args.allowlist_file:
-        file_ips, file_networks, file_domains = parse_allowlist_file(args.allowlist_file, silent_if_missing=False)
-        allowlist_ips.update(file_ips)
-        allowlist_networks.extend(file_networks)
-        allowlist_domains.update(file_domains)
-
-    # 3. Add IPs/CIDRs from CLI
-    if args.allowlist_ips:
-        for entry in args.allowlist_ips:
-            # Try as single IP first
-            try:
-                ipaddress.ip_address(entry)
-                allowlist_ips.add(entry)
-                continue
-            except ValueError:
-                pass
-
-            # Try as CIDR network
-            try:
-                network = ipaddress.ip_network(entry, strict=False)
-                allowlist_networks.append(network)
-                continue
-            except ValueError:
-                pass
-
-            # Invalid entry
-            logger.error("[!] Error: Invalid IP or CIDR in --allowlist-ip: %s", entry)
-            sys.exit(1)
-
-    # 4. Add domains from CLI (case-insensitive)
-    if args.allowlist_domains:
-        for domain in args.allowlist_domains:
-            allowlist_domains.add(domain.lower())
+    allowlist_ips, allowlist_networks, allowlist_domains = _collect_allowlists(args, logger)
 
     # Create redactor and process file
     redactor = PfSenseRedactor(

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2331,6 +2331,81 @@ def _get_sensitive_directories() -> frozenset[str]:
     return frozenset(normalised)
 
 
+# System files that must never be written to, compared against the resolved
+# lower-cased path. Checked in addition to the sensitive-directory scan.
+DANGEROUS_OUTPUT_FILES: frozenset[str] = frozenset({
+    '/etc/passwd', '/etc/shadow', '/etc/group', '/etc/sudoers',
+    '/etc/hosts', '/etc/fstab', '/etc/crontab',
+    'c:\\windows\\system32\\config\\sam',
+    'c:\\windows\\system32\\config\\system',
+})
+
+
+def _resolve_for_validation(file_path: str, path: Path) -> tuple[Path, bool]:
+    """Resolve a path to absolute form. Returns (resolved, was_absolute)
+
+    Windows drive-letter paths are detected explicitly because Path.is_absolute
+    returns False for them on POSIX, which would otherwise let 'C:\\...' be
+    treated as relative and resolved against the working directory.
+    """
+    is_windows_absolute = (
+        len(file_path) >= 3 and
+        file_path[1:3] in (':\\', ':/')  # C:\ or C:/
+    )
+    is_absolute_form = path.is_absolute() or is_windows_absolute
+
+    # Follows symlinks; relative paths resolve against the working directory
+    resolved = path.resolve() if is_absolute_form else (Path.cwd() / path).resolve()
+    return resolved, is_absolute_form
+
+
+def _is_in_sensitive_directory(resolved_str: str, sensitive_dirs: frozenset[str]) -> bool:
+    """Check whether a resolved output path falls inside a protected directory"""
+    for sensitive_dir in sensitive_dirs:
+        try:
+            if resolved_str.startswith(sensitive_dir):
+                return True
+        except (ValueError, AttributeError):
+            pass
+    return False
+
+
+def _is_safe_absolute_location(resolved_str: str) -> bool:
+    """Check whether an absolute path points somewhere writing is acceptable
+
+    Safe means the current working directory, the user's home, or a system
+    temp directory. Called only when --allow-absolute-paths was not given, and
+    only after the sensitive-directory check has already run.
+    """
+    # Normalise to forward slashes so Windows and POSIX compare alike
+    resolved_normalised = resolved_str.replace('\\', '/')
+
+    safe_prefixes = [
+        str(Path.home()).lower(),
+        str(Path.cwd()).lower(),
+        str(Path(os.environ.get('TMPDIR', '/tmp'))).lower(),
+        str(Path(os.environ.get('TEMP', '/tmp'))).lower(),
+        str(Path(os.environ.get('TMP', '/tmp'))).lower(),
+        '/tmp',  # Standard Unix temp directory
+        '/private/tmp',  # macOS /tmp (canonical path)
+        '/var/folders',  # macOS temp
+        '/private/var/folders',  # macOS temp (canonical)
+    ]
+
+    # The cwd itself is safe, as well as anything beneath it
+    cwd_normalised = str(Path.cwd()).lower().replace('\\', '/')
+    if not cwd_normalised.endswith('/'):
+        cwd_normalised += '/'
+    if resolved_normalised.startswith(cwd_normalised) or resolved_normalised == cwd_normalised.rstrip('/'):
+        return True
+
+    # Require the separator so /tmpfoo does not match the /tmp prefix
+    return any(
+        resolved_normalised.startswith(prefix if prefix.endswith('/') else prefix + '/')
+        for prefix in (p.replace('\\', '/') for p in safe_prefixes)
+    )
+
+
 def validate_file_path(
     file_path: str,
     allow_absolute: bool = False,
@@ -2371,89 +2446,24 @@ def validate_file_path(
         if '..' in path.parts:
             return False, "Path contains directory traversal components (..)", None
 
-        # Check if this looks like a Windows absolute path (e.g., C:\, D:\)
-        # On Unix systems, Path.is_absolute() returns False for Windows paths
-        is_windows_absolute = (
-            len(file_path) >= 3 and
-            file_path[1:3] in (':\\', ':/')  # C:\ or C:/
-        )
-
-        # Resolve the path to its absolute form (follows symlinks)
-        # Use Path.cwd() as base for relative paths
-        if path.is_absolute() or is_windows_absolute:
-            resolved = path.resolve()
-        else:
-            # For relative paths, resolve against current working directory
-            resolved = (Path.cwd() / path).resolve()
-
+        resolved, is_absolute_form = _resolve_for_validation(file_path, path)
         resolved_str = str(resolved).lower()
 
         # Check if resolved path is in a sensitive directory FIRST
         # This is the critical security check - do it before the absolute path check
         # so that even with --allow-absolute-paths, we still block sensitive dirs
-        if is_output:
-            for sensitive_dir in sensitive_dirs:
-                # Check if resolved path is within or equal to sensitive directory
-                try:
-                    # Use is_relative_to for Python 3.9+
-                    if resolved_str.startswith(sensitive_dir):
-                        return False, f"Cannot write to sensitive system directory: {resolved}", None
-                except (ValueError, AttributeError):
-                    pass
+        if is_output and _is_in_sensitive_directory(resolved_str, sensitive_dirs):
+            return False, f"Cannot write to sensitive system directory: {resolved}", None
 
         # Check if absolute path is allowed (after sensitive dir check)
         # Allow absolute paths to safe locations (like temp dirs, home, cwd)
-        if (path.is_absolute() or is_windows_absolute) and not allow_absolute:
-            # Normalise resolved path for comparison (convert backslashes to forward slashes)
-            resolved_normalised = resolved_str.replace('\\', '/')
-
-            # Check if this is a "safe" absolute path (temp dir, home, or under cwd)
-            # Normalise all safe prefixes to use forward slashes for consistent comparison
-            safe_prefixes_raw = [
-                str(Path.home()).lower(),
-                str(Path.cwd()).lower(),
-                str(Path(os.environ.get('TMPDIR', '/tmp'))).lower(),
-                str(Path(os.environ.get('TEMP', '/tmp'))).lower(),
-                str(Path(os.environ.get('TMP', '/tmp'))).lower(),
-                '/tmp',  # Standard Unix temp directory
-                '/private/tmp',  # macOS /tmp (canonical path)
-                '/var/folders',  # macOS temp
-                '/private/var/folders',  # macOS temp (canonical)
-            ]
-
-            # Normalise all safe prefixes to use forward slashes
-            safe_prefixes_normalised = [prefix.replace('\\', '/') for prefix in safe_prefixes_raw]
-
-            # Check if path is under CWD
-            cwd_normalised = str(Path.cwd()).lower().replace('\\', '/')
-
-            # Ensure CWD ends with separator for proper prefix matching
-            if not cwd_normalised.endswith('/'):
-                cwd_normalised += '/'
-
-            is_under_cwd = resolved_normalised.startswith(cwd_normalised) or resolved_normalised == cwd_normalised.rstrip('/')
-
-            # Check other safe prefixes (also normalised)
-            is_under_safe_prefix = any(
-                resolved_normalised.startswith(prefix if prefix.endswith('/') else prefix + '/')
-                for prefix in safe_prefixes_normalised
-            )
-
-            is_safe = is_under_cwd or is_under_safe_prefix
-
-            if not is_safe:
+        if is_absolute_form and not allow_absolute:
+            if not _is_safe_absolute_location(resolved_str):
                 return False, f"Absolute paths not allowed (use --allow-absolute-paths): {file_path}", None
 
         # Additional check: ensure we're not trying to write to system config files
-        if is_output:
-            dangerous_files = {
-                '/etc/passwd', '/etc/shadow', '/etc/group', '/etc/sudoers',
-                '/etc/hosts', '/etc/fstab', '/etc/crontab',
-                'c:\\windows\\system32\\config\\sam',
-                'c:\\windows\\system32\\config\\system',
-            }
-            if resolved_str in {f.lower() for f in dangerous_files}:
-                return False, f"Cannot write to system configuration file: {resolved}", None
+        if is_output and resolved_str in DANGEROUS_OUTPUT_FILES:
+            return False, f"Cannot write to system configuration file: {resolved}", None
 
         return True, "", resolved
 

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -110,73 +110,70 @@ def compare_versions(current: str, latest: str) -> bool:
         return False
 
 
-def detect_installation_method() -> InstallationMethod:
-    """Detect how pfsense-redactor was installed
-
-    Returns:
-        InstallationMethod with method name and upgrade command
-    """
-    # Check if running in pipx environment
-    if 'PIPX_HOME' in os.environ or 'pipx' in sys.prefix:
-        return InstallationMethod(
-            method="pipx",
-            upgrade_command="pipx upgrade pfsense-redactor"
-        )
-
-    # Check if running in a virtual environment
-    if hasattr(sys, 'real_prefix') or (
-            hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
-    ):
-        return InstallationMethod(
-            method="venv",
-            upgrade_command="pip install --upgrade pfsense-redactor"
-        )
-
-    # Check if installed as editable (development mode)
+def _is_editable_install() -> bool:
+    """Check for a pip editable install via direct_url.json"""
     try:
         import importlib.metadata
         dist = importlib.metadata.distribution('pfsense-redactor')
         # Use the public files() API to check if this is an editable install
         if dist.files and any(f.name == 'direct_url.json' for f in dist.files):
-            # Has direct_url.json which indicates editable or direct install
-            # Check if it's a local directory (editable install)
+            # direct_url.json indicates an editable or direct install; dir_info
+            # .editable distinguishes the editable case
             direct_url_data = json.loads(dist.read_text('direct_url.json'))
-            if direct_url_data.get('dir_info', {}).get('editable'):
-                return InstallationMethod(
-                    method="source",
-                    upgrade_command="git pull && pip install -e ."
-                )
+            return bool(direct_url_data.get('dir_info', {}).get('editable'))
     except (ImportError, AttributeError, ValueError, TypeError, KeyError, FileNotFoundError):
         # importlib.metadata not available, no direct_url.json, or parsing error
         pass
+    return False
 
-    # Check if installed in user site-packages
+
+def _is_user_site_install() -> bool:
+    """Check whether the distribution lives in user site-packages"""
     try:
         import site
         import importlib.metadata
         user_site = site.getusersitepackages()
-        dist = importlib.metadata.distribution('pfsense-redactor')
-        # Get the location using the metadata's locate_file method
-        dist_files = dist.files
-        if dist_files and user_site:
-            # Check if any of the files are in user site-packages
-            first_file = dist_files[0]
-            location = first_file.locate().resolve().parent
-            # Navigate up to find the site-packages directory
-            # Stop at root (location.parent == location) or when we find site-packages
-            while location.name not in ('site-packages', 'dist-packages') and location != location.parent:
-                location = location.parent
-            if location.is_relative_to(Path(user_site).resolve()):
-                # Installed in user site-packages
-                return InstallationMethod(
-                    method="user",
-                    upgrade_command="pip install --user --upgrade pfsense-redactor"
-                )
+        dist_files = importlib.metadata.distribution('pfsense-redactor').files
+        if not (dist_files and user_site):
+            return False
+
+        location = dist_files[0].locate().resolve().parent
+        # Walk up to the site-packages directory, stopping at the filesystem root
+        while location.name not in ('site-packages', 'dist-packages') and location != location.parent:
+            location = location.parent
+        return location.is_relative_to(Path(user_site).resolve())
     except (ImportError, AttributeError, ValueError, TypeError, OSError, IndexError):
         # site/importlib.metadata not available, or path resolution failed
-        pass
+        return False
 
-    # Default/unknown method
+
+def detect_installation_method() -> InstallationMethod:
+    """Detect how pfsense-redactor was installed
+
+    Checks are ordered most specific first; the last entry is the fallback.
+
+    Returns:
+        InstallationMethod with method name and upgrade command
+    """
+    def is_pipx() -> bool:
+        return 'PIPX_HOME' in os.environ or 'pipx' in sys.prefix
+
+    def is_venv() -> bool:
+        return hasattr(sys, 'real_prefix') or (
+            hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+        )
+
+    checks = (
+        (is_pipx, "pipx", "pipx upgrade pfsense-redactor"),
+        (is_venv, "venv", "pip install --upgrade pfsense-redactor"),
+        (_is_editable_install, "source", "git pull && pip install -e ."),
+        (_is_user_site_install, "user", "pip install --user --upgrade pfsense-redactor"),
+    )
+
+    for predicate, method, upgrade_command in checks:
+        if predicate():
+            return InstallationMethod(method=method, upgrade_command=upgrade_command)
+
     return InstallationMethod(
         method="pip",
         upgrade_command="pip install --upgrade pfsense-redactor"

--- a/tests/unit/test_allowlist_parsing.py
+++ b/tests/unit/test_allowlist_parsing.py
@@ -1,0 +1,135 @@
+"""Direct unit tests for allow-list file parsing
+
+parse_allowlist_file was previously exercised only end to end through the CLI,
+which left its line-classification and error paths without direct coverage.
+These tests pin the current behaviour so it can be refactored safely.
+"""
+import ipaddress
+
+import pytest
+
+from pfsense_redactor.redactor import parse_allowlist_file
+
+
+def write(tmp_path, content, name='allowlist.txt'):
+    """Write an allow-list file and return its path as a string"""
+    path = tmp_path / name
+    path.write_text(content, encoding='utf-8')
+    return str(path)
+
+
+class TestLineClassification:
+    """Each line is classified as an IP, a CIDR network, or a domain"""
+
+    def test_plain_ipv4_and_ipv6(self, tmp_path):
+        """Bare addresses land in the IP set as written"""
+        ips, networks, domains = parse_allowlist_file(
+            write(tmp_path, '8.8.8.8\n2001:db8::1\n')
+        )
+
+        assert ips == {'8.8.8.8', '2001:db8::1'}
+        assert networks == []
+        assert domains == set()
+
+    def test_cidr_networks(self, tmp_path):
+        """CIDR entries become network objects, not IP strings"""
+        _, networks, _ = parse_allowlist_file(
+            write(tmp_path, '10.0.0.0/8\n2001:db8::/32\n')
+        )
+
+        assert networks == [
+            ipaddress.ip_network('10.0.0.0/8'),
+            ipaddress.ip_network('2001:db8::/32'),
+        ]
+
+    def test_host_bits_set_are_accepted(self, tmp_path):
+        """strict=False, so 10.1.2.3/8 is accepted and normalised"""
+        _, networks, _ = parse_allowlist_file(write(tmp_path, '10.1.2.3/8\n'))
+
+        assert networks == [ipaddress.ip_network('10.0.0.0/8')]
+
+    def test_domains_are_lowercased(self, tmp_path):
+        """Domain matching is case-insensitive"""
+        _, _, domains = parse_allowlist_file(
+            write(tmp_path, 'Time.NIST.gov\nPOOL.ntp.org\n')
+        )
+
+        assert domains == {'time.nist.gov', 'pool.ntp.org'}
+
+    def test_unparseable_entries_are_treated_as_domains(self, tmp_path):
+        """Anything that is not an IP or CIDR falls through to the domain set"""
+        _, _, domains = parse_allowlist_file(
+            write(tmp_path, 'not an ip\n999.999.999.999\n')
+        )
+
+        assert domains == {'not an ip', '999.999.999.999'}
+
+    def test_mixed_file(self, tmp_path):
+        """All three kinds coexist in one file"""
+        ips, networks, domains = parse_allowlist_file(
+            write(tmp_path, '8.8.8.8\n192.168.0.0/16\ntime.nist.gov\n')
+        )
+
+        assert ips == {'8.8.8.8'}
+        assert networks == [ipaddress.ip_network('192.168.0.0/16')]
+        assert domains == {'time.nist.gov'}
+
+
+class TestIgnoredLines:
+    """Comments, blanks and surrounding whitespace"""
+
+    @pytest.mark.parametrize('content', [
+        '',
+        '\n\n\n',
+        '# just a comment\n',
+        '   \n\t\n',
+        '# comment\n\n   # indented comment is not stripped first\n',
+    ])
+    def test_nothing_collected(self, tmp_path, content):
+        """These files contribute no entries"""
+        ips, networks, domains = parse_allowlist_file(write(tmp_path, content))
+
+        assert (ips, networks, domains) == (set(), [], set())
+
+    def test_surrounding_whitespace_stripped(self, tmp_path):
+        """Entries are stripped before classification"""
+        ips, _, domains = parse_allowlist_file(
+            write(tmp_path, '   8.8.8.8   \n\t time.nist.gov\t\n')
+        )
+
+        assert ips == {'8.8.8.8'}
+        assert domains == {'time.nist.gov'}
+
+    def test_comment_after_entry_is_not_stripped(self, tmp_path):
+        """Only whole-line comments are supported; trailing ones are not"""
+        _, _, domains = parse_allowlist_file(
+            write(tmp_path, '8.8.8.8 # google\n')
+        )
+
+        assert domains == {'8.8.8.8 # google'}
+
+
+class TestMissingFile:
+    """silent_if_missing distinguishes default files from explicit ones"""
+
+    def test_silent_returns_empty(self, tmp_path):
+        """Default allow-list files may simply not exist"""
+        result = parse_allowlist_file(
+            str(tmp_path / 'nope.txt'), silent_if_missing=True
+        )
+
+        assert result == (set(), [], set())
+
+    def test_explicit_missing_file_exits(self, tmp_path):
+        """An explicitly requested file that is absent is a fatal error"""
+        with pytest.raises(SystemExit) as exc:
+            parse_allowlist_file(str(tmp_path / 'nope.txt'))
+
+        assert exc.value.code == 1
+
+    def test_directory_instead_of_file_exits(self, tmp_path):
+        """Passing a directory is an OSError path, also fatal"""
+        with pytest.raises(SystemExit) as exc:
+            parse_allowlist_file(str(tmp_path))
+
+        assert exc.value.code == 1

--- a/tests/unit/test_allowlist_parsing.py
+++ b/tests/unit/test_allowlist_parsing.py
@@ -28,8 +28,8 @@ class TestLineClassification:
         )
 
         assert ips == {'8.8.8.8', '2001:db8::1'}
-        assert networks == []
-        assert domains == set()
+        assert not networks
+        assert not domains
 
     def test_cidr_networks(self, tmp_path):
         """CIDR entries become network objects, not IP strings"""


### PR DESCRIPTION
`python-app.yml` already ran `flake8 --max-complexity=10`, but with `--exit-zero` — so the gate reported and was ignored. Nine functions were over it.

**This is a pure refactor: no behaviour change, no version bump, no CHANGELOG entry.**

## Result

| | Before | After |
|---|---|---|
| Functions over the CI threshold (mccabe) | **9** | **0** |
| `main` | 36 | under 10 |
| Average complexity (radon) | B (5.92) | **A (4.70)** |
| Blocks analysed | 84 | 109 |
| Gate | advisory (`--exit-zero`) | **blocking** |

**Correction after review.** The first version of this PR claimed "0 over the threshold" on the strength of mccabe alone. Codacy's analyser reported `main` at 15 and `_resolve_output_path` at 12, and radon agreed — two tools out of three disagreed with the claim. Rather than defend the metric, the functions were reduced further in `2b5b613`:

| Function | mccabe | radon before | radon after |
|---|---|---|---|
| `main` | 8 | 15 | **2** |
| `_resolve_output_path` | 8 | 12 | **9** |
| `validate_file_path` | 8 | 12 | under 10 |
| `_is_high_entropy_value` | — | 14 | under 10 |
| `redact_element` | — | 11 | under 10 |

Every function is now at or below 10 by **both** mccabe and radon. Average **A (4.35)**, from B (5.92).

Also addressed Codacy's 50-line method limit: `_build_arg_parser` was 79 lines and is now four `_add_*_arguments` groups.

**On the Bandit alerts:** they are false positives and the evidence is concrete. The `/tmp` literals are *moved, not added* (the diff shows matching `+`/`-` pairs), the project's own `.bandit` config reports nothing on either branch, and B108 is about *creating* temp files whereas this is a safe-prefix allow-list used to *validate* output paths. Codacy also anchored the comments to the Windows drive-letter detection, which contains no temp paths at all.

## Commits, lowest risk first

| Commit | Function | Was |
|---|---|---|
| `acc21f3` | `is_rfc_documentation_ip` extracted — the RFC 5737/3849 check was **triplicated** and rebuilt `ip_network` objects on every call | fixes 3 at once |
| `11991b0` | `_print_stats` | 18 |
| `c387846` | `_counter_to_rfc_ip` | 14 |
| `…` | `_mask_url_sample` | 14 |
| `…` | `_mask_ip_like_tokens` | 22 |
| `…` | `redact_config`, `detect_installation_method` | 12, 12 |
| `b520f6b` | **tests** for `parse_allowlist_file` (see below) | — |
| `1a91c22` | `parse_allowlist_file` | 12 |
| `baffb99` | `main` — three pylint disables removed | 36 |
| `369ee9e` | `validate_file_path` | 17 |
| `…` | make the gate blocking | — |

## How behaviour preservation was checked

Reference snapshots are the primary signal and **never moved** — verified after every commit. On top of that, each commit got equivalence testing appropriate to what it touched:

- **84-run CLI output harness** (27,187 lines) comparing the working copy against the previous commit across 14 flag combinations × 6 configs, exploiting the standalone-runnable property to run both versions side by side
- `_print_stats`: 18 runs byte-identical, including the "no examples collected" branch no sample config reaches
- `_counter_to_rfc_ip`: **1,620** counter/family combinations, every boundary (254, 508, 762, 763, 0xFFFF, the 10.0.0.0/8 exhaustion marker)
- `_mask_ip_like_tokens`: 108 token/mode combinations — malformed ports, zone identifiers, already-masked values
- `validate_file_path`: **120** (path × `allow_absolute` × `is_output`) combinations — traversal, null bytes, sensitive dirs, dangerous files, Windows drive letters, and `/tmpfoo` which must not match the `/tmp` prefix
- `main`: 14 CLI cases including exit codes, `--help`, invalid `--allowlist-ip`, missing files; `--inplace` compared on isolated copies

End-to-end: canary corpus still **2/46** under `--aggressive` (both deliberate), false-positive scan unchanged at **14/875**, and the 1.1.1 reporter's `urls.xml`/`paths.xml` still produce their fixed output.

## Two things done deliberately

**`parse_allowlist_file` got tests first, in a separate commit.** It had **zero direct tests and 57% coverage** — the weakest safety net of the nine, despite being one of the simpler ones. The 16 tests pass against the *unmodified* implementation, pinning existing behaviour before the refactor had anything to violate. Coverage 57% → 89%.

**`validate_file_path` guard order is unchanged and load-bearing.** The sensitive-directory check still runs *before* the absolute-path check, so `--allow-absolute-paths` cannot be used to write into a protected directory. The comment saying so stays at the call site rather than migrating into the extracted function.

## Scope note

The blocking gate is scoped to `pfsense_redactor/`. Making the existing whole-repo flake8 run blocking would also fail on 53 pre-existing style findings in `tests/` (trailing whitespace, an unused local) — a separate concern that would turn this PR into something else. Worth doing, just not here.

