### PR TITLE
Refuse input that declares a DOCTYPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ reviewing that work, both older than 1.1.0.
 - **FIX**: `<webhook_url>` and similar elements are now redacted whole. A Slack
   or Discord webhook URL is a credential in its entirety, not merely a
   secret-bearing path segment.
+- **HARDENING**: Input declaring a `<!DOCTYPE>` is now refused. pfSense never
+  emits one, so its presence means the file did not come from pfSense
+  untouched.
+
+  This is deliberately *not* described as an XXE fix. `xml.etree.ElementTree`
+  does not resolve external entities — a `SYSTEM` entity raises `ParseError`,
+  so there is no file disclosure and no SSRF. What it does do is expand
+  *internal* entities, where a few hundred bytes of nested definitions expand
+  to gigabytes. Severity is low: the input is a file the user supplies, and the
+  failure is loud rather than a silent under-redaction.
+
+  The whole prolog is scanned rather than a fixed-size prefix. A DOCTYPE placed
+  behind a larger comment passes a prefix check untouched, which would leave
+  the guard reporting success while doing nothing.
 
 ### Fixed
 - **FIX**: FQDN substitution rewrote filenames as domains, corrupting output

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -424,6 +424,21 @@ _PROLOG_SKIPPABLE: tuple[tuple[bytes, bytes], ...] = (
 )
 
 
