### PR TITLE
Derive Windows system directories from the environment, not a hardcoded C:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ reviewing that work, both older than 1.1.0.
   under-blocked, so it was a usability failure rather than a security one, and
   every protected directory remains blocked.
 
+- **FIX** (predates 1.1.0): Windows system directories were hardcoded to `C:`,
+  so a machine with Windows installed on any other drive had no write
+  protection for its system directories at all — `D:\\Windows\\System32` was
+  freely writable. The real locations are now read from `SystemRoot`, `windir`,
+  `ProgramFiles`, `ProgramFiles(x86)`, `ProgramW6432` and `ProgramData`, the
+  same way temp directories are already read from `TMPDIR`/`TEMP`. The `C:`
+  literals are kept, since the full set is applied on every platform by design.
+  No effect off Windows, where none of these variables are set.
+
 ### Known limitations
 - A path segment of 21-23 characters containing no digit is not detected.
   `Open_VM_Tools_package` (a route name that must be preserved) and a

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2316,6 +2316,33 @@ def find_default_allowlist_files() -> list[Path]:
 # ==========================================================================
 # 6. PATH SAFETY
 # ==========================================================================
+def _windows_dirs_from_environment() -> set[str]:
+    """Locate the real Windows system directories from the environment
+
+    The hardcoded list assumes C:. Windows can be installed on any drive, and
+    ProgramFiles/ProgramData are relocatable independently of it, so a machine
+    with the system on D: had no protection for D:\\Windows at all.
+
+    Returns an empty set off Windows, where none of these variables are set.
+    """
+    dirs: set[str] = set()
+
+    for variable in ('SystemRoot', 'windir', 'ProgramFiles', 'ProgramFiles(x86)',
+                     'ProgramW6432', 'ProgramData'):
+        value = os.environ.get(variable)
+        if not value:
+            continue
+
+        dirs.add(value.lower())
+
+        # System32 sits under SystemRoot and is worth naming explicitly, since
+        # the most damaging writes land there rather than in the root
+        if variable in ('SystemRoot', 'windir'):
+            dirs.add(f"{value.rstrip(chr(92))}\\system32".lower())
+
+    return dirs
+
+
 def _get_sensitive_directories() -> frozenset[str]:
     """Get list of sensitive system directories that should not be written to
 
@@ -2329,11 +2356,16 @@ def _get_sensitive_directories() -> frozenset[str]:
         '/var/log', '/var/run', '/run',
     }
 
-    # Windows system directories
+    # Windows system directories. The literals assume the system is on C:,
+    # which is usual but not guaranteed - Windows can be installed on any
+    # drive. They are kept because the whole set is applied on every platform
+    # (see below), and supplemented with the real locations read from the
+    # environment, the same way _is_safe_absolute_location reads TMPDIR/TEMP.
     windows_sensitive_dirs = {
         'c:\\windows', 'c:\\windows\\system32', 'c:\\program files',
         'c:\\program files (x86)', 'c:\\programdata',
     }
+    windows_sensitive_dirs |= _windows_dirs_from_environment()
 
     # Normalise paths for comparison (resolve symlinks, make absolute)
     normalised = set()
@@ -2401,13 +2433,18 @@ def _is_in_sensitive_directory(resolved_str: str, sensitive_dirs: frozenset[str]
     """
     for sensitive_dir in sensitive_dirs:
         try:
-            if resolved_str == sensitive_dir:
+            # Strip any trailing separator first, so the comparisons do not
+            # depend on how the entry was written. Path.resolve() never returns
+            # a trailing separator, so an entry of '/etc/' would otherwise fail
+            # to match a resolved path of exactly '/etc'.
+            base = sensitive_dir.rstrip('/\\')
+
+            if resolved_str == base:
                 return True
 
             # Require a separator after the prefix so only whole path
             # components match. Both separators are checked because the
             # sensitive list spans platforms.
-            base = sensitive_dir.rstrip('/\\')
             if any(resolved_str.startswith(base + sep) for sep in ('/', '\\')):
                 return True
         except (ValueError, AttributeError):

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2336,9 +2336,14 @@ def _windows_dirs_from_environment() -> set[str]:
         dirs.add(value.lower())
 
         # System32 sits under SystemRoot and is worth naming explicitly, since
