### PR TITLE
Clear CodeScene's structural findings, and gate them so they stay clear

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,13 +32,19 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Cyclomatic complexity is a hard gate for the package itself. Every
-        # function was brought under 10; without a blocking check that decays.
-        # Scoped to pfsense_redactor/ deliberately - the tests carry pre-existing
-        # style findings that are a separate concern.
-        flake8 pfsense_redactor/ --count --select=C901 --max-complexity=10 --show-source --statistics
+        # Cyclomatic complexity is a hard gate, across the tests as well as the
+        # package. Every function was brought under 9; without a blocking check
+        # that decays. mccabe folds a nested closure into its parent, so a
+        # closure cannot be used to hide complexity from this.
+        flake8 pfsense_redactor/ tests/ tools/ --count --select=C901 --max-complexity=8 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=8 --max-line-length=127 --statistics
+    - name: Check code structure
+      run: |
+        # Nesting depth, separate blocks of nested logic, and multi-operator
+        # conditions. flake8 measures none of these, so they need their own
+        # gate or the shape work decays even while complexity stays green.
+        python tools/check_structure.py pfsense_redactor/ tests/ tools/
     - name: Test with pytest
       run: |
         pytest

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -849,6 +849,36 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         host_parts = host.split(':')
         return f"[{host_parts[0]}:{host_parts[1]}:*:****::{host_parts[-1]}]" if len(host_parts) >= 3 else f"[{host}]"
 
+    @staticmethod
+    def _build_sample_netloc(parts: SplitResult, masked_host: str) -> str:
+        """Assemble the netloc for a sample display
+
+        The password becomes *** rather than disappearing, so the preview still
+        shows that one was there.
+        """
+        userinfo = ''
+        if parts.username:
+            userinfo = f"{parts.username}:***@" if parts.password else f"{parts.username}@"
+        netloc = f"{userinfo}{masked_host}"
+        if parts.port:
+            netloc += f":{parts.port}"
+        return netloc
+
+    @staticmethod
+    def _join_bracketed_url(parts: SplitResult, netloc: str,
+                            path: str, query: str) -> str:
+        """Reassemble a sample URL whose masked host is a bracketed IPv6 literal
+
+        Kept as hand assembly rather than urlunsplit, which is how this branch
+        has always built the bracketed form.
+        """
+        result = f"{parts.scheme}://{netloc}{path}"
+        if query:
+            result += f"?{query}"
+        if parts.fragment:
+            result += f"#{parts.fragment}"
+        return result
+
     def _mask_url_sample(self, value: str) -> str:
         """Mask URL for sample display
 
@@ -865,25 +895,14 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return value
 
             masked_host = self._mask_sample_host(host)
-
-            userinfo = ''
-            if parts.username:
-                userinfo = f"{parts.username}:***@" if parts.password else f"{parts.username}@"
-            netloc = f"{userinfo}{masked_host}"
-            if parts.port:
-                netloc += f":{parts.port}"
+            netloc = self._build_sample_netloc(parts, masked_host)
 
             # Credentials also live in the path and query, not just userinfo
             safe_path, _ = self._build_redacted_path(parts.path)
             safe_query, _ = self._build_redacted_query(parts.query)
 
             if '[' in masked_host:
-                result = f"{parts.scheme}://{netloc}{safe_path}"
-                if safe_query:
-                    result += f"?{safe_query}"
-                if parts.fragment:
-                    result += f"#{parts.fragment}"
-                return result
+                return self._join_bracketed_url(parts, netloc, safe_path, safe_query)
             return urlunsplit((parts.scheme, netloc, safe_path, safe_query, parts.fragment))
         except (ValueError, AttributeError):
             pass
@@ -2361,12 +2380,12 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return False
             root = tree.getroot()
 
+            # Both lines are progress reporting under the same condition, and
+            # nothing runs between them, so they share one guard.
             if not dry_run and not stdout_mode:
                 self.logger.info("[+] Parsing XML configuration from: %s", input_file)
-
-            # Redact the configuration
-            if not dry_run and not stdout_mode:
                 self.logger.info("[+] Redacting sensitive information...")
+
             self.redact_element(root, redact_ips, redact_domains)
 
             # Dry run mode: just print stats

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -513,6 +513,40 @@ def _prolog_scan_is_conclusive(data: bytes, pos: int, at_eof: bool) -> bool:
     return at_eof or len(data) - pos >= len(_DOCTYPE_DECL)
 
 
+# Distinguishes "this buffer cannot decide yet" from "accept" (None), which a
+# bare None would conflate.
+_NEED_MORE_INPUT = object()
+
+
+def _examine_prolog(data: bytes, at_eof: bool) -> str | None | object:
+    """Judge the prolog from the bytes read so far
+
+    Returns a refusal reason, None to accept, or _NEED_MORE_INPUT when the
+    answer still depends on bytes that have not been read.
+    """
+    if len(data) > _PROLOG_MAX:
+        return (f"its XML prolog exceeds {_PROLOG_MAX // 1024} KiB "
+                "without reaching a root element")
+
+    start = len(_UTF8_BOM) if data.startswith(_UTF8_BOM) else 0
+    pos = _skip_prolog_noise(data, start)
+
+    if pos is not None and _prolog_scan_is_conclusive(data, pos, at_eof):
+        # Compared case-insensitively even though XML requires the upper-case
+        # spelling, so that '<!doctype' is refused here rather than relying on
+        # the parser to reject it.
+        if data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL:
+            return "it declares a DOCTYPE, which pfSense never emits"
+        return None
+
+    if at_eof:
+        # Unterminated comment or PI. The file is malformed, and ET.parse
+        # reports that more precisely than this guard could.
+        return None
+
+    return _NEED_MORE_INPUT
+
+
 def _prolog_refusal_reason(input_file: str) -> str | None:
     """Say why the input's XML prolog is unacceptable, or None if it is fine
 
@@ -535,27 +569,9 @@ def _prolog_refusal_reason(input_file: str) -> str | None:
         while True:
             chunk = handle.read(_PROLOG_CHUNK)
             data += chunk
-
-            at_eof = not chunk
-            if len(data) > _PROLOG_MAX:
-                return (f"its XML prolog exceeds {_PROLOG_MAX // 1024} KiB "
-                        "without reaching a root element")
-
-            start = len(_UTF8_BOM) if data.startswith(_UTF8_BOM) else 0
-            pos = _skip_prolog_noise(data, start)
-
-            if pos is not None and _prolog_scan_is_conclusive(data, pos, at_eof):
-                # Compared case-insensitively even though XML requires the
-                # upper-case spelling, so that '<!doctype' is refused here
-                # rather than relying on the parser to reject it.
-                if data[pos:pos + len(_DOCTYPE_DECL)].upper() == _DOCTYPE_DECL:
-                    return "it declares a DOCTYPE, which pfSense never emits"
-                return None
-
-            if at_eof:
-                # Unterminated comment or PI. The file is malformed, and
-                # ET.parse reports that more precisely than this guard could.
-                return None
+            verdict = _examine_prolog(data, at_eof=not chunk)
+            if verdict is not _NEED_MORE_INPUT:
+                return verdict
 
 
 # ==========================================================================

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -71,6 +71,15 @@ class ColouredFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style)
         self.stream = stream
 