+def _skip_one_prolog_construct(data: bytes, pos: int) -> int | None:
+    """Advance past a single comment or processing instruction at pos
+
+    Returns the offset just after it, `pos` unchanged when no construct starts
+    here, or None if the construct is unterminated within `data`.
+    """
+    for opener, closer in _PROLOG_SKIPPABLE:
+        if not data.startswith(opener, pos):
+            continue
+        end = data.find(closer, pos + len(opener))
+        return None if end == -1 else end + len(closer)
+
+    return pos
+
+
 def _skip_prolog_noise(data: bytes, pos: int) -> int | None:
     """Advance past whitespace, comments and processing instructions
 
@@ -435,17 +450,25 @@ def _skip_prolog_noise(data: bytes, pos: int) -> int | None:
             pos += 1
             continue
 
-        for opener, closer in _PROLOG_SKIPPABLE:
-            if data.startswith(opener, pos):
-                end = data.find(closer, pos + len(opener))
-                if end == -1:
-                    return None
-                pos = end + len(closer)
-                break
-        else:
-            return pos
+        after = _skip_one_prolog_construct(data, pos)
+        if after is None or after == pos:
+            # None: unterminated, so undecidable. Unchanged: nothing skippable
+            # starts here, so this is where the prolog ends.
+            return after
+        pos = after
 
     return pos
+
+
+def _prolog_scan_is_conclusive(data: bytes, pos: int, at_eof: bool) -> bool:
+    """Whether enough input is present for the comparison at pos to be final
+
+    The subtle case this guards: a declaration straddling a read boundary. With
+    only part of it buffered the comparison would say "no DOCTYPE" and be
+    believed, so the scan must wait for either the full length or the end of
+    the file.
+    """
+    return at_eof or len(data) - pos >= len(_DOCTYPE_DECL)
 
 
 def _declares_doctype(input_file: str) -> bool:
@@ -467,18 +490,17 @@ def _declares_doctype(input_file: str) -> bool:
             chunk = handle.read(_PROLOG_CHUNK)
             data += chunk
 
+            at_eof = not chunk
             start = len(_UTF8_BOM) if data.startswith(_UTF8_BOM) else 0
             pos = _skip_prolog_noise(data, start)
 
-            # Decide only once the answer cannot change: either enough bytes
-            # remain to compare against the declaration, or the file ran out.
-            if pos is not None and (len(data) - pos >= len(_DOCTYPE_DECL) or not chunk):
+            if pos is not None and _prolog_scan_is_conclusive(data, pos, at_eof):
                 # Compared case-insensitively even though XML requires the
                 # upper-case spelling, so that '<!doctype' is refused here
                 # rather than relying on the parser to reject it.
                 return data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL
 
-            if not chunk:
+            if at_eof:
                 # Unterminated comment or PI. The file is malformed, and
                 # ET.parse reports that more precisely than this guard could.
                 return False
@@ -2165,6 +2187,13 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             )
             return None
 
+        # nosemgrep: python.lang.security.use-defusedxml.use-defusedxml
+        # Scanners flag any stdlib xml use as XXE-prone. It does not apply:
+        # ElementTree does not resolve external entities (a SYSTEM entity
+        # raises ParseError, so no file disclosure and no SSRF), and the
+        # DOCTYPE refusal above is stricter still, blocking internal entity
+        # expansion too. defusedxml would add a runtime dependency, which
+        # tests/integration/test_standalone_script.py exists to prevent.
         tree = ET.parse(input_file)
         if not self._check_root_tag(tree.getroot()):
             return None

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -410,6 +410,80 @@ def _idna_encode(domain: str) -> str:
         return domain
 
 
+# Prologs are a few bytes in any real config, but a hostile file can pad one
+# with a large comment, so the scan below grows on demand rather than peeking
+# at a fixed-size prefix.
+_PROLOG_CHUNK: int = 65536
+_UTF8_BOM: bytes = b'\xef\xbb\xbf'
+_DOCTYPE_DECL: bytes = b'<!DOCTYPE'
+
+# Constructs that may legally precede the root element, as (opener, closer).
+_PROLOG_SKIPPABLE: tuple[tuple[bytes, bytes], ...] = (
+    (b'<!--', b'-->'),  # comment
+    (b'<?', b'?>'),     # XML declaration or processing instruction
+)
+
+
+def _skip_prolog_noise(data: bytes, pos: int) -> int | None:
+    """Advance past whitespace, comments and processing instructions
+
+    Returns the offset of the first byte that is none of those, or None if
+    `data` ends inside a comment or PI, meaning more input is needed to tell.
+    """
+    while pos < len(data):
+        if data[pos:pos + 1].isspace():
+            pos += 1
+            continue
+
+        for opener, closer in _PROLOG_SKIPPABLE:
+            if data.startswith(opener, pos):
+                end = data.find(closer, pos + len(opener))
+                if end == -1:
+                    return None
+                pos = end + len(closer)
+                break
+        else:
+            return pos
+
+    return pos
+
+
+def _declares_doctype(input_file: str) -> bool:
+    """Report whether a DOCTYPE declaration precedes the root element
+
+    pfSense never emits one, so its presence means the file did not come from
+    pfSense untouched. That is worth refusing rather than parsing: ElementTree
+    does not resolve external entities - a SYSTEM entity raises ParseError, so
+    there is no XXE here - but it does expand internal ones, and a few hundred
+    bytes of nested definitions expand to gigabytes.
+
+    Scanning the whole prolog rather than a fixed-size prefix is the point. A
+    DOCTYPE preceded by a comment longer than the window sails straight past a
+    prefix check, which would leave the guard passing while doing nothing.
+    """
+    with open(input_file, 'rb') as handle:
+        data = b''
+        while True:
+            chunk = handle.read(_PROLOG_CHUNK)
+            data += chunk
+
+            start = len(_UTF8_BOM) if data.startswith(_UTF8_BOM) else 0
+            pos = _skip_prolog_noise(data, start)
+
+            # Decide only once the answer cannot change: either enough bytes
+            # remain to compare against the declaration, or the file ran out.
+            if pos is not None and (len(data) - pos >= len(_DOCTYPE_DECL) or not chunk):
+                # Compared case-insensitively even though XML requires the
+                # upper-case spelling, so that '<!doctype' is refused here
+                # rather than relying on the parser to reject it.
+                return data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL
+
+            if not chunk:
+                # Unterminated comment or PI. The file is malformed, and
+                # ET.parse reports that more precisely than this guard could.
+                return False
+
+
 # ==========================================================================
 # 4. REDACTOR
 # ==========================================================================
@@ -2076,6 +2150,27 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.logger.warning("%s Proceeding anyway...", msg)
         return True
 
+    def _load_config_tree(self, input_file: str) -> ET.ElementTree | None:
+        """Parse the configuration, refusing input pfSense would not produce
+
+        None means abort; the reason has already been logged. Both checks live
+        here so that redact_config has one failure branch rather than three.
+        """
+        if _declares_doctype(input_file):
+            self.logger.error(
+                "[!] Input declares a DOCTYPE, which pfSense never emits. "
+                "Refusing to parse: internal entity expansion can turn a "
+                "small file into gigabytes of memory. Remove the DOCTYPE "
+                "if you trust the file."
+            )
+            return None
+
+        tree = ET.parse(input_file)
+        if not self._check_root_tag(tree.getroot()):
+            return None
+
+        return tree
+
     def _write_output(
         self, tree: ET.ElementTree, input_file: str, output_file: str | None,
         stdout_mode: bool, inplace: bool
@@ -2105,12 +2200,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     ) -> bool:
         """Redact pfSense configuration file"""
         try:
-            # Parse XML
-            tree = ET.parse(input_file)
-            root = tree.getroot()
-
-            if not self._check_root_tag(root):
+            tree = self._load_config_tree(input_file)
+            if tree is None:
                 return False
+            root = tree.getroot()
 
             if not dry_run and not stdout_mode:
                 self.logger.info("[+] Parsing XML configuration from: %s", input_file)

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -417,6 +417,18 @@ _PROLOG_CHUNK: int = 65536
 _UTF8_BOM: bytes = b'\xef\xbb\xbf'
 _DOCTYPE_DECL: bytes = b'<!DOCTYPE'
 
+# Ceiling on how much prolog will be examined. The largest prolog in this
+# project's own fixtures is 68 bytes, so this is roughly 15,000x any real one.
+# It exists to bound the work a hostile file can demand: the buffer is
+# rescanned on each refill, which is quadratic, and at 50 MB of comment that
+# is seconds rather than milliseconds.
+#
+# Exceeding it *refuses* the file. A cap that instead stopped scanning and
+# carried on parsing would reintroduce the bypass this scan exists to close -
+# a DOCTYPE hidden behind one byte more than the cap - which is the whole
+# reason a fixed-size prefix check was rejected in the first place.
+_PROLOG_MAX: int = 1024 * 1024
+
 # Constructs that may legally precede the root element, as (opener, closer).
 _PROLOG_SKIPPABLE: tuple[tuple[bytes, bytes], ...] = (
     (b'<!--', b'-->'),  # comment
@@ -471,14 +483,18 @@ def _prolog_scan_is_conclusive(data: bytes, pos: int, at_eof: bool) -> bool:
     return at_eof or len(data) - pos >= len(_DOCTYPE_DECL)
 
 
-def _declares_doctype(input_file: str) -> bool:
-    """Report whether a DOCTYPE declaration precedes the root element
+def _prolog_refusal_reason(input_file: str) -> str | None:
+    """Say why the input's XML prolog is unacceptable, or None if it is fine
 
-    pfSense never emits one, so its presence means the file did not come from
-    pfSense untouched. That is worth refusing rather than parsing: ElementTree
-    does not resolve external entities - a SYSTEM entity raises ParseError, so
-    there is no XXE here - but it does expand internal ones, and a few hundred
-    bytes of nested definitions expand to gigabytes.
+    Two refusals, both fail-closed:
+
+    - A DOCTYPE declaration. pfSense never emits one, so its presence means the
+      file did not come from pfSense untouched. ElementTree does not resolve
+      external entities - a SYSTEM entity raises ParseError, so there is no XXE
+      here - but it does expand internal ones, and a few hundred bytes of
+      nested definitions expand to gigabytes.
+    - A prolog past _PROLOG_MAX, which bounds the work a hostile file can ask
+      for without letting an oversized one through unexamined.
 
     Scanning the whole prolog rather than a fixed-size prefix is the point. A
     DOCTYPE preceded by a comment longer than the window sails straight past a
@@ -491,6 +507,10 @@ def _declares_doctype(input_file: str) -> bool:
             data += chunk
 
             at_eof = not chunk
+            if len(data) > _PROLOG_MAX:
+                return (f"its XML prolog exceeds {_PROLOG_MAX // 1024} KiB "
+                        "without reaching a root element")
+
             start = len(_UTF8_BOM) if data.startswith(_UTF8_BOM) else 0
             pos = _skip_prolog_noise(data, start)
 
@@ -498,12 +518,14 @@ def _declares_doctype(input_file: str) -> bool:
                 # Compared case-insensitively even though XML requires the
                 # upper-case spelling, so that '<!doctype' is refused here
                 # rather than relying on the parser to reject it.
-                return data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL
+                if data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL:
+                    return "it declares a DOCTYPE, which pfSense never emits"
+                return None
 
             if at_eof:
                 # Unterminated comment or PI. The file is malformed, and
                 # ET.parse reports that more precisely than this guard could.
-                return False
+                return None
 
 
 # ==========================================================================
@@ -2178,23 +2200,26 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         None means abort; the reason has already been logged. Both checks live
         here so that redact_config has one failure branch rather than three.
         """