-        # the most damaging writes land there rather than in the root
+        # the most damaging writes land there rather than in the root.
+        #
+        # Joined with a literal backslash rather than os.path.join: these are
+        # Windows paths, and join would use the *host* separator, producing
+        # 'd:\\windows/system32' when the set is built on POSIX - as it is in
+        # the tests that simulate a Windows environment.
         if variable in ('SystemRoot', 'windir'):
-            dirs.add(f"{value.rstrip(chr(92))}\\system32".lower())
+            dirs.add((value.rstrip('/\\') + '\\system32').lower())
 
     return dirs
 
@@ -2389,7 +2394,11 @@ def _get_sensitive_directories() -> frozenset[str]:
             # Handle errors in path resolution (e.g., permission denied)
             normalised.add(path_str.lower())
 
-    return frozenset(normalised)
+    # Canonicalise: no entry carries a trailing separator, so the set is
+    # predictable for callers and comparisons do not depend on how an entry
+    # was spelled. _is_in_sensitive_directory strips defensively as well,
+    # because it also accepts hand-built sets.
+    return frozenset(entry.rstrip('/\\') or entry for entry in normalised)
 
 
 # System files that must never be written to, compared against the resolved

--- a/tests/unit/test_path_validation.py
+++ b/tests/unit/test_path_validation.py
@@ -2,8 +2,10 @@
 Unit tests for file path validation security
 Tests the validate_file_path function to ensure it properly blocks malicious paths
 """
+import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -11,7 +13,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # pylint: disable=wrong-import-position
-from pfsense_redactor.redactor import validate_file_path, _get_sensitive_directories
+from pfsense_redactor.redactor import (
+    validate_file_path,
+    _get_sensitive_directories,
+    _is_in_sensitive_directory,
+    _windows_dirs_from_environment,
+)
 
 
 class TestPathValidation:  # pylint: disable=too-many-public-methods
@@ -365,6 +372,25 @@ class TestSensitiveDirectoryComponentMatching:
 
         assert is_valid is True, f"{path} was wrongly blocked: {error}"
 
+    @pytest.mark.parametrize('entry,separator', [
+        ('/etc', '/'),
+        ('/etc/', '/'),
+        ('c:\\windows', '\\'),
+        ('c:\\windows\\', '\\'),
+    ])
+    def test_matching_survives_trailing_separators(self, entry, separator):
+        """Entry formatting must not decide whether protection applies
+
+        Path.resolve() never returns a trailing separator, so an entry written
+        as '/etc/' would previously fail to match a resolved path of exactly
+        '/etc' - a silent bypass if such an entry were ever added.
+        """
+        sensitive = frozenset({entry})
+        base = entry.rstrip('/\\')
+
+        assert _is_in_sensitive_directory(base, sensitive), 'directory itself'
+        assert _is_in_sensitive_directory(base + separator + 'out.xml', sensitive), 'child path'
+
     def test_exact_directory_itself_blocked(self):
         """The protected directory itself, with no trailing component"""
         if sys.platform == 'win32':
@@ -373,3 +399,69 @@ class TestSensitiveDirectoryComponentMatching:
         is_valid, _, _ = validate_file_path('/root', allow_absolute=True, is_output=True)
 
         assert is_valid is False
+
+
+class TestWindowsSystemDirectoriesFromEnvironment:
+    """Windows system directories must be found wherever they are installed
+
+    The hardcoded list assumes C:. Windows can be installed on any drive, and
+    ProgramFiles/ProgramData are relocatable independently of it, so a machine
+    with the system on D: had no protection for D:\\Windows.
+    """
+
+    WINDOWS_ON_D = {
+        'SystemRoot': 'D:\\Windows',
+        'ProgramFiles': 'D:\\Program Files',
+        'ProgramFiles(x86)': 'D:\\Program Files (x86)',
+        'ProgramData': 'D:\\ProgramData',
+    }
+
+    def test_nothing_derived_off_windows(self):
+        """The variables are absent on POSIX, so the set is unchanged there"""
+        if sys.platform == 'win32':
+            pytest.skip("Windows-specific test")
+
+        assert _windows_dirs_from_environment() == set()
+
+    def test_system_root_on_another_drive_is_found(self):
+        """A system installed on D: contributes D:\\Windows, not just C:"""
+        with patch.dict(os.environ, self.WINDOWS_ON_D, clear=False):
+            derived = _windows_dirs_from_environment()
+
+        assert 'd:\\windows' in derived
+        assert 'd:\\windows\\system32' in derived, 'System32 named explicitly'
+        assert 'd:\\program files' in derived
+        assert 'd:\\programdata' in derived
+
+    @pytest.mark.parametrize('path', [
+        'd:\\windows\\system32\\config\\sam',
+        'd:\\windows\\notepad.exe',
+        'd:\\program files\\app\\x.xml',
+        'd:\\programdata\\x.xml',
+    ])
+    def test_paths_under_relocated_system_are_blocked(self, path):
+        """Writes beneath the real system directories are refused"""
+        with patch.dict(os.environ, self.WINDOWS_ON_D, clear=False):
+            sensitive = _get_sensitive_directories()
+
+        assert _is_in_sensitive_directory(path, sensitive) is True
+
+    @pytest.mark.parametrize('path', [
+        'd:\\windows-old\\x.xml',
+        'd:\\users\\me\\out.xml',
+        'd:\\programdata-backup\\x.xml',
+    ])
+    def test_similarly_named_paths_still_allowed(self, path):
+        """Component matching still applies to the derived entries"""
+        with patch.dict(os.environ, self.WINDOWS_ON_D, clear=False):
+            sensitive = _get_sensitive_directories()
+
+        assert _is_in_sensitive_directory(path, sensitive) is False
+
+    def test_trailing_separator_in_environment_value(self):
+        """Environment values may carry a trailing backslash"""
+        with patch.dict(os.environ, {'SystemRoot': 'D:\\Windows\\'}, clear=False):
+            sensitive = _get_sensitive_directories()
+
+        assert _is_in_sensitive_directory('d:\\windows', sensitive) is True
+        assert _is_in_sensitive_directory('d:\\windows\\system32\\x', sensitive) is True


### PR DESCRIPTION
`_get_sensitive_directories` listed the Windows protected directories as literals rooted at `C:`. Windows can be installed on any drive, and `ProgramFiles`/`ProgramData` are relocatable independently of it — so a machine with the system on `D:` had **no write protection for its system directories at all**.

| Path | `main` | This PR |
|---|---|---|
| `d:\windows\system32\config\sam` | writable | **blocked** |
| `d:\windows\x` | writable | **blocked** |
| `d:\program files\x` | writable | **blocked** |
| `d:\programdata\x` | writable | **blocked** |

The real locations are now read from `SystemRoot`, `windir`, `ProgramFiles`, `ProgramFiles(x86)`, `ProgramW6432` and `ProgramData`. `System32` is named explicitly under `SystemRoot`, since that is where the most damaging writes land.

This follows the pattern `_is_safe_absolute_location` already uses for `TMPDIR`/`TEMP`/`TMP`, so it is not a new idea in this file.

The `C:` literals are kept — the whole set is deliberately applied on every platform, per the existing comment, so Unix paths are checked on Windows and vice versa.

## Correcting how I originally described this

I raised this as *"POSIX paths get no sensitive-directory protection on Windows"*. That is technically true but it is **not the risk**, and I should not have filed it that way:

- A POSIX path on Windows resolves drive-relative — `/etc/passwd` becomes `D:\etc\passwd`, which is an ordinary folder, not a system location
- Where such a path *does* land in the real system directory, the `C:` entries already caught it

The actual defect was the drive-letter assumption. I only found that by reading `_get_sensitive_directories` properly instead of trusting my earlier summary.

## Also folds in an orphaned commit

`ba7f03d` was pushed to the `#52` branch **after** that PR had already merged, so it never reached `main`. It stops sensitive-directory matching depending on whether an entry carries a trailing separator: `Path.resolve()` never emits one, so an entry written `/etc/` would not match a resolved path of exactly `/etc` — a silent bypass if such an entry were ever added.

Same function, same class of issue, and otherwise lost. Worth checking I have not mis-attributed this: `git branch --contains ba7f03d` lists only the feature branch, and the merge commit contains zero occurrences of the fixed form.

## Verification

- 13 new tests covering a simulated D: install, similarly-named paths (`d:\windows-old` still allowed), and trailing separators in environment values
- **No effect off Windows**: none of these variables are set, entry count unchanged at 20, and CLI output byte-identical across the 84-run comparison
- 546 tests pass, reference snapshots unmoved, complexity gate clean

## Note on merge order

This touches the same `1.1.1` CHANGELOG section as #53. Whichever merges second will need a trivial resolution — #53 merges the two `### Fixed` headings, and this adds bullets under the second of them.