+    @staticmethod
+    def _stream_is_tty(stream) -> bool:
+        """Whether the stream is a terminal that can render colour
+
+        Streams reaching here are not always file objects - the tests pass
+        stand-ins - so isatty is checked for rather than assumed.
+        """
+        return bool(stream) and hasattr(stream, 'isatty') and stream.isatty()
+
     def format(self, record):
         """Format log record with colours if outputting to a TTY
 
@@ -81,7 +90,7 @@ class ColouredFormatter(logging.Formatter):
         formatted = super().format(record)
 
         # Only add colours if outputting to a TTY
-        if self.stream and hasattr(self.stream, 'isatty') and self.stream.isatty():
+        if self._stream_is_tty(self.stream):
             levelname = record.levelname
             if levelname in self.COLOURS:
                 colour = self.COLOURS[levelname]
@@ -204,6 +213,18 @@ SECRET_TAG_DENYLIST: frozenset[str] = frozenset({
     'source_hash_key',       # HAProxy load-balancing algorithm selector
 })
 
+
+def _is_secret_query_param(name_lower: str, value: str) -> bool:
+    """Whether a URL query parameter carries a credential
+
+    The deny-list is consulted before the pattern, so a name that merely looks
+    secret-ish ('keylen', 'certref') is not redacted on the strength of a
+    substring match.
+    """
+    return (bool(value)
+            and name_lower not in SECRET_TAG_DENYLIST
+            and bool(SECRET_TAG_PATTERN.search(name_lower)))
+
 # Opaque free-text containers that routinely carry credentials inline.
 # custom_options is the standard place for OpenVPN/Unbound/Squid directives and
 # frequently holds askpass, auth-user-pass and inline keys.
@@ -293,6 +314,15 @@ RFC_DOC_NETWORKS_V4: tuple[IPNetwork, ...] = (
     ipaddress.ip_network('203.0.113.0/24'),
 )
 RFC_DOC_NETWORK_V6: IPNetwork = ipaddress.ip_network('2001:db8::/32')
+
+
+def _disqualified_as_blob(compact: str) -> bool:
+    """Whether a candidate is ruled out as encoded key material on shape alone
+
+    Too short to be a key, or containing whitespace - which encoded blobs do
+    not, once line wrapping has been removed, but ordinary prose does.
+    """
+    return len(compact) < BLOB_MIN_SCAN_LENGTH or ' ' in compact or '\t' in compact
 
 
 def _has_mixed_character_classes(compact: str, hex_only: bool) -> bool:
@@ -1374,6 +1404,15 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         masked = self._anonymise_domain(host) if self.anonymise else 'example.com'
         return masked, True, False
 
+    @staticmethod
+    def _needs_ipv6_brackets(host: str, is_ipv6: bool) -> bool:
+        """Whether a host must be bracketed to be a valid URL netloc
+
+        A colon in an unbracketed host means IPv6 even when the caller did not
+        already know it, which is why the flag alone is not enough.
+        """
+        return is_ipv6 or (':' in host and not host.startswith('['))
+
     def _build_netloc(self, parts: SplitResult, host: str, is_ipv6: bool) -> str:
         """Build netloc with userinfo, host, and port"""
         userinfo = ''
@@ -1387,7 +1426,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             userinfo += '@'
 
         # Wrap IPv6 in brackets
-        if is_ipv6 or (':' in host and not host.startswith('[')):
+        if self._needs_ipv6_brackets(host, is_ipv6):
             host = f"[{host}]"
 
         netloc = f"{userinfo}{host}"
@@ -1431,7 +1470,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         out = []
         for name, value in pairs:
             name_l = name.lower()
-            if value and name_l not in SECRET_TAG_DENYLIST and SECRET_TAG_PATTERN.search(name_l):
+            if _is_secret_query_param(name_l, value):
                 out.append((name, '[REDACTED]'))
                 changed = True
             else:
@@ -1912,7 +1951,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # ordinary prose ("This is a fairly long note") into an unbroken
         # alphanumeric run that looks exactly like base64.
         compact = text.replace('\n', '').replace('\r', '')
-        if len(compact) < BLOB_MIN_SCAN_LENGTH or ' ' in compact or '\t' in compact:
+        if _disqualified_as_blob(compact):
             return False
 
         if not (BASE64ISH_RE.match(compact) or HEXISH_RE.match(compact)):
@@ -2063,14 +2102,23 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return True
 
+    def _looks_like_cert_material(self, text: str | None) -> bool:
+        """Whether an element's text is a certificate or key rather than a reference
+
+        Short values in cert-named elements are references (a certref, a key
+        id), not the material itself, so length is what separates them absent a
+        PEM header.
+        """
+        if not text:
+            return False
+        return bool(self.PEM_MARKER.search(text)) or len(text.strip()) > self.CERT_MIN_LENGTH
+
     def _redact_cert_key_element(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Redact certificate/key elements. Returns True if this is a cert/key element."""
         if not self._is_cert_tag(tag, tag_base):
             return False
 
-        # Use class constant for minimum certificate length
-        if element.text and (self.PEM_MARKER.search(element.text) or
-                            len(element.text.strip()) > self.CERT_MIN_LENGTH):
+        if self._looks_like_cert_material(element.text):
             self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
 
         return True
@@ -2117,6 +2165,15 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                     element.attrib[attr], redact_ips, redact_domains
                 )
 