-        if _declares_doctype(input_file):
+        refusal = _prolog_refusal_reason(input_file)
+        if refusal is not None:
             self.logger.error(
-                "[!] Input declares a DOCTYPE, which pfSense never emits. "
-                "Refusing to parse: internal entity expansion can turn a "
-                "small file into gigabytes of memory. Remove the DOCTYPE "
-                "if you trust the file."
+                "[!] Refusing to parse this file because %s. Entity expansion "
+                "in a DOCTYPE can turn a small file into gigabytes of memory, "
+                "so the prolog is checked before parsing.", refusal
             )
             return None
 
-        # nosemgrep: python.lang.security.use-defusedxml.use-defusedxml
         # Scanners flag any stdlib xml use as XXE-prone. It does not apply:
         # ElementTree does not resolve external entities (a SYSTEM entity
         # raises ParseError, so no file disclosure and no SSRF), and the
-        # DOCTYPE refusal above is stricter still, blocking internal entity
+        # prolog refusal above is stricter still, blocking internal entity
         # expansion too. defusedxml would add a runtime dependency, which
         # tests/integration/test_standalone_script.py exists to prevent.
-        tree = ET.parse(input_file)
+        #
+        # The suppression sits on the statement itself: it applies to its own
+        # line or the one directly below, so it cannot be parked above a
+        # comment block like this one.
+        tree = ET.parse(input_file)  # nosemgrep  # nosec
         if not self._check_root_tag(tree.getroot()):
             return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,25 @@ def temp_output_dir(tmp_path):
 
 
 @pytest.fixture
+def require_writable_home():
+    """Skip when $HOME is a directory the redactor refuses to write to
+
+    Containers that run as root have HOME=/root, which _get_sensitive_directories
+    lists. Tests asserting that an ordinary home directory is an acceptable
+    output location have nothing to say there - the tool is right to refuse, and
+    the test's premise is what fails - so they skip rather than report a defect.
+    """
+    from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+        _get_sensitive_directories,
+    )
+
+    home = Path.home().resolve()
+    enclosing = {str(home).lower(), *(str(parent).lower() for parent in home.parents)}
+    if enclosing & _get_sensitive_directories():
+        pytest.skip(f"$HOME ({home}) is a sensitive directory")
+
+
+@pytest.fixture
 def update_reference():
     """Check if reference files should be updated"""
     return os.environ.get("UPDATE_REFERENCE", "0") == "1"

--- a/tests/integration/test_path_security.py
+++ b/tests/integration/test_path_security.py
@@ -210,7 +210,7 @@ class TestPathSecurityCLI:
         assert result.returncode != 0
         assert "sensitive" in result.stderr.lower() or "system" in result.stderr.lower()
 
-    def test_safe_absolute_path_in_home(self):
+    def test_safe_absolute_path_in_home(self, require_writable_home):
         """Absolute paths in home directory should work with flag"""
         # Create a temp file in home directory
         home_output = Path.home() / f"test-output-{os.getpid()}.xml"

--- a/tests/unit/test_doctype_rejection.py
+++ b/tests/unit/test_doctype_rejection.py
@@ -12,10 +12,21 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from pfsense_redactor.redactor import (
+    _PROLOG_MAX,
     PfSenseRedactor,
-    _declares_doctype,
+    _prolog_refusal_reason,
     _skip_prolog_noise,
 )
+
+
+def declares_doctype(path):
+    """Whether the prolog is refused specifically because of a DOCTYPE
+
+    Checking the reason, not merely that something was refused, keeps these
+    tests from passing for the wrong cause once the size cap also refuses.
+    """
+    reason = _prolog_refusal_reason(path)
+    return reason is not None and 'DOCTYPE' in reason
 
 MINIMAL_CONFIG = '<?xml version="1.0"?>\n<pfsense><version>1.0</version></pfsense>'
 
@@ -36,19 +47,19 @@ def write(tmp_path, content, name='config.xml'):
 
 
 class TestDoctypeDetection:
-    """_declares_doctype on the shapes a prolog can take"""
+    """_prolog_refusal_reason on the shapes a prolog can take"""
 
     def test_plain_doctype_detected(self, tmp_path):
         """The ordinary case: a DOCTYPE straight after the XML declaration"""
         path = write(tmp_path, ENTITY_BOMB)
 
-        assert _declares_doctype(path)
+        assert declares_doctype(path)
 
     def test_no_doctype_accepted(self, tmp_path):
         """A normal config declares nothing"""
         path = write(tmp_path, MINIMAL_CONFIG)
 