+    @staticmethod
+    def _carries_unhandled_url(text: str | None, handled: bool) -> bool:
+        """Whether text still needs the URL-credential pass
+
+        'handled' means an earlier, more specific pass already rewrote this
+        element, so running the URL pass over it again would double-process it.
+        """
+        return bool(text) and not handled and '://' in text
+
     def _redact_element_text(
         self, tag: str, tag_base: str, element: ET.Element,
         redact_ips: bool, redact_domains: bool
@@ -2146,7 +2203,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # carriers (e.g. <updateurl>, <webhook_url>). Previously these were
         # only touched under --aggressive, so the token survived by default.
         # Host anonymisation deliberately stays out of the default path here.
-        if element.text and not handled and '://' in element.text:
+        if self._carries_unhandled_url(element.text, handled):
             element.text = self._redact_url_secrets_only(element.text)
 
         return handled
@@ -2724,6 +2781,19 @@ def validate_file_path(
         return False, f"Error validating path: {e}", None
 
 
+def _is_disallowed_absolute(is_absolute_form: bool, allow_absolute: bool,
+                            resolved_str: str) -> bool:
+    """Whether an absolute path is refused for being absolute
+
+    Only the reason is named here, not the ordering: this check must still run
+    *after* the sensitive-directory check in _resolved_path_error, so that
+    --allow-absolute-paths cannot reach a protected directory.
+    """
+    return (is_absolute_form
+            and not allow_absolute
+            and not _is_safe_absolute_location(resolved_str))
+
+
 def _resolved_path_error(
     file_path: str, resolved: Path, is_absolute_form: bool, allow_absolute: bool,
     is_output: bool, sensitive_dirs: frozenset[str]
@@ -2741,7 +2811,7 @@ def _resolved_path_error(
     if is_output and _is_in_sensitive_directory(resolved_str, sensitive_dirs):
         return f"Cannot write to sensitive system directory: {resolved}"
 
-    if is_absolute_form and not allow_absolute and not _is_safe_absolute_location(resolved_str):
+    if _is_disallowed_absolute(is_absolute_form, allow_absolute, resolved_str):
         return f"Absolute paths not allowed (use --allow-absolute-paths): {file_path}"
 
     if is_output and resolved_str in DANGEROUS_OUTPUT_FILES:
@@ -2907,20 +2977,42 @@ def _resolve_input_path(
         sys.exit(1)
 
 
+def _output_path_will_be_used(args: argparse.Namespace) -> bool:
+    """Whether args.output is worth validating
+
+    The only skipped case is --stdout without --dry-run, where args.output is
+    never written.
+    """
+    return bool(args.output) and (args.dry_run or not args.stdout)
+
+
+def _would_overwrite_without_force(args: argparse.Namespace, resolved: Path) -> bool:
+    """Whether writing would destroy an existing file the user did not consent to
+
+    Overwrite protection applies only when a write will actually happen, so the
+    modes that write nothing are excluded first, then explicit consent.
+    """
+    if args.dry_run or args.stdout:
+        return False
+    if args.force:
+        return False
+    return resolved.exists()
+
+
 def _resolve_output_path(
     args: argparse.Namespace, sensitive_dirs: frozenset[str], logger: logging.Logger
 ) -> None:
     """Validate the output path, including the extra --inplace checks"""
     # Validated whenever the path will be used. The only skipped case is
     # --stdout without --dry-run, where args.output is never written.
-    if args.output and (args.dry_run or not args.stdout):
+    if _output_path_will_be_used(args):
         resolved = _validate_as_output_target(
             args.output, args, sensitive_dirs, logger,
             "[!] Error: Invalid output path: %s"
         )
 
         # Overwrite protection applies only when a write will actually happen
-        if not args.dry_run and not args.stdout and not args.force and resolved.exists():
+        if _would_overwrite_without_force(args, resolved):
             logger.error("[!] Error: Output file '%s' already exists. Use --force to overwrite.", args.output)
             sys.exit(1)
 
@@ -3065,6 +3157,19 @@ def _configure_logging_from_args(args: argparse.Namespace) -> None:
     setup_logging(log_level, use_stderr=args.stdout)
 
 
+def _needs_generated_output_name(args: argparse.Namespace) -> bool:
+    """Whether a destination has to be invented because none was given
+
+    Every mode that writes somewhere else - stdout, in place, or nowhere at all
+    under --dry-run - supplies its own destination.
+    """
+    if args.stdout or args.inplace:
+        return False
+    if args.dry_run:
+        return False
+    return not args.output
+
+
 def _apply_argument_defaults(args: argparse.Namespace) -> None:
     """Fill in values implied by other flags, before any validation"""
     # --dry-run-verbose is a louder --dry-run
@@ -3072,7 +3177,7 @@ def _apply_argument_defaults(args: argparse.Namespace) -> None:
         args.dry_run = True
 
     # Auto-generate output filename when one is needed but not given
-    if not args.stdout and not args.inplace and not args.dry_run and not args.output:
+    if _needs_generated_output_name(args):
         input_path = Path(args.input)
         args.output = str(input_path.parent / f"{input_path.stem}-redacted{input_path.suffix}")
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -790,17 +790,19 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # Compute IDNA form using cached function
         host_idna = _idna_encode(host_l)
 
-        # Check exact match or suffix match against Unicode forms
-        for allow_domain in self.allowlist_domains:
-            if host_l == allow_domain or host_l.endswith('.' + allow_domain):
-                return True
+        # Both forms are checked so a host written either way matches the
+        # same allow-list entry.
+        return (self._matches_allowed_domain(host_l, self.allowlist_domains)
+                or self._matches_allowed_domain(host_idna, self.allowlist_domains_idna))
 
-        # Check exact match or suffix match against IDNA forms
-        for allow_domain_idna in self.allowlist_domains_idna:
-            if host_idna == allow_domain_idna or host_idna.endswith('.' + allow_domain_idna):
-                return True
+    @staticmethod
+    def _matches_allowed_domain(host: str, allowed: set[str]) -> bool:
+        """Whether host equals, or is a subdomain of, any allowed domain
 
-        return False
+        The leading dot on the suffix test matters: without it 'notexample.com'
+        would match an allow-list entry of 'example.com'.
+        """
+        return any(host == domain or host.endswith('.' + domain) for domain in allowed)
 
     def _is_ip_allowed(self, ip: IPAddress) -> bool:
         """Check if an IP address is in the allow-list (including CIDR networks)"""
@@ -1455,17 +1457,23 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         """
         return is_ipv6 or (':' in host and not host.startswith('['))
 
+    def _build_userinfo(self, parts: SplitResult) -> str:
+        """Build the 'user:pass@' prefix of a netloc, redacting as configured
+
+        The password is always replaced; the username only under
+        --redact-url-usernames, since it is often an ordinary account name that
+        is more useful left readable.
+        """
+        if not parts.username:
+            return ''
+
+        username = 'REDACTED' if self.redact_url_usernames else parts.username
+        password = ':REDACTED' if parts.password else ''
+        return f"{username}{password}@"
+
     def _build_netloc(self, parts: SplitResult, host: str, is_ipv6: bool) -> str:
         """Build netloc with userinfo, host, and port"""
-        userinfo = ''
-        if parts.username:
-            if self.redact_url_usernames:
-                userinfo = 'REDACTED'
-            else:
-                userinfo = parts.username
-            if parts.password:
-                userinfo += ':REDACTED'
-            userinfo += '@'
+        userinfo = self._build_userinfo(parts)
 
         # Wrap IPv6 in brackets
         if self._needs_ipv6_brackets(host, is_ipv6):

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -225,6 +225,7 @@ def _is_secret_query_param(name_lower: str, value: str) -> bool:
             and name_lower not in SECRET_TAG_DENYLIST
             and bool(SECRET_TAG_PATTERN.search(name_lower)))
 
+
 # Opaque free-text containers that routinely carry credentials inline.
 # custom_options is the standard place for OpenVPN/Unbound/Squid directives and
 # frequently holds askpass, auth-user-pass and inline keys.

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -654,30 +654,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.MAX_TEXT_CHUNK: int = 1048576  # 1MB max for any text element
 
         # Allow-lists (opt-in, empty by default)
-        # IP allow-lists: support both individual IPs and CIDR networks
-        self.allowlist_ip_addrs: set[IPAddress] = set()
-        if allowlist_ips:
-            for ip_str in allowlist_ips:
-                try:
-                    self.allowlist_ip_addrs.add(ipaddress.ip_address(ip_str))
-                except ValueError:
-                    pass  # Will be handled as network or error elsewhere
-
-        self.allowlist_ip_networks: list[IPNetwork] = []
-        if allowlist_networks:
-            self.allowlist_ip_networks = list(allowlist_networks)
-
-        # Domain allow-lists: store both normalised Unicode and IDNA forms
-        self.allowlist_domains: set[str] = set()
-        self.allowlist_domains_idna: set[str] = set()
-        if allowlist_domains:
-            for domain in allowlist_domains:
-                norm_domain, idna_domain = self._normalise_domain(domain)
-                # Skip invalid/empty domains (returns None, None)
-                if norm_domain is not None:
-                    self.allowlist_domains.add(norm_domain)
-                    if idna_domain and idna_domain != norm_domain:
-                        self.allowlist_domains_idna.add(idna_domain)
+        self._ingest_allowlist_ips(allowlist_ips, allowlist_networks)
+        self._ingest_allowlist_domains(allowlist_domains)
 
         # Sample collection for --dry-run-verbose
         self.sample_limit: int = self.SAMPLE_LIMIT
@@ -728,6 +706,35 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.PEM_MARKER = re.compile(
             r'-----BEGIN (?:CERTIFICATE|RSA PRIVATE KEY|EC PRIVATE KEY|ENCRYPTED PRIVATE KEY|PRIVATE KEY|PUBLIC KEY|OPENVPN STATIC KEY|OPENSSH PRIVATE KEY)-----'
         )
+
+    def _ingest_allowlist_ips(self, allowlist_ips: set[str] | None,
+                              allowlist_networks: list[IPNetwork] | None) -> None:
+        """Populate the IP allow-lists, accepting both addresses and CIDRs"""
+        self.allowlist_ip_addrs: set[IPAddress] = set()
+        self.allowlist_ip_networks: list[IPNetwork] = list(allowlist_networks or [])
+
+        for ip_str in allowlist_ips or ():
+            try:
+                self.allowlist_ip_addrs.add(ipaddress.ip_address(ip_str))
+            except ValueError:
+                pass  # Will be handled as network or error elsewhere
+
+    def _ingest_allowlist_domains(self, allowlist_domains: set[str] | None) -> None:
+        """Populate the domain allow-lists in both Unicode and IDNA forms
+
+        Both are stored so a host written either way matches the same entry.
+        """
+        self.allowlist_domains: set[str] = set()
+        self.allowlist_domains_idna: set[str] = set()
+
+        for domain in allowlist_domains or ():
+            norm_domain, idna_domain = self._normalise_domain(domain)
+            # Skip invalid/empty domains (returns None, None)
+            if norm_domain is None:
+                continue
+            self.allowlist_domains.add(norm_domain)
+            if idna_domain and idna_domain != norm_domain:
+                self.allowlist_domains_idna.add(idna_domain)
 
     def _normalise_domain(self, domain: str) -> tuple[str | None, str | None]:
         """Normalise domain: lowercase, strip leading and trailing dots, handle wildcards, compute IDNA

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -1182,53 +1182,63 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # multicast, reserved and unspecified
         return self.keep_private_ips and not ip.is_global
 
+    def _mask_one_ip_token(self, token: str) -> str:
+        """Mask a single IP-like token, or return it unchanged
+
+        A method rather than a closure inside _mask_ip_like_tokens: it uses
+        nothing but self and its argument, and analysers that fold nested
+        functions into their parent counted the whole thing as one oversized
+        unit.
+        """
+        # Skip already-masked tokens
+        if token in ('XXX.XXX.XXX.XXX', 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX', '[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]'):
+            return token
+        original_token = token
+
+        token, port_suffix = self._strip_ip_token_port(token)
+
+        ip, bracketed, zone = self._parse_ip_token(token)
+        if ip is None:
+            return original_token
+
+        if self._should_preserve_ip(ip):
+            return original_token
+
+        # Anonymisation mode
+        if self.anonymise:
+            rep = self._anonymise_ip(str(ip))
+        else:
+            # Standard redaction
+            rep = 'XXX.XXX.XXX.XXX' if ip.version == 4 else 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX'
+
+        # Preserve zone identifier if present
+        if zone:
+            rep = f"{rep}%{zone}"
+        if bracketed:
+            rep = f"[{rep}]"
+
+        result = rep + port_suffix
+
+        # Only count if actually changed
+        if result != original_token:
+            self.stats['ips_redacted'] += 1
+            # Collect sample for dry-run-verbose
+            self._add_sample('IP', str(ip), rep)
+
+        return result
+
     def _mask_ip_like_tokens(self, text: str) -> str:
         """IP address masking using ipaddress module"""
-        def repl(token: str) -> str:
-            # Skip already-masked tokens
-            if token in ('XXX.XXX.XXX.XXX', 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX', '[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]'):
-                return token
-            original_token = token
-
-            token, port_suffix = self._strip_ip_token_port(token)
-
-            ip, bracketed, zone = self._parse_ip_token(token)
-            if ip is None:
-                return original_token
-
-            if self._should_preserve_ip(ip):
-                return original_token
-
-            # Anonymisation mode
-            if self.anonymise:
-                rep = self._anonymise_ip(str(ip))
-            else:
-                # Standard redaction
-                rep = 'XXX.XXX.XXX.XXX' if ip.version == 4 else 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX'
-
-            # Preserve zone identifier if present
-            if zone:
-                rep = f"{rep}%{zone}"
-            if bracketed:
-                rep = f"[{rep}]"
-
-            result = rep + port_suffix
-
-            # Only count if actually changed
-            if result != original_token:
-                self.stats['ips_redacted'] += 1
-                # Collect sample for dry-run-verbose
-                self._add_sample('IP', str(ip), rep)
-
-            return result
-
         # Split conservatively - matches IP-like tokens including zone IDs and ports
         # Pattern matches: IPs with optional brackets, zone identifiers, and ports
         # Examples: [fe80::1%eth0]:51820, [fe80::1%eth0], fe80::1%eth0, 192.168.1.1
         parts = self._ip_token_splitter.split(text)
         # Match tokens that look like IPs (with or without brackets/zones/ports)
         # Use pre-compiled pattern for consistency and performance
-        return ''.join(repl(p) if self.IP_PATTERN.match(p) else p for p in parts)
+        return ''.join(
+            self._mask_one_ip_token(p) if self.IP_PATTERN.match(p) else p
+            for p in parts
+        )
 
     def _anonymise_domain(self, domain: str) -> str:
         """Generate a consistent alias for a domain
@@ -1599,31 +1609,43 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         'user:password@host' intact while the query secret next to it showed as
         [REDACTED], which reads as sanitised when it is not.
         """
-        def replacer(match):
-            url = match.group(0)
-            if len(url) > self.MAX_URL_LENGTH:
-                return url
+        return self.URL_RE.sub(self._redact_url_secrets_in_match, text)
 
-            parts = self._parse_url_safely(url)
-            if parts is None or not parts.netloc:
-                return url
+    def _redact_url_secrets_in_match(self, match) -> str:
+        """Redact credentials in one matched URL, leaving the host alone
 
-            netloc, netloc_changed = self._redact_netloc_userinfo(parts)
-            path = self._redact_path_secrets(parts.path) if self.aggressive else parts.path
-            query = self._redact_query_secrets(parts.query)
+        A method rather than a closure, for the same reason as
+        _mask_one_ip_token: it needs only self and the match.
+        """
+        url = match.group(0)
+        if len(url) > self.MAX_URL_LENGTH:
+            return url
 
-            # netloc_changed must be part of this test: a URL carrying
-            # credentials but no secret-named query parameter would otherwise
-            # never be rewritten at all.
-            if not netloc_changed and path == parts.path and query == parts.query:
-                return url
+        parts = self._parse_url_safely(url)
+        if parts is None or not parts.netloc:
+            return url
 
-            if netloc_changed:
-                self.stats['url_secrets_redacted'] += 1
+        netloc, netloc_changed = self._redact_netloc_userinfo(parts)
+        path = self._redact_path_secrets(parts.path) if self.aggressive else parts.path
+        query = self._redact_query_secrets(parts.query)
 
-            return urlunsplit((parts.scheme, netloc, path, query, parts.fragment))
+        if self._url_parts_unchanged(parts, netloc_changed, path, query):
+            return url
 
-        return self.URL_RE.sub(replacer, text)
+        if netloc_changed:
+            self.stats['url_secrets_redacted'] += 1
+
+        return urlunsplit((parts.scheme, netloc, path, query, parts.fragment))
+
+    @staticmethod
+    def _url_parts_unchanged(parts: SplitResult, netloc_changed: bool,
+                             path: str, query: str) -> bool:
+        """Whether redaction left the URL identical, so it can be returned as-is
+
+        netloc_changed must be part of this test: a URL carrying credentials but
+        no secret-named query parameter would otherwise never be rewritten.
+        """
+        return not netloc_changed and path == parts.path and query == parts.query
 
     def _redact_urls_safe(self, text: str) -> str:
         """Redact URLs with ReDoS protection via length pre-filtering"""

--- a/pfsense_redactor/version_checker.py
+++ b/pfsense_redactor/version_checker.py
@@ -10,6 +10,7 @@ import os
 import sys
 import urllib.request
 import urllib.error
+from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 import logging
@@ -32,6 +33,29 @@ class InstallationMethod(NamedTuple):
     upgrade_command: str
 
 
+def _scan_for_version(lines: Iterable[str]) -> str:
+    """Pull __version__ out of the lines of an __init__.py"""
+    for line in lines:
+        if line.startswith('__version__'):
+            # Extract version from __version__ = "x.y.z"
+            return line.split('=')[1].strip().strip('"').strip("'")
+    return "unknown"
+
+
+def _version_from_source() -> str:
+    """Read the version straight from __init__.py
+
+    The fallback for a source checkout, where no distribution metadata has been
+    installed for importlib.metadata to find.
+    """
+    try:
+        init_file = Path(__file__).parent / '__init__.py'
+        with open(init_file, 'r', encoding='utf-8') as file_handle:
+            return _scan_for_version(file_handle)
+    except Exception:  # pylint: disable=broad-except
+        return "unknown"
+
+
 def get_current_version() -> str:
     """Get the current installed version"""
     try:
@@ -39,17 +63,7 @@ def get_current_version() -> str:
         import importlib.metadata
         return importlib.metadata.version('pfsense-redactor')
     except Exception:  # pylint: disable=broad-except
-        # Fallback: try to read from __init__.py directly
-        try:
-            init_file = Path(__file__).parent / '__init__.py'
-            with open(init_file, 'r', encoding='utf-8') as file_handle:
-                for line in file_handle:
-                    if line.startswith('__version__'):
-                        # Extract version from __version__ = "x.y.z"
-                        return line.split('=')[1].strip().strip('"').strip("'")
-        except Exception:
-            pass
-        return "unknown"
+        return _version_from_source()
 
 
 def check_pypi_version(timeout: int = 5) -> str | None:

--- a/tests/properties/test_invariants.py
+++ b/tests/properties/test_invariants.py
@@ -9,22 +9,31 @@ import random
 import ipaddress
 
 
+def _random_private_ips(count):
+    """RFC1918 addresses, one from each of the three blocks per iteration"""
+    ips = []
+    for _ in range(count // 3):
+        ips.append(f"192.168.{random.randint(0, 255)}.{random.randint(1, 254)}")
+        ips.append(f"10.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}")
+        ips.append(f"172.{random.randint(16, 31)}.{random.randint(0, 255)}.{random.randint(1, 254)}")
+    return ips
+
+
+def _random_public_ips(count):
+    """Globally routable addresses, avoiding reserved ranges"""
+    return [
+        f"{random.randint(1, 223)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}"
+        for _ in range(count // 3)
+    ]
+
+
 def generate_random_ips(count=10, include_private=True, include_public=True):
     """Generate random IP addresses for testing"""
     ips = []
-
     if include_private:
-        # RFC1918
-        for _ in range(count // 3):
-            ips.append(f"192.168.{random.randint(0, 255)}.{random.randint(1, 254)}")
-            ips.append(f"10.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}")
-            ips.append(f"172.{random.randint(16, 31)}.{random.randint(0, 255)}.{random.randint(1, 254)}")
-
+        ips += _random_private_ips(count)
     if include_public:
-        # Public IPs (avoiding reserved ranges)
-        for _ in range(count // 3):
-            ips.append(f"{random.randint(1, 223)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(1, 254)}")
-
+        ips += _random_public_ips(count)
     return ips
 
 

--- a/tests/unit/test_check_structure.py
+++ b/tests/unit/test_check_structure.py
@@ -1,0 +1,159 @@
+"""
+Tests for tools/check_structure.py, the structural CI gate.
+
+A gate that cannot fail is worse than no gate: it reports success while
+allowing exactly what it was added to prevent. These check that each rule
+actually fires, and that ordinary code passes.
+"""
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+TOOL_PATH = Path(__file__).parent.parent.parent / 'tools' / 'check_structure.py'
+
+
+def load_tool():
+    """Import check_structure.py, which lives outside the package"""
+    spec = importlib.util.spec_from_file_location('check_structure', TOOL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(name='tool')
+def tool_fixture():
+    """The loaded checker module"""
+    return load_tool()
+
+
+def reasons(tool, source):
+    """Run the checker over a source string and return the reasons reported"""
+    return [reason for _, _, reason in tool.violations(ast.parse(source))]
+
+
+class TestNestingDepth:
+    """Deeply nested logic is reported"""
+
+    def test_four_deep_is_flagged(self, tool):
+        """One level past the limit fires"""
+        src = (
+            "def f(a, b, c, d):\n"
+            "    if a:\n"
+            "        for x in b:\n"
+            "            while c:\n"
+            "                with open(d) as handle:\n"
+            "                    return handle\n"
+            "    return None\n"
+        )
+
+        assert any('nested 4 deep' in r for r in reasons(tool, src))
+
+    def test_three_deep_is_allowed(self, tool):
+        """The limit itself passes, so the gate is not off by one"""
+        src = (
+            "def f(a, b, c):\n"
+            "    if a:\n"
+            "        for x in b:\n"
+            "            if c:\n"
+            "                return x\n"
+            "    return None\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'nested' in r]
+
+    def test_nested_function_measured_separately(self, tool):
+        """A closure's depth is its own, not added to its parent's
+
+        Otherwise a shallow function containing a shallow closure would report
+        as deep, and the fix would be to inline the closure - the opposite of
+        what is wanted.
+        """
+        src = (
+            "def outer(a, b):\n"
+            "    if a:\n"
+            "        def inner(c):\n"
+            "            if c:\n"
+            "                for x in c:\n"
+            "                    return x\n"
+            "            return None\n"
+            "        return inner\n"
+            "    return None\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'nested' in r]
+
+
+class TestBumps:
+    """Two separate blocks of nested logic in one function are reported"""
+
+    def test_two_nested_blocks_flagged(self, tool):
+        """The Bumpy Road shape: two humps doing different things"""
+        src = (
+            "def f(items, other):\n"
+            "    for i in items:\n"
+            "        if i:\n"
+            "            print(i)\n"
+            "    for j in other:\n"
+            "        if j:\n"
+            "            print(j)\n"
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    def test_flat_loops_are_not_bumps(self, tool):
+        """A loop with no conditional inside is not a hump"""
+        src = (
+            "def f(items, other):\n"
+            "    for i in items:\n"
+            "        print(i)\n"
+            "    for j in other:\n"
+            "        print(j)\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'blocks' in r]
+
+
+class TestComplexConditional:
+    """Conditions chaining several operators are reported"""
+
+    def test_two_operators_flagged(self, tool):
+        """'a and b and c' is the shape that has to be re-derived on each read"""
+        src = "def f(a, b, c):\n    if a and b and c:\n        return 1\n    return 0\n"
+
+        assert any('chains 2 operators' in r for r in reasons(tool, src))
+
+    def test_one_operator_allowed(self, tool):
+        """'a and b' reads directly and stays"""
+        src = "def f(a, b):\n    if a and b:\n        return 1\n    return 0\n"
+
+        assert not [r for r in reasons(tool, src) if 'chains' in r]
+
+    def test_nested_boolop_counted_flat(self, tool):
+        """Parenthesising does not hide the operator count"""
+        src = "def f(a, b, c):\n    if a or (b and c):\n        return 1\n    return 0\n"
+
+        assert any('chains 2 operators' in r for r in reasons(tool, src))
+
+    def test_while_conditions_checked_too(self, tool):
+        """Not only if-statements carry conditions"""
+        src = "def f(a, b, c):\n    while a and b and c:\n        return 1\n    return 0\n"
+
+        assert any('chains 2 operators' in r for r in reasons(tool, src))
+
+
+class TestRepositoryIsClean:
+    """The gate passes on the tree it is committed with"""
+
+    def test_no_violations_anywhere(self, tool):
+        """Every checked path is clean, so a future failure means a regression"""
+        root = Path(__file__).parent.parent.parent
+        found = []
+        for target in ('pfsense_redactor', 'tests', 'tools'):
+            for path in sorted((root / target).rglob('*.py')):
+                tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+                found += [f"{path.name}:{line} {name}: {reason}"
+                          for line, name, reason in tool.violations(tree)]
+
+        assert not found, 'structural violations: ' + '; '.join(found)

--- a/tests/unit/test_dry_run_verbose.py
+++ b/tests/unit/test_dry_run_verbose.py
@@ -33,7 +33,7 @@ def test_dry_run_verbose_shows_samples(cli_runner, create_xml_file):
     assert "limit N=" in stdout
 
     # Should show sample categories
-    assert "IP:" in stdout or "Secret:" in stdout or "FQDN:" in stdout
+    assert any(label in stdout for label in ("IP:", "Secret:", "FQDN:"))
 
 
 def test_dry_run_verbose_masks_ip_samples_safely(cli_runner, create_xml_file):

--- a/tests/unit/test_ipv6_zone_identifiers.py
+++ b/tests/unit/test_ipv6_zone_identifiers.py
@@ -37,7 +37,7 @@ class TestIPv6ZoneIdentifiers:
         for input_text, expected in test_cases:
             result = redactor._mask_ip_like_tokens(input_text)
             # Zone should be preserved even if IP is redacted
-            assert '%eth0.100' in result or '%ens18.200' in result or '%bond0.50' in result, \
+            assert any(z in result for z in ('%eth0.100', '%ens18.200', '%bond0.50')), \
                 f"Zone identifier lost for {input_text}, got: {result}"
 
     def test_zone_with_dash_interface(self):
@@ -52,7 +52,7 @@ class TestIPv6ZoneIdentifiers:
 
         for input_text, expected in test_cases:
             result = redactor._mask_ip_like_tokens(input_text)
-            assert '%wlan0-1' in result or '%br-lan' in result or '%eth-mgmt' in result, \
+            assert any(z in result for z in ('%wlan0-1', '%br-lan', '%eth-mgmt')), \
                 f"Zone identifier with dash lost for {input_text}, got: {result}"
 
     def test_zone_with_colon_interface(self):
@@ -84,7 +84,7 @@ class TestIPv6ZoneIdentifiers:
         for input_text, expected in test_cases:
             result = redactor._mask_ip_like_tokens(input_text)
             # Check that the zone is preserved (even if IP is redacted)
-            assert '%eth0.100-vlan' in result or '%br-lan.10' in result or '%bond0.50:1' in result, \
+            assert any(z in result for z in ('%eth0.100-vlan', '%br-lan.10', '%bond0.50:1')), \
                 f"Complex zone identifier lost for {input_text}, got: {result}"
 
     def test_bracketed_ipv6_with_zone(self):
@@ -100,7 +100,7 @@ class TestIPv6ZoneIdentifiers:
         for input_text, expected in test_cases:
             result = redactor._mask_ip_like_tokens(input_text)
             # Zone should be preserved in bracketed form
-            assert '%eth0.100]' in result or '%wlan0-1]' in result or '%eth0:1]' in result, \
+            assert any(z in result for z in ('%eth0.100]', '%wlan0-1]', '%eth0:1]')), \
                 f"Zone identifier lost in bracketed form for {input_text}, got: {result}"
 
     def test_bracketed_ipv6_with_zone_and_port(self):
@@ -116,9 +116,9 @@ class TestIPv6ZoneIdentifiers:
         for input_text, expected in test_cases:
             result = redactor._mask_ip_like_tokens(input_text)
             # Zone and port should both be preserved
-            assert ('%eth0.100]:' in result or '%wlan0-1]:' in result or '%br-lan.10]:' in result), \
+            assert any(z in result for z in ('%eth0.100]:', '%wlan0-1]:', '%br-lan.10]:')), \
                 f"Zone identifier or port lost for {input_text}, got: {result}"
-            assert (':51820' in result or ':8080' in result or ':443' in result), \
+            assert any(p in result for p in (':51820', ':8080', ':443')), \
                 f"Port lost for {input_text}, got: {result}"
 
     def test_zone_parsing_in_parse_ip_token(self):

--- a/tests/unit/test_rfc_ip_idempotency.py
+++ b/tests/unit/test_rfc_ip_idempotency.py
@@ -65,7 +65,7 @@ class TestRFCIPIdempotency:
         assert redactor2.stats['ips_redacted'] == 0, "IPs were re-redacted on second pass"
 
         # Verify RFC IPs were generated
-        assert '192.0.2.' in url1 or '198.51.100.' in url1 or '203.0.113.' in url1
+        assert any(net in url1 for net in ('192.0.2.', '198.51.100.', '203.0.113.'))
 
         # Clean up
         os.unlink(input_file)

--- a/tests/unit/test_symlink_security.py
+++ b/tests/unit/test_symlink_security.py
@@ -230,7 +230,7 @@ class TestSymlinkSecurity:
 
         # Error should mention symlink or that it's not a file
         stderr_lower = result.stderr.lower()
-        assert "symlink" in stderr_lower or "not found" in stderr_lower or "directory" in stderr_lower, \
+        assert any(w in stderr_lower for w in ("symlink", "not found", "directory")), \
             f"Error should mention issue: {result.stderr}"
 
     def test_relative_symlink_refused(self, sample_config, temp_dir):

--- a/tools/check_structure.py
+++ b/tools/check_structure.py
@@ -54,30 +54,52 @@ def count_operands(node: ast.AST) -> int:
     return sum(count_operands(value) for value in node.values)
 
 
+def too_deep(func: ast.AST):
+    """Report a function whose blocks nest further than the limit"""
+    depth = nesting_depth(func)
+    if depth > MAX_NESTING:
+        yield func.lineno, func.name, f"nested {depth} deep (max {MAX_NESTING})"
+
+
+def too_bumpy(func: ast.AST):
+    """Report a function carrying several separate blocks of nested logic
+
+    A bump is a top-level block that itself contains nested logic. A flat loop
+    is not one; a loop wrapping a conditional is. Two of them in one function
+    means two things are going on in it.
+    """
+    bumps = sum(1 for stmt in func.body
+                if isinstance(stmt, NESTING_NODES) and nesting_depth(stmt) >= 1)
+    if bumps > MAX_BUMPS:
+        yield func.lineno, func.name, f"{bumps} blocks of nested logic (max {MAX_BUMPS})"
+
+
+def chained_conditions(func: ast.AST):
+    """Report each condition joining more operators than the limit allows"""
+    for node in ast.walk(func):
+        test = getattr(node, 'test', None)
+        if not isinstance(test, ast.BoolOp):
+            continue
+        operators = count_operands(test) - 1
+        if operators > MAX_BOOL_OPERATORS:
+            yield (test.lineno, func.name,
+                   f"condition chains {operators} operators "
+                   f"(max {MAX_BOOL_OPERATORS}) - name it instead")
+
+
+RULES = (too_deep, too_bumpy, chained_conditions)
+
+
 def violations(tree: ast.AST):
-    """Yield (line, function, reason) for every shape over threshold"""
+    """Yield (line, function, reason) for every shape over threshold
+
+    One function per rule, rather than three blocks in a loop. The tool that
+    gates complexity is a poor advertisement for it otherwise - this function
+    was itself the worst in the repository until it was split.
+    """
     for func in (n for n in ast.walk(tree) if isinstance(n, FUNCTION_NODES)):
-        depth = nesting_depth(func)
-        if depth > MAX_NESTING:
-            yield func.lineno, func.name, f"nested {depth} deep (max {MAX_NESTING})"
-
-        # A bump is a top-level block that itself contains nested logic. A flat
-        # loop is not one; a loop wrapping a conditional is. Two of them in one
-        # function means two things are going on in it.
-        bumps = sum(1 for stmt in func.body
-                    if isinstance(stmt, NESTING_NODES) and nesting_depth(stmt) >= 1)
-        if bumps > MAX_BUMPS:
-            yield func.lineno, func.name, f"{bumps} blocks of nested logic (max {MAX_BUMPS})"
-
-        for node in ast.walk(func):
-            test = getattr(node, 'test', None)
-            if not isinstance(test, ast.BoolOp):
-                continue
-            operators = count_operands(test) - 1
-            if operators > MAX_BOOL_OPERATORS:
-                yield (test.lineno, func.name,
-                       f"condition chains {operators} operators "
-                       f"(max {MAX_BOOL_OPERATORS}) - name it instead")
+        for rule in RULES:
+            yield from rule(func)
 
 
 def python_files(targets: list[str]):

--- a/tools/check_structure.py
+++ b/tools/check_structure.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail on the code shapes flake8 cannot see.
+
+`flake8 --select=C901 --max-complexity` already gates cyclomatic complexity,
+and mccabe folds a nested closure into its parent, so that part is covered.
+What it does not measure at all is *shape*: how deeply logic nests, how many
+separate humps of it a function contains, and how many operators a single
+condition chains together. Those are exactly the findings this repository set
+out to clear, so without a check they would drift straight back.
+
+Thresholds are one step tighter than the analyser that flagged them, so the
+first regression trips the gate rather than the second.
+
+Usage:
+    python tools/check_structure.py pfsense_redactor/ tests/
+
+Prints `path:line function: reason` for each violation and exits 1, or exits 0
+in silence.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+MAX_NESTING = 3       # if/for/while/try/with inside one another
+MAX_BUMPS = 1         # separate nested blocks directly in a function body
+MAX_BOOL_OPERATORS = 1  # 'and'/'or' chained in a single condition
+
+NESTING_NODES = (ast.If, ast.For, ast.While, ast.Try, ast.With,
+                 ast.AsyncFor, ast.AsyncWith)
+FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def nesting_depth(node: ast.AST, depth: int = 0) -> int:
+    """Deepest run of nested blocks, not counting nested function bodies
+
+    A nested function is measured in its own right, so folding its depth into
+    the parent would report the same code twice.
+    """
+    deepest = depth
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, FUNCTION_NODES):
+            continue
+        deeper = depth + isinstance(child, NESTING_NODES)
+        deepest = max(deepest, nesting_depth(child, deeper))
+    return deepest
+
+
+def count_operands(node: ast.AST) -> int:
+    """Leaf operands in a boolean expression, flattening nested and/or"""
+    if not isinstance(node, ast.BoolOp):
+        return 1
+    return sum(count_operands(value) for value in node.values)
+
+
+def violations(tree: ast.AST):
+    """Yield (line, function, reason) for every shape over threshold"""
+    for func in (n for n in ast.walk(tree) if isinstance(n, FUNCTION_NODES)):
+        depth = nesting_depth(func)
+        if depth > MAX_NESTING:
+            yield func.lineno, func.name, f"nested {depth} deep (max {MAX_NESTING})"
+
+        # A bump is a top-level block that itself contains nested logic. A flat
+        # loop is not one; a loop wrapping a conditional is. Two of them in one
+        # function means two things are going on in it.
+        bumps = sum(1 for stmt in func.body
+                    if isinstance(stmt, NESTING_NODES) and nesting_depth(stmt) >= 1)
+        if bumps > MAX_BUMPS:
+            yield func.lineno, func.name, f"{bumps} blocks of nested logic (max {MAX_BUMPS})"
+
+        for node in ast.walk(func):
+            test = getattr(node, 'test', None)
+            if not isinstance(test, ast.BoolOp):
+                continue
+            operators = count_operands(test) - 1
+            if operators > MAX_BOOL_OPERATORS:
+                yield (test.lineno, func.name,
+                       f"condition chains {operators} operators "
+                       f"(max {MAX_BOOL_OPERATORS}) - name it instead")
+
+
+def python_files(targets: list[str]):
+    """Expand each argument into the .py files under it"""
+    for target in targets:
+        path = Path(target)
+        if path.is_dir():
+            yield from sorted(path.rglob('*.py'))
+        elif path.suffix == '.py':
+            yield path
+
+
+def main() -> int:
+    """Report every violation across the given paths. Non-zero means failure"""
+    targets = sys.argv[1:] or ['pfsense_redactor', 'tests']
+    found = 0
+
+    for path in python_files(targets):
+        try:
+            tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        except SyntaxError as exc:
+            print(f"{path}:{exc.lineno} could not parse: {exc.msg}")
+            found += 1
+            continue
+
+        # Sorted so the report is stable regardless of walk order.
+        for line, name, reason in sorted(violations(tree)):
+            print(f"{path}:{line} {name}: {reason}")
+            found += 1
+
+    if found:
+        print(f"\n{found} structural violation(s). "
+              f"Extracting a named function is the usual fix.")
+    return 1 if found else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What this is

Clears the three CodeScene categories that are actually fixable, across **all
`.py` files including tests**, and gates them so they stay clear.

Out of scope by decision, and unchanged: Low Cohesion, Number of Functions in a
Single Module, and Excess Function Arguments. All three follow from the
deliberate single-module design that `tests/integration/test_standalone_script.py`
enforces; satisfying them means breaking it.

Pure refactoring — no behaviour change, no version bump, no CHANGELOG entry.

## Results

| Metric | Before | After |
|---|---|---|
| Functions at complexity ≥ 9 | 10 | **0** |
| Multi-operator conditions | 21 | **0** |
| Functions nested > 3 deep | 3 | **0** |
| Functions with 2+ blocks of nested logic | 3 | **0** |
| Average complexity (radon) | A (4.38) | **A (3.95)** |

Tests went 571 → 581; the 10 new ones cover the checker itself.

## The ratchet

The previous complexity PR only held because its gate became blocking, so this
one closes properly:

- **flake8 `--max-complexity` 10 → 8**, and scoped to `tests/` and `tools/` as
  well as the package. mccabe folds a nested closure into its parent, so
  complexity cannot be hidden inside one.
- **`tools/check_structure.py`** gates nesting depth, blocks of nested logic and
  multi-operator conditions. flake8 measures none of those, which is most of
  what this PR fixed — without it that work decays while complexity stays green.

The checker has its own tests. A gate that cannot fail is worse than no gate: it
reports success while allowing exactly what it exists to prevent.

## Two things worth flagging

**My first bump rule was miscalibrated.** It only counted a block containing two
further levels, which found one function where CodeScene found seven. Counting a
block with one further level matches — a loop wrapping a conditional is a hump —
and caught three more functions, now split. I had claimed the proxy reproduced
CodeScene exactly; that held for Complex Conditional (12/12, including its exact
operator counts) but not for Bumpy Road until this fix.

**Two helpers first reproduced the chain they replaced.** `_would_overwrite_without_force`
and `_needs_generated_output_name` moved a three-operand condition rather than
removing it. Splitting them by reason — writes nothing, versus consent given —
is shorter and clearer about why each case returns early.

## Ordering that had to be preserved

`_is_disallowed_absolute` names the reason only, not the ordering. It must still
run **after** the sensitive-directory check in `_resolved_path_error`, so
`--allow-absolute-paths` cannot reach a protected directory. The comment saying
so stays at the call site.

## Verification

Run after every commit, exit status as the signal:

- 580 passed / 581 collected, **reference snapshots unmoved**
- `pylint` exits 0 for both configs, including the new tool and its tests
- `flake8 --select=C901 --max-complexity=8` clean over package, tests and tools
- `tools/check_structure.py` clean over the same
- Nothing at radon C or worse
- Coverage 87.4% total, `redactor.py` 89.9% — no regression

End to end:

- **Canary corpus identical to `main`** — the same 4 known-acceptable results
- DOCTYPE matrix unchanged: plain bomb, bomb behind 200 KB comment and 2 MB
  prolog all refused; large body with small prolog, BOM handling and wrong root
  tag all as before
- The 1.1.0 reporter's URL and filename fixtures produce byte-identical output
- `test_standalone_script.py` passes — no module split crept in

## Note on sequencing

1.1.1 is still untagged. It carries the security fixes from #52, #54 and #56 and
does not depend on this PR — worth releasing first rather than behind a refactor
touching ~20 functions in the redaction path.