-        assert not _declares_doctype(path)
+        assert not declares_doctype(path)
 
     def test_doctype_behind_oversized_comment_detected(self, tmp_path):
         """A comment larger than the read chunk must not hide the DOCTYPE
@@ -63,7 +74,7 @@ class TestDoctypeDetection:
             f'<?xml version="1.0"?>\n<!--{padding}-->\n{ENTITY_BOMB.split(chr(10), 1)[1]}'
         )
 
-        assert _declares_doctype(path)
+        assert declares_doctype(path)
 
     def test_comment_without_doctype_accepted(self, tmp_path):
         """Padding alone is not grounds for refusal"""
@@ -73,7 +84,7 @@ class TestDoctypeDetection:
             f'<?xml version="1.0"?>\n<!--{padding}-->\n<pfsense><a>1</a></pfsense>'
         )
 
-        assert not _declares_doctype(path)
+        assert not declares_doctype(path)
 
     def test_lowercase_doctype_detected(self, tmp_path):
         """XML requires the upper-case spelling; refuse the other one here
@@ -83,14 +94,14 @@ class TestDoctypeDetection:
         """
         path = write(tmp_path, '<!doctype pfsense><pfsense><a>1</a></pfsense>')
 
-        assert _declares_doctype(path)
+        assert declares_doctype(path)
 
     def test_utf8_bom_skipped(self, tmp_path):
         """A byte-order mark must not shift the declaration out of view"""
         path = tmp_path / 'bom.xml'
         path.write_bytes(b'\xef\xbb\xbf' + ENTITY_BOMB.encode('utf-8'))
 
-        assert _declares_doctype(str(path))
+        assert declares_doctype(str(path))
 
     def test_multiple_comments_and_pis_skipped(self, tmp_path):
         """Whitespace, several comments and a PI may all precede the DOCTYPE"""
@@ -100,7 +111,7 @@ class TestDoctypeDetection:
             '<?target data?>\n  <!DOCTYPE pfsense>\n<pfsense><a>1</a></pfsense>'
         )
 
-        assert _declares_doctype(path)
+        assert declares_doctype(path)
 
     def test_doctype_inside_comment_not_detected(self, tmp_path):
         """A DOCTYPE mentioned in a comment is text, not a declaration"""
@@ -109,19 +120,19 @@ class TestDoctypeDetection:
             '<!-- no <!DOCTYPE here -->\n<pfsense><a>1</a></pfsense>'
         )
 
-        assert not _declares_doctype(path)
+        assert not declares_doctype(path)
 
     def test_empty_file_accepted(self, tmp_path):
         """Nothing to refuse; ET.parse reports the real problem"""
         path = write(tmp_path, '')
 
-        assert not _declares_doctype(path)
+        assert not declares_doctype(path)
 
     def test_unterminated_comment_accepted(self, tmp_path):
         """Malformed input is the parser's to describe, not this guard's"""
         path = write(tmp_path, '<!-- never closed\n<pfsense><a>1</a></pfsense>')
 
-        assert not _declares_doctype(path)
+        assert not declares_doctype(path)
 
     @pytest.mark.parametrize('boundary_offset', range(-2, 3))
     def test_doctype_split_across_read_boundary(self, tmp_path, boundary_offset):
@@ -135,7 +146,67 @@ class TestDoctypeDetection:
             '<pfsense><a>1</a></pfsense>'
         )
 
-        assert _declares_doctype(path)
+        assert declares_doctype(path)
+
+
+class TestPrologSizeCap:
+    """The cap bounds the scan without opening a way past it
+
+    Rescanning a growing buffer is quadratic, so an unbounded prolog lets a
+    large file cost seconds of CPU. The cap fixes that, but only safely if
+    exceeding it refuses the file - stopping the scan and parsing anyway would
+    put back the very bypass the whole-prolog scan exists to close.
+    """
+
+    def test_oversized_prolog_refused(self, tmp_path):
+        """A prolog past the cap is refused, with the size given as the reason"""
+        padding = 'P' * (_PROLOG_MAX + 1024)
+        path = write(
+            tmp_path,
+            f'<?xml version="1.0"?>\n<!--{padding}-->\n<pfsense><a>1</a></pfsense>'
+        )
+
+        reason = _prolog_refusal_reason(path)
+
+        assert reason is not None
+        assert 'prolog' in reason
+
+    def test_cap_does_not_become_a_bypass(self, tmp_path):
+        """A DOCTYPE hidden past the cap must not be let through
+
+        The reason differs - the scan stops before reaching the declaration -
+        but the file is still refused, which is the property that matters.
+        """
+        padding = 'P' * (_PROLOG_MAX + 1024)
+        path = write(
+            tmp_path,
+            f'<?xml version="1.0"?>\n<!--{padding}-->\n'
+            '<!DOCTYPE pfsense [ <!ENTITY a "aaaa"> ]>\n<pfsense><a>&a;</a></pfsense>'
+        )
+
+        assert _prolog_refusal_reason(path) is not None
+
+    def test_large_file_with_small_prolog_accepted(self, tmp_path):
+        """The cap measures the prolog, not the file
+
+        A config far larger than the cap is ordinary and must still parse; only
+        the bytes before the root element are counted.
+        """
+        body = '<a>' + ('x' * (_PROLOG_MAX * 2)) + '</a>'
+        path = write(tmp_path, f'<?xml version="1.0"?>\n<pfsense>{body}</pfsense>')
+
+        assert _prolog_refusal_reason(path) is None
+
+    def test_prolog_just_under_cap_still_scanned(self, tmp_path):
+        """Right below the cap the DOCTYPE is still found, not skipped"""
+        padding = 'P' * (_PROLOG_MAX - 4096)
+        path = write(
+            tmp_path,
+            f'<?xml version="1.0"?>\n<!--{padding}-->\n'
+            '<!DOCTYPE pfsense>\n<pfsense><a>1</a></pfsense>'
+        )
+
+        assert declares_doctype(path), 'must be caught for the DOCTYPE, not the size'
 
 
 class TestSkipPrologNoise:

--- a/tests/unit/test_doctype_rejection.py
+++ b/tests/unit/test_doctype_rejection.py
@@ -1,0 +1,190 @@
+"""
+Tests for the DOCTYPE guard on input files.
+
+pfSense never emits a DOCTYPE, so one in the input means the file did not come
+from pfSense untouched. ElementTree does not resolve external entities - a
+SYSTEM entity raises ParseError, so there is no XXE - but it does expand
+internal ones, and a few hundred bytes of nested definitions expand to
+gigabytes. The guard refuses the file rather than parsing it.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import (
+    PfSenseRedactor,
+    _declares_doctype,
+    _skip_prolog_noise,
+)
+
+MINIMAL_CONFIG = '<?xml version="1.0"?>\n<pfsense><version>1.0</version></pfsense>'
+
+ENTITY_BOMB = '''<?xml version="1.0"?>
+<!DOCTYPE pfsense [
+<!ENTITY a "aaaaaaaaaa">
+<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+<!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+]>
+<pfsense><version>&c;</version></pfsense>'''
+
+
+def write(tmp_path, content, name='config.xml'):
+    """Write a config file and return its path as a string"""
+    path = tmp_path / name
+    path.write_text(content, encoding='utf-8')
+    return str(path)
+
+
+class TestDoctypeDetection:
+    """_declares_doctype on the shapes a prolog can take"""
+
+    def test_plain_doctype_detected(self, tmp_path):
+        """The ordinary case: a DOCTYPE straight after the XML declaration"""
+        path = write(tmp_path, ENTITY_BOMB)
+
+        assert _declares_doctype(path)
+
+    def test_no_doctype_accepted(self, tmp_path):
+        """A normal config declares nothing"""
+        path = write(tmp_path, MINIMAL_CONFIG)
+
+        assert not _declares_doctype(path)
+
+    def test_doctype_behind_oversized_comment_detected(self, tmp_path):
+        """A comment larger than the read chunk must not hide the DOCTYPE
+
+        This is the regression that motivates scanning the whole prolog. A
+        fixed-size prefix check reports success while letting the file through,
+        which is worse than no guard at all.
+        """
+        padding = 'P' * (_chunk() * 2)
+        path = write(
+            tmp_path,
+            f'<?xml version="1.0"?>\n<!--{padding}-->\n{ENTITY_BOMB.split(chr(10), 1)[1]}'
+        )
+
+        assert _declares_doctype(path)
+
+    def test_comment_without_doctype_accepted(self, tmp_path):
+        """Padding alone is not grounds for refusal"""
+        padding = 'P' * (_chunk() * 2)
+        path = write(
+            tmp_path,
+            f'<?xml version="1.0"?>\n<!--{padding}-->\n<pfsense><a>1</a></pfsense>'
+        )
+
+        assert not _declares_doctype(path)
+
+    def test_lowercase_doctype_detected(self, tmp_path):
+        """XML requires the upper-case spelling; refuse the other one here
+
+        Rather than leave it to the parser, so the outcome does not depend on
+        which parser is in use.
+        """
+        path = write(tmp_path, '<!doctype pfsense><pfsense><a>1</a></pfsense>')
+
+        assert _declares_doctype(path)
+
+    def test_utf8_bom_skipped(self, tmp_path):
+        """A byte-order mark must not shift the declaration out of view"""
+        path = tmp_path / 'bom.xml'
+        path.write_bytes(b'\xef\xbb\xbf' + ENTITY_BOMB.encode('utf-8'))
+
+        assert _declares_doctype(str(path))
+
+    def test_multiple_comments_and_pis_skipped(self, tmp_path):
+        """Whitespace, several comments and a PI may all precede the DOCTYPE"""
+        path = write(
+            tmp_path,
+            '<?xml version="1.0"?>\n\n  <!-- one -->\n<!-- two -->\n'
+            '<?target data?>\n  <!DOCTYPE pfsense>\n<pfsense><a>1</a></pfsense>'
+        )
+
+        assert _declares_doctype(path)
+
+    def test_doctype_inside_comment_not_detected(self, tmp_path):
+        """A DOCTYPE mentioned in a comment is text, not a declaration"""
+        path = write(
+            tmp_path,
+            '<!-- no <!DOCTYPE here -->\n<pfsense><a>1</a></pfsense>'
+        )
+
+        assert not _declares_doctype(path)
+
+    def test_empty_file_accepted(self, tmp_path):
+        """Nothing to refuse; ET.parse reports the real problem"""
+        path = write(tmp_path, '')
+
+        assert not _declares_doctype(path)
+
+    def test_unterminated_comment_accepted(self, tmp_path):
+        """Malformed input is the parser's to describe, not this guard's"""
+        path = write(tmp_path, '<!-- never closed\n<pfsense><a>1</a></pfsense>')
+
+        assert not _declares_doctype(path)
+
+    @pytest.mark.parametrize('boundary_offset', range(-2, 3))
+    def test_doctype_split_across_read_boundary(self, tmp_path, boundary_offset):
+        """The declaration must be found even when a read splits it in two"""
+        # Pad so '<!DOCTYPE' straddles the chunk boundary at several offsets.
+        prefix = '<?xml version="1.0"?>'
+        padding_len = _chunk() - len(prefix) - len('<!--') - len('-->') + boundary_offset
+        path = write(
+            tmp_path,
+            f'{prefix}<!--{"P" * padding_len}--><!DOCTYPE pfsense>'
+            '<pfsense><a>1</a></pfsense>'
+        )
+
+        assert _declares_doctype(path)
+
+
+class TestSkipPrologNoise:
+    """_skip_prolog_noise reports where the prolog ends"""
+
+    def test_returns_none_when_construct_is_truncated(self):
+        """None means 'read more', not 'nothing here'"""
+        assert _skip_prolog_noise(b'<!-- unterminated', 0) is None
+
+    def test_stops_at_root_element(self):
+        """A start tag is not noise, so scanning stops there"""
+        data = b'<!-- c --><pfsense>'
+
+        assert _skip_prolog_noise(data, 0) == data.index(b'<pfsense>')
+
+    def test_stops_at_doctype(self):
+        """The DOCTYPE is not skippable; the caller inspects it"""
+        data = b'  <?xml version="1.0"?>  <!DOCTYPE r>'
+
+        assert _skip_prolog_noise(data, 0) == data.index(b'<!DOCTYPE')
+
+
+class TestRedactConfigRefusesDoctype:
+    """End to end: the file is refused before any parsing happens"""
+
+    def test_entity_bomb_refused(self, tmp_path, caplog):
+        """redact_config fails, and says why"""
+        redactor = PfSenseRedactor()
+        output = tmp_path / 'out.xml'
+
+        result = redactor.redact_config(write(tmp_path, ENTITY_BOMB), str(output))
+
+        assert result is False
+        assert not output.exists(), 'nothing should be written'
+        assert 'DOCTYPE' in caplog.text
+
+    def test_ordinary_config_still_processed(self, tmp_path):
+        """The guard does not stand in the way of a normal file"""
+        redactor = PfSenseRedactor()
+        output = tmp_path / 'out.xml'
+
+        result = redactor.redact_config(write(tmp_path, MINIMAL_CONFIG), str(output))
+
+        assert result is True
+        assert ET.parse(str(output)).getroot().tag == 'pfsense'
+
+
+def _chunk() -> int:
+    """The guard's read size, so the boundary tests track it if it changes"""
+    from pfsense_redactor.redactor import _PROLOG_CHUNK
+
+    return _PROLOG_CHUNK

--- a/tests/unit/test_path_validation.py
+++ b/tests/unit/test_path_validation.py
@@ -171,7 +171,7 @@ class TestPathValidation:  # pylint: disable=too-many-public-methods
         assert error == ""
         assert resolved is not None
 
-    def test_home_directory_allowed(self):
+    def test_home_directory_allowed(self, require_writable_home):
         """Paths in home directory should be allowed"""
         home_path = str(Path.home() / "config.xml")
         valid, error, resolved = validate_file_path(


### PR DESCRIPTION
## What this is

A follow-up report was filed against 1.1.0 (the PyPI release) proposing four
fixes. Three of them — and the entire second finding — are **already on `main`**
in the unreleased 1.1.1, which the reporter could not have seen. This PR
implements the one item that is genuinely new, and fixes the two test failures
they hit on an unmodified checkout.

## Already fixed on `main` (no change needed)

Verified by running the reporter's own fixtures under `--aggressive`:

| Case | Result on `main` |
|---|---|
| Slack token, alphanumeric | `[REDACTED]` |
| Slack token, all-alpha (24 ch) | `[REDACTED]` |
| Discord webhook token | `[REDACTED]` |
| Telegram `bot<id>:<secret>` | `[REDACTED]` |
| AWS `AKIAIOSFODNN7EXAMPLE` (20 ch) | `[REDACTED]` |
| `list.txt`, `emerging-block.rules`, `haproxy.sh`, `backup-2026.tar.gz` | preserved |

The regression cases the report suggested adding also already exist, in
`tests/unit/test_secret_detection.py::TestURLPathCredentialFormats`.

One deliberate difference on the Telegram case: the report proposed emitting
`bot123456789:[REDACTED]`, keeping the bot ID. `main` redacts the whole
segment. Given the threat model is failure to redact, the stricter form is the
right default and the bot ID is not worth preserving.

## What this PR adds

### Refuse input declaring a DOCTYPE

Worth being precise about severity, since the report itself walked back an
initial overstatement:

- **There is no XXE.** Confirmed: `xml.etree.ElementTree` does not resolve
  external entities; a `SYSTEM "file:///etc/hostname"` entity raises
  `ParseError: undefined entity`. No file disclosure, no SSRF.
- **Internal entity expansion is real.** A small file expands to gigabytes.
- **Severity is low.** The input is a file the user supplies, and the failure is
  loud — not a silent under-redaction.

It is implemented because it is cheap, fails closed, and pfSense never emits a
DOCTYPE.

### The proposed fix would not have worked

The report suggested scanning the first 8192 bytes for `<!DOCTYPE`. That is
bypassable, and I confirmed it: a DOCTYPE preceded by a 9 KB comment parses and
expands entities normally, while the guard reports the file clean. A guard that
passes while doing nothing is worse than no guard.

This scans the **whole prolog** instead — skipping whitespace, comments and PIs
until it reaches either the declaration or the root element — so padding cannot
push the DOCTYPE out of view. Verified against a bomb hidden behind 200 KB of
comment. `tests/unit/test_doctype_rejection.py` covers that case, plus BOM
handling, lowercase `<!doctype>`, a DOCTYPE mentioned inside a comment, and the
declaration straddling a read boundary at five offsets.

### Two tests no longer depend on $HOME

`test_home_directory_allowed` and `test_safe_absolute_path_in_home` both assert
that an ordinary home directory is an acceptable output location. That is false
when running as root — `HOME=/root`, which `_get_sensitive_directories()` lists,
so the tool correctly refuses and the test fails. This is what the reporter hit;
the tool is right and the test's premise is what breaks.

A shared `require_writable_home` fixture skips them there. Confirmed both pass
normally and skip under `HOME=/root`.

## Complexity

The guard initially pushed `redact_config` from radon B(10) to C(11). Folding
it and the existing root-tag check into `_load_config_tree` returns it to
**B(10)**, matching `main` exactly. Nothing in the module is at C or worse.

Note `flake8 --select=C901` reported clean throughout — mccabe undercounts
relative to radon, which is what Codacy uses, so both were checked.

## Verification

- 553 tests collected (533 on `main` + 20 new), 552 passed, 1 pre-existing skip
- Reference snapshots unchanged
- `pylint` exits 0 for both prod and test configs
- No radon C-or-worse; average A (4.42)
- Canary corpus unchanged from `main` — the same 4 known-acceptable results,
  two of which are the short cert *references* the report withdrew as filed in
  error
- `--stdout`/`--aggressive` behaviour on the reporter's fixtures unchanged

## Not done

The report's remaining item — running non-sensitively-named attribute values
through the aggressive text scanner — is left alone. It is speculative, pfSense
barely uses XML attributes, and `SENSITIVE_ATTR_PATTERN` matching on attribute
name is a deliberate design choice.
