### PR TITLE
Split the README, and publish the canary corpus as evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ pfsense-redactor config.xml --dry-run-verbose
 
 Prints what would change, with samples safely masked.
 
-**If your config sends notifications** (Slack, Discord, Telegram), add
-`--aggressive` — webhook tokens live in URL paths, which are preserved by
-default so package feed URLs are not destroyed. See
+**Using an unusual package?** Add `--aggressive`. Webhook tokens live in URL
+paths, and paths are otherwise preserved so package feed URLs are not destroyed.
+Slack, Discord and Telegram are recognised and redacted without it; anything
+else needs the flag. See
 [security](https://github.com/grounzero/pfsense-redactor/blob/main/docs/security.md#what-gets-redacted).
 
 ## How well does it work?
@@ -91,7 +92,7 @@ default so package feed URLs are not destroyed. See
 Measured against a 46-secret canary corpus that ships with the repository:
 
 | Tool | Caught |
-|---|---|
+| --- | --- |
 | **pfsense-redactor 1.1.1** | **42 / 46** |
 | ForesightCyber Config Anonymizer | 17 / 46 |
 | netgate-xlsx | 11 / 46 |
@@ -120,7 +121,7 @@ scanner that fails differently, see
 ## Documentation
 
 | Guide | Covers |
-|---|---|
+| --- | --- |
 | [CLI reference](https://github.com/grounzero/pfsense-redactor/blob/main/docs/cli-reference.md) | Every flag, with examples |
 | [Use cases](https://github.com/grounzero/pfsense-redactor/blob/main/docs/use-cases.md) | Netgate TAC, AI tools, MSP handoff, audits — and how this relates to `diag_sanitize.php` |
 | [Allow-lists](https://github.com/grounzero/pfsense-redactor/blob/main/docs/allow-lists.md) | Keep specific IPs, CIDRs and domains readable |

--- a/README.md
+++ b/README.md
@@ -6,711 +6,145 @@
 [![Tests](https://github.com/grounzero/pfsense-redactor/actions/workflows/tests.yml/badge.svg)](https://github.com/grounzero/pfsense-redactor/actions/workflows/tests.yml)
 [![Downloads](https://pepy.tech/badge/pfsense-redactor)](https://pepy.tech/project/pfsense-redactor)
 
-Safely redact sensitive fields in a pfSense `config.xml` export so you can share it without exposing passwords, keys, or network identifiers.
-
-**Keywords:** pfSense config.xml redactor, pfSense sanitiser, firewall config sanitisation, VPN config anonymisation, OpenVPN redaction, WireGuard key redaction, IPsec secret removal, network topology anonymiser, Netgate TAC sharing
-
-**pfsense-redactor** redacts secrets and optionally anonymises identifiers in pfSense `config.xml` exports—so you can share them safely with support, vendors, auditors, forums, or AI tools.
-
-Unlike generic XML redaction tools, pfsense-redactor understands pfSense-specific configuration structures and VPN formats.
-
-## Why pfsense-redactor?
-
-- ✅ **pfSense-native** – Understands pfSense XML structures (IPsec, OpenVPN, WireGuard, packages)
-- ✅ **Zero dependencies** – Pure Python stdlib, runs anywhere (Windows, macOS, Linux)
-- ✅ **Well-tested** – Extensively tested across multiple OSes and Python versions
-- ✅ **Topology-preserving** – Anonymise without breaking routing logic or firewall rules
-- ✅ **Security-first** – Built-in protections against path traversal and symlink attacks
-- ✅ **CI/CD ready** – Suitable for automated compliance workflows and GitOps
-
----
-
-## When should I use pfsense-redactor?
-
-Use pfsense-redactor when you need to share a pfSense `config.xml` file
-outside the firewall (for example with vendors, consultants, forums, or AI tools)
-and want to remove secrets and/or anonymise network identifiers without
-breaking topology or routing logic.
-
-### Quick start (recommended)
-
-#### 1) Preserve private IPs (best for support / troubleshooting)
-
-```bash
-pfsense-redactor config.xml redacted.xml --keep-private-ips
-```
-
-Keeps internal addressing visible while removing secrets and redacting public identifiers.
-
-#### 2) Topology-preserving anonymisation (best for vendors / forums / AI)
-
-```bash
-pfsense-redactor config.xml redacted.xml --anonymise
-```
-
-Replaces identifiers with consistent placeholders so relationships remain clear while reducing disclosure.
-
-For pfSense on-firewall sanitisation, see `diag_sanitize.php` below; pfsense-redactor is intended for off-box use and anonymisation.
-
-See the [Usage](#usage) section and the [Command-Line Flags Reference](#command-line-flags-reference) below for all available options.
-
----
-
-## Use Cases
-
-Common command patterns depending on who you’re sharing with.
-
-### Sharing with Netgate TAC Support
-
-```bash
-# On the firewall (recommended for TAC)
-/usr/local/sbin/diag_sanitize.php /conf/config.xml > /conf/config_sanitised.xml
-
-# Off-box: additional anonymisation before sharing further
-pfsense-redactor config_sanitised.xml support-safe.xml --keep-private-ips --no-redact-domains
-```
-
-### Sharing with AI tools
-
-Use `--aggressive` if you have third-party packages or aren’t sure where secrets live.
-
-```bash
-# Topology-preserving anonymisation (private IPs are kept visible by default with --anonymise)
-pfsense-redactor config.xml ai-ready.xml --anonymise --aggressive
-# Now safe to upload to AI tools for configuration analysis
-```
-
-```bash
-# Anonymise everything (including private IPs)
-pfsense-redactor config.xml ai-ready.xml --anonymise --no-keep-private-ips --aggressive
-# Now safe to upload to AI tools for configuration analysis
-```
-
-### Vendor/MSP Handoffs
-
-```bash
-# Option A: Preserve private IPs for troubleshooting context
-pfsense-redactor config.xml vendor-share.xml --anonymise
-```
-
-```bash
-# Option B: Anonymise everything (including private IPs) for stricter privacy
-pfsense-redactor config.xml vendor-share.xml --anonymise --no-keep-private-ips
-```
-
-### Security Audits
-
-```bash
-# Preview what will be redacted before sharing
-pfsense-redactor config.xml --dry-run-verbose
-```
-
-### Automated Compliance Workflows
-
-```bash
-# CI/CD integration for automated sanitisation
-pfsense-redactor $INPUT_CONFIG $OUTPUT_CONFIG --aggressive --fail-on-warn
-```
-
----
-
-## Relationship to pfSense built-in sanitisation
-
-pfSense includes a built-in configuration sanitisation script:
-
-```bash
-/usr/local/sbin/diag_sanitize.php /conf/config.xml > /conf/config_sanitised.xml
-```
-
-This official tool runs **on the firewall itself** and is primarily intended for safely sharing configurations with Netgate support. It removes high-value secrets (password hashes, pre-shared keys, certificates, etc.) while preserving the original network topology.
-
-**pfsense-redactor is complementary, not a replacement.**
-
-| Built-in `diag_sanitize.php`         | pfsense-redactor                                                  |
-| ------------------------------------ | ----------------------------------------------------------------- |
-| Runs on pfSense only                 | Runs anywhere (workstation, CI, automation)                       |
-| PHP, internal to pfSense             | Python, standalone, MIT-licensed                                  |
-| Fixed sanitisation behaviour         | Configurable redaction and anonymisation                          |
-| Removes secrets                      | Removes secrets **and** can anonymise IPs, domains, MACs and URLs |
-| Best suited to Netgate support (TAC) | Best suited to vendors, consultants, AI tools and forums          |
-
-pfsense-redactor exists to cover use cases where:
-
-- the configuration has already been exported,
-- you do not wish to run additional tooling on the firewall,
-- or you require **privacy-preserving anonymisation** in addition to basic secret removal.
-
-Both tools share the same goal: preventing accidental disclosure of sensitive information when sharing pfSense configurations.
-
----
-
-## Comparison with Alternatives
-
-<details>
-<summary>Comparison with Alternatives</summary>
-
-| Feature                 | pfsense-redactor  | Generic XML Tools | Manual Redaction | Built-in diag_sanitize.php |
-| ----------------------- | ----------------- | ----------------- | ---------------- | -------------------------- |
-| pfSense-aware structure | ✅                | ❌                | ⚠️ Manual        | ✅                         |
-| Runs off-firewall       | ✅                | ✅                | ✅               | ❌ (pfSense only)          |
-| Network anonymisation   | ✅                | ❌                | ⚠️ Error-prone   | ❌                         |
-| Topology preservation   | ✅                | ❌                | ⚠️ Error-prone   | ✅                         |
-| Configurable modes      | ✅ multiple modes | ❌                | N/A              | ❌ Fixed                   |
-| CIDR allow-lists        | ✅                | ❌                | ⚠️ Error-prone   | ❌                         |
-| CI/CD integration       | ✅                | ⚠️                | ⚠️ Error-prone   | ❌                         |
-| Cross-platform          | ✅                | ⚠️                | ✅               | ❌                         |
-| WireGuard/IPsec aware   | ✅                | ❌                | ⚠️               | ✅                         |
-| Zero dependencies       | ✅                | ⚠️ Varies         | ✅               | ✅                         |
-
-</details>
-
----
-
-## FAQ
-
-### What does pfsense-redactor redact by default?
-
-pfsense-redactor removes secrets such as passwords, private keys, certificates, tokens, and shared secrets.  
-It also redacts public IP addresses, domains, MAC addresses, and URLs unless explicitly preserved.
-
-### Does pfsense-redactor anonymise or just remove data?
-
-It supports both. Redaction removes sensitive values entirely, while anonymisation replaces identifiers with consistent placeholders so topology and relationships remain clear.
-
-### Will anonymisation break troubleshooting or topology analysis?
-
-No. Deterministic anonymisation ensures the same identifier is always replaced with the same alias, preserving logical relationships and routing flow.
-
-### Can I safely share the output with vendors or AI tools?
-
-Yes. pfsense-redactor is designed for sharing configurations externally without exposing secrets or identifiable network information.  
-Redacted output is for analysis only and must not be restored to pfSense.
-
-### Does this understand pfSense-specific configuration structures?
-
-Yes. Unlike generic XML redaction tools, pfsense-redactor understands pfSense configuration layouts, including VPNs, interfaces, gateways, and common package XML structures.
-
-### When should I use aggressive mode?
-
-Use `--aggressive` when sharing configurations publicly or when third-party packages may include unknown sensitive fields.
-
-Aggressive mode broadens both secret detection and identifier rewriting. On top of the default behaviour it will:
-
-- Redact unrecognised high-entropy values (base64/hex/PEM-shaped) in any element, rather than reporting them
-- Redact free-text option blocks (`custom_options`, `userparams`, `upsd_users`, `advanced`, …) wholesale
-- Redact credential-shaped URL **path** segments, such as Slack/Discord webhook tokens
-- Apply IP/domain redaction to all element text, not just known fields
-
-### Can I restore the redacted file to pfSense?
-
-No. Redacted output is for analysis/sharing only and must never be imported back into pfSense.
-
----
-
-## Installation
-
-### From PyPI (recommended)
+Redact secrets from a pfSense `config.xml` so you can share it — with Netgate
+support, a vendor, a forum, or an AI tool — without handing over your passwords,
+keys and network layout.
+
+Unlike generic XML redaction, it understands pfSense structures: IPsec, OpenVPN,
+WireGuard, captive portal, and the package configs where credentials actually
+hide.
+
+## Install
 
 ```bash
 pip install pfsense-redactor
 ```
 
-> **Note:** If you encounter an `externally-managed-environment` error (common on macOS and modern Linux distributions), use one of these alternatives:
->
-> **Option 1: Install with pipx (recommended for CLI tools)**
->
-> ```bash
-> brew install pipx
-> pipx install pfsense-redactor
-> ```
->
-> **Option 2: Use a virtual environment**
->
-> ```bash
-> python3 -m venv venv
-> source venv/bin/activate
-> pip install pfsense-redactor
-> ```
->
-> **Option 3: Install in user space**
->
-> ```bash
-> pip install --user pfsense-redactor
-> ```
+Pure Python standard library, no dependencies, Python 3.9+.
 
-### From Source
+<details>
+<summary>If pip reports <code>externally-managed-environment</code></summary>
+
+Common on macOS and recent Linux distributions. Any of these work:
+
+```bash
+pipx install pfsense-redactor          # recommended for CLI tools
+```
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install pfsense-redactor
+```
+
+```bash
+pip install --user pfsense-redactor
+```
+
+</details>
+
+<details>
+<summary>From source</summary>
 
 ```bash
 git clone https://github.com/grounzero/pfsense-redactor.git
 cd pfsense-redactor
-```
-
-**Option 1: Development mode (recommended for contributing)**
-
-```bash
 pip install -e .
 ```
 
-**Option 2: With virtual environment**
+</details>
 
-```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -e .
-```
+## Quick start
 
-The tool preserves **network architecture and routing logic** whilst sanitising **secrets and identifiers** allowing safe troubleshooting and topology review without disclosing private data.
-
-> Keeps firewall and routing context  
-> Removes passwords, keys, public IPs (optional), tokens, certs  
-> Supports anonymisation for consistent placeholder mapping  
-> Understands pfSense config structures, namespaces, VPNs, WireGuard, XML attributes, IPv6 zone IDs
-
----
-
-## Features
-
-### Protects real secrets
-
-- Passwords & encrypted passwords
-- Pre-shared keys (IPSec, OpenVPN, WireGuard)
-- TLS/OpenVPN static keys & certs
-- SNMP community strings
-- LDAP / RADIUS secrets
-- API keys & tokens
-- PEM blocks (RSA / EC / OpenSSH)
-
-### Preserves network logic
-
-- Subnets & masks (255.x.x.x always preserved)
-- Router topology
-- VLAN and VPN interfaces
-- Firewall rules and gateways
-
-### Smart redaction
-
-| Data            | Behaviour                            |
-| --------------- | ------------------------------------ |
-| Internal IPs    | Preserve with `--keep-private-ips`   |
-| Public IPs      | Mask or anonymise                    |
-| Email addresses | Mask or anonymise                    |
-| URLs            | Preserve structure, mask hostname    |
-| MAC addresses   | Mask format-preserving               |
-| Certificates    | Collapse to `[REDACTED_CERT_OR_KEY]` |
-
-### Operational modes
-
-| Mode                 | Purpose                                                                      |
-| -------------------- | ---------------------------------------------------------------------------- |
-| Default              | Safe redaction for sharing logs                                              |
-| `--keep-private-ips` | Preserve private IPs (best for support/AI)                                   |
-| `--anonymise`        | Replace identifiers with consistent placeholders (`IP_1`, `domain3.example`) |
-| `--aggressive`       | Scrub **all** fields (plugins/custom XML)                                    |
-| `--redact-descriptions` | Also redact descriptions, hostnames and SSIDs (may contain personal names) |
-
----
-
-## Requirements
-
-- **Python 3.9+**
-
----
-
-## Usage
-
-### Basic usage
-
-```bash
-# Output filename auto-generated as config-redacted.xml
-pfsense-redactor config.xml
-
-# Or specify output filename explicitly
-pfsense-redactor config.xml redacted.xml
-```
-
-### Preserve private IPs (recommended)
+**Sharing with support — keep internal addressing readable:**
 
 ```bash
 pfsense-redactor config.xml redacted.xml --keep-private-ips
 ```
 
-### Allow-list specific IPs and domains
+Removes secrets and public identifiers, leaves RFC 1918 addressing intact so
+whoever is helping can still follow your topology.
 
-```bash
-# Preserve specific public services (never redact)
-pfsense-redactor config.xml --allowlist-ip 8.8.8.8 --allowlist-domain time.nist.gov
-
-# Preserve entire CIDR ranges
-pfsense-redactor config.xml --allowlist-ip 203.0.113.0/24
-
-# Use an allow-list file (supports IPs, CIDRs, and domains)
-pfsense-redactor config.xml --allowlist-file my-allowlist.txt
-```
-
-### Topology-safe anonymisation
+**Sharing with a vendor, forum or AI tool — anonymise identifiers:**
 
 ```bash
 pfsense-redactor config.xml redacted.xml --anonymise
 ```
 
-### Allow internal DNS names
+Replaces addresses and domains with consistent placeholders, so relationships
+between rules and interfaces survive while the real values do not.
+
+**Check before you commit to it:**
 
 ```bash
-pfsense-redactor config.xml redacted.xml --no-redact-domains --keep-private-ips
-```
-
-### Aggressive mode
-
-```bash
-pfsense-redactor config.xml redacted.xml --aggressive
-```
-
-### Dry run
-
-```bash
-# Show statistics only
-pfsense-redactor config.xml --dry-run
-
-# Show statistics with sample redactions (safely masked)
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
-### Output to STDOUT
+Prints what would change, with samples safely masked.
+
+**If your config sends notifications** (Slack, Discord, Telegram), add
+`--aggressive` — webhook tokens live in URL paths, which are preserved by
+default so package feed URLs are not destroyed. See
+[security](https://github.com/grounzero/pfsense-redactor/blob/main/docs/security.md#what-gets-redacted).
+
+## How well does it work?
+
+Measured against a 46-secret canary corpus that ships with the repository:
+
+| Tool | Caught |
+|---|---|
+| **pfsense-redactor 1.1.1** | **42 / 46** |
+| ForesightCyber Config Anonymizer | 17 / 46 |
+| netgate-xlsx | 11 / 46 |
+
+The corpus was built alongside this tool, which biases it — and the four misses
+are documented rather than hidden. Run it yourself:
 
 ```bash
-pfsense-redactor config.xml --stdout > redacted.xml
+pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
+  | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
 ```
 
-### In-place (danger)
-
-```bash
-pfsense-redactor config.xml --inplace --force
-```
-
----
-
-## Command-Line Flags Reference
-
-### Version & Help
-
-| Flag              | Description                   |
-| ----------------- | ----------------------------- |
-| `--version`       | Show program version and exit |
-| `--check-version` | Check for updates from PyPI   |
-| `-h, --help`      | Show help message and exit    |
-
-### Input/Output
-
-| Flag                     | Description                                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `input`                  | Input pfSense config.xml file (positional argument)                                                     |
-| `output`                 | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
-| `--stdout`               | Write redacted XML to stdout instead of file                                                            |
-| `--inplace`              | Overwrite input file with redacted output (use with caution)                                            |
-| `--force`                | Overwrite output file if it already exists                                                              |
-| `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security)                                 |
-
-### Redaction Modes
-
-| Flag                     | Description                                                                                                                                        |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--keep-private-ips`     | Keep non-global IP addresses visible (RFC1918/ULA/loopback/link-local). Netmasks and unspecified addresses (0.0.0.0, ::) always preserved          |
-| `--no-keep-private-ips`  | When used with `--anonymise`, do NOT keep private IPs visible (mask all IPs)                                                                       |
-| `--anonymise`            | Use consistent aliases (IP_1, domain1.example) to preserve network topology. Implies `--keep-private-ips` unless `--no-keep-private-ips` specified |
-| `--aggressive`           | Broaden secret detection (high-entropy values, free-text option blocks, URL path tokens) and apply IP/domain redaction to all element text          |
-| `--no-redact-ips`        | Do not redact IP addresses                                                                                                                         |
-| `--no-redact-domains`    | Do not redact domain names                                                                                                                         |
-| `--redact-url-usernames` | Redact usernames in URLs (default: preserve usernames, always redact passwords)                                                                    |
-| `--redact-descriptions`  | Redact free-text descriptions and identifiers (`descr`, `detail`, `hostname`, `ssid`). Off by default as these aid troubleshooting                  |
-
-<details>
-<summary>Allow-lists</summary>
-
-- Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
-
-| Flag                        | Description                                                                                                              |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `--allowlist-ip IP_OR_CIDR` | IP address or CIDR network to never redact (repeatable). Applies to text and URLs                                        |
-| `--allowlist-domain DOMAIN` | Domain to never redact (repeatable, case-insensitive, supports suffix matching). Applies to bare FQDNs and URL hostnames |
-| `--allowlist-file PATH`     | File containing IPs, CIDR networks, and domains to never redact (one per line)                                           |
-| `--no-default-allowlist`    | Do not load default allow-list files (.pfsense-allowlist in current dir or ~/.pfsense-allowlist)                         |
-
-</details>
-
-<details>
-<summary>Testing & Diagnostics</summary>
-
-| Flag                | Description                                                             |
-| ------------------- | ----------------------------------------------------------------------- |
-| `--dry-run`         | Show statistics only, do not write output file                          |
-| `--dry-run-verbose` | Show statistics with sample redactions (safely masked to prevent leaks) |
-| `--fail-on-warn`    | Exit with non-zero code if root tag is not 'pfsense' (useful in CI)     |
-
-</details>
-
-### Output Control
-
-| Flag            | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `-q, --quiet`   | Suppress progress messages (show only warnings and errors) |
-| `-v, --verbose` | Show detailed debug information                            |
-
----
-
-## Allow-lists
-
-Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
-
-### Default allow-list files
-
-The tool automatically loads allow-lists from these locations (if they exist):
-
-1. `.pfsense-allowlist` in current directory
-2. `~/.pfsense-allowlist` in home directory
-
-To disable: use `--no-default-allowlist`
-
-### Allow-list file format
-
-Create `.pfsense-allowlist` or use `--allowlist-file`:
-
-```
-# Comments start with #
-# One item per line (IP, CIDR, or domain)
-
-# Public DNS servers
-8.8.8.8
-1.1.1.1
-
-# Cloud provider ranges
-203.0.113.0/24
-198.51.100.0/24
-
-# NTP servers (suffix matching: preserves time.nist.gov and *.time.nist.gov)
-time.nist.gov
-pool.ntp.org
-
-# Wildcard domains (*.example.org preserves all subdomains)
-*.pfsense.org
-```
-
-See [`allowlist.example`](allowlist.example) for a complete template.
-
-### CLI allow-list flags
-
-```bash
-# Add specific IPs or CIDR ranges (repeatable)
---allowlist-ip 8.8.8.8 --allowlist-ip 203.0.113.0/24
-
-# Add specific domains (repeatable, case-insensitive, supports suffix matching)
---allowlist-domain time.nist.gov --allowlist-domain pool.ntp.org
-
-# Load from file (supports IPs, CIDRs, and domains)
---allowlist-file /path/to/allowlist.txt
-
-# Disable default file loading
---no-default-allowlist
-```
-
-**Features:**
-
-- **CIDR support**: `203.0.113.0/24` preserves all IPs in that range
-- **Suffix matching**: `example.org` preserves `sub.example.org`, `db.corp.example.org`, etc.
-- **Wildcard domains**: `*.example.org` is equivalent to suffix matching on `example.org`
-- **IDNA/punycode**: Automatically handles internationalised domains (e.g., `bücher.example` ↔ `xn--bcher-kva.example`)
-- **Merged sources**: All CLI flags, files, and default files are combined
-
-**Note:** Items in allow-lists are never redacted in:
-
-- Raw text IP/domain references
-- URL hostnames
-- Bare FQDNs
-
----
-
-## Example
-
-### Input
-
-```xml
-<openvpn>
-  <server>
-    <local>192.168.10.1</local>
-    <tlsauth>-----BEGIN OpenVPN Static key-----ABC123...</tlsauth>
-    <remote>198.51.100.10</remote>
-    <remote_port>443</remote_port>
-  </server>
-</openvpn>
-```
-
-### Output (`--keep-private-ips`)
-
-```xml
-<openvpn>
-  <server>
-    <local>192.168.10.1</local>
-    <tlsauth>[REDACTED]</tlsauth>
-    <remote>XXX.XXX.XXX.XXX</remote>
-    <remote_port>443</remote_port>
-  </server>
-</openvpn>
-```
-
-### Output (`--anonymise`)
-
-```xml
-<openvpn>
-  <server>
-    <local>IP_1</local>
-    <tlsauth>[REDACTED]</tlsauth>
-    <remote>IP_2</remote>
-    <remote_port>443</remote_port>
-  </server>
-</openvpn>
-```
-
----
-
-## Security Notes
-
-> **Never restore the redacted file to pfSense.**
-
-Redacted output is for **analysis only**, because:
-
-- CDATA and comments are removed by XML parser
-- PEM blocks and binary data are collapsed
-- Some optional metadata fields may be stripped
-
-Always keep the **original secure copy**.
-
-### Path Security
-
-The tool includes built-in protections against malicious file path operations:
-
-**Default behaviour (secure):**
-
-- Only relative paths are allowed by default
-- Directory traversal (`../../../etc/passwd`) is blocked
-- Paths with null bytes are rejected
-- Writing to system directories (`/etc`, `/sys`, `/proc`, `/Windows/System32`, etc.) is blocked
-- Safe locations (home directory, current working directory, temp directories) are automatically allowed
-
-**Using `--allow-absolute-paths`:**
-
-- Enables absolute paths for intentional use cases
-- Still blocks writes to sensitive system directories
-- Still blocks directory traversal attempts
-- Useful when you need to specify full paths explicitly
-
-**Examples:**
-
-```bash
-# Safe: relative path (default)
-pfsense-redactor config.xml output.xml
-
-# Blocked: absolute path without flag
-pfsense-redactor /etc/config.xml output.xml
-# Error: Absolute paths not allowed (use --allow-absolute-paths)
-
-# Blocked: directory traversal
-pfsense-redactor ../../../etc/passwd output.xml
-# Error: Path contains directory traversal components (..)
-
-# Blocked: writing to system directory (even with flag)
-pfsense-redactor config.xml /etc/output.xml --allow-absolute-paths
-# Error: Cannot write to sensitive system directory
-
-# Allowed: absolute path to safe location with flag
-pfsense-redactor ~/config.xml ~/output.xml --allow-absolute-paths
-
-# Blocked: in-place editing of system files
-pfsense-redactor /etc/hosts --inplace --force --allow-absolute-paths
-# Error: Cannot use --inplace with this file
-```
-
-**Protected system directories:**
-
-- Unix/Linux: `/etc`, `/sys`, `/proc`, `/dev`, `/boot`, `/root`, `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/lib`, `/lib64`, `/var/log`, `/var/run`, `/tmp`, `/run`
-- Windows: `C:\Windows`, `C:\Windows\System32`, `C:\Program Files`, `C:\ProgramData`
-- Critical files: `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, etc.
-
----
-
-## Testing
-
-### Dry run summary
-
-```bash
-# Statistics only
-pfsense-redactor config.xml --dry-run
-
-# Statistics with sample redactions (safely masked to avoid leaks)
-pfsense-redactor config.xml --dry-run-verbose
-```
-
-**Sample output with `--dry-run-verbose`:**
-
-```
-[+] Redaction summary:
-    - Passwords/keys/secrets: 10
-    - Certificates: 6
-    - IP addresses: 26
-    - Domain names: 47
-
-[+] Samples of changes (limit N=5):
-    IP: 198.51.***.42 → XXX.XXX.XXX.XXX
-    IP: 2001:db8:*:****::1 → XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX
-    URL: https://198.51.***.42/admin → https://XXX.XXX.XXX.XXX/admin
-    FQDN: db.***.example.org → example.com
-    MAC: aa:bb:**:**:ee:ff → XX:XX:XX:XX:XX:XX
-    Secret: p****************d (len=18) → [REDACTED]
-    Cert/Key: PEM blob (len≈2048) → [REDACTED_CERT_OR_KEY]
-```
-
-**Sample masking policy** (prevents leaks in dry-run output):
-
-- **IP**: Keep first and last octet/segment, mask middle (e.g., `198.51.***.42`)
-- **URL**: Show full URL but mask host as above
-- **FQDN**: Keep TLD and one left label, mask rest (e.g., `db.***.example.org`)
-- **MAC**: Mask middle octets (e.g., `aa:bb:**:**:ee:ff`)
-- **Secret**: Show length and first/last 2 chars only (e.g., `p****************d (len=18)`)
-- **Cert/Key**: Just show placeholder with length (e.g., `PEM blob (len≈2048)`)
-
-### Recommended test flags
-
-| Purpose                      | Command                                  |
-| ---------------------------- | ---------------------------------------- |
-| Support & AI review          | `--keep-private-ips --no-redact-domains` |
-| Topology map w/o identifiers | `--anonymise`                            |
-| Nuke everything              | `--aggressive`                           |
-
----
-
-## Stats example
-
-```
-[+] Redaction summary:
-    - Passwords/keys/secrets: 4
-    - Certificates: 2
-    - IP addresses: 11
-    - MAC addresses: 3
-    - Domain names: 5
-    - Email addresses: 1
-    - URLs: 2
-```
-
----
+Full method, caveats and per-secret results in
+[the benchmark](https://github.com/grounzero/pfsense-redactor/blob/main/docs/benchmark.md).
+
+## Before you share the output
+
+> **Never restore a redacted file to pfSense.** Comments, CDATA and some
+> metadata do not survive the round trip. Keep your original.
+
+Read the run summary — it reports high-entropy values it deliberately *kept*,
+with their element paths, so you can audit them. For a second opinion from a
+scanner that fails differently, see
+[verifying output](https://github.com/grounzero/pfsense-redactor/blob/main/docs/verifying-output.md).
+
+## Documentation
+
+| | |
+|---|---|
+| [CLI reference](https://github.com/grounzero/pfsense-redactor/blob/main/docs/cli-reference.md) | Every flag, with examples |
+| [Use cases](https://github.com/grounzero/pfsense-redactor/blob/main/docs/use-cases.md) | Netgate TAC, AI tools, MSP handoff, audits — and how this relates to `diag_sanitize.php` |
+| [Allow-lists](https://github.com/grounzero/pfsense-redactor/blob/main/docs/allow-lists.md) | Keep specific IPs, CIDRs and domains readable |
+| [Security](https://github.com/grounzero/pfsense-redactor/blob/main/docs/security.md) | Threat model, what gets redacted, path safety |
+| [Verifying output](https://github.com/grounzero/pfsense-redactor/blob/main/docs/verifying-output.md) | Checking the result, and using gitleaks alongside |
+| [Benchmark](https://github.com/grounzero/pfsense-redactor/blob/main/docs/benchmark.md) | Canary corpus results and known gaps |
+| [Examples](https://github.com/grounzero/pfsense-redactor/blob/main/docs/examples.md) | Before/after output, statistics, testing |
+| [FAQ](https://github.com/grounzero/pfsense-redactor/blob/main/docs/faq.md) | Common questions |
+| [Changelog](https://github.com/grounzero/pfsense-redactor/blob/main/CHANGELOG.md) | Release history |
 
 ## Contributing
 
-Pull requests welcome. Particularly:
+Issues and pull requests are welcome. If you find a secret that survives
+redaction, that is the most valuable report there is — a minimal fragment with
+the value replaced by a `CANARY_*` marker can go straight into the corpus so the
+miss stays fixed.
 
-- Additional pfSense element coverage
-- Plugin XML tag packs (WireGuard, pfBlockerNG, HAProxy, Snort, ACME, FRR)
-- Unit test configs
+Run the tests with:
 
----
+```bash
+pip install -e ".[dev]"
+pytest
+```
 
 ## Licence
 
-MIT
+MIT — see [LICENSE](https://github.com/grounzero/pfsense-redactor/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ scanner that fails differently, see
 
 ## Documentation
 
-| | |
+| Guide | Covers |
 |---|---|
 | [CLI reference](https://github.com/grounzero/pfsense-redactor/blob/main/docs/cli-reference.md) | Every flag, with examples |
 | [Use cases](https://github.com/grounzero/pfsense-redactor/blob/main/docs/use-cases.md) | Netgate TAC, AI tools, MSP handoff, audits — and how this relates to `diag_sanitize.php` |

--- a/docs/allow-lists.md
+++ b/docs/allow-lists.md
@@ -1,10 +1,8 @@
 # Allow-lists
 
-## Allow-lists
-
 Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
 
-### Default allow-list files
+## Default allow-list files
 
 The tool automatically loads allow-lists from these locations (if they exist):
 
@@ -13,7 +11,7 @@ The tool automatically loads allow-lists from these locations (if they exist):
 
 To disable: use `--no-default-allowlist`
 
-### Allow-list file format
+## Allow-list file format
 
 Create `.pfsense-allowlist` or use `--allowlist-file`:
 
@@ -39,7 +37,7 @@ pool.ntp.org
 
 See [`allowlist.example`](allowlist.example) for a complete template.
 
-### CLI allow-list flags
+## CLI allow-list flags
 
 ```bash
 # Add specific IPs or CIDR ranges (repeatable)

--- a/docs/allow-lists.md
+++ b/docs/allow-lists.md
@@ -1,5 +1,7 @@
 # Allow-lists
 
+[← Documentation index](../README.md#documentation)
+
 Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
 
 ## Default allow-list files
@@ -35,7 +37,7 @@ pool.ntp.org
 *.pfsense.org
 ```
 
-See [`allowlist.example`](allowlist.example) for a complete template.
+See [`allowlist.example`](../allowlist.example) for a complete template.
 
 ## CLI allow-list flags
 

--- a/docs/allow-lists.md
+++ b/docs/allow-lists.md
@@ -1,0 +1,70 @@
+# Allow-lists
+
+## Allow-lists
+
+Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
+
+### Default allow-list files
+
+The tool automatically loads allow-lists from these locations (if they exist):
+
+1. `.pfsense-allowlist` in current directory
+2. `~/.pfsense-allowlist` in home directory
+
+To disable: use `--no-default-allowlist`
+
+### Allow-list file format
+
+Create `.pfsense-allowlist` or use `--allowlist-file`:
+
+```
+# Comments start with #
+# One item per line (IP, CIDR, or domain)
+
+# Public DNS servers
+8.8.8.8
+1.1.1.1
+
+# Cloud provider ranges
+203.0.113.0/24
+198.51.100.0/24
+
+# NTP servers (suffix matching: preserves time.nist.gov and *.time.nist.gov)
+time.nist.gov
+pool.ntp.org
+
+# Wildcard domains (*.example.org preserves all subdomains)
+*.pfsense.org
+```
+
+See [`allowlist.example`](allowlist.example) for a complete template.
+
+### CLI allow-list flags
+
+```bash
+# Add specific IPs or CIDR ranges (repeatable)
+--allowlist-ip 8.8.8.8 --allowlist-ip 203.0.113.0/24
+
+# Add specific domains (repeatable, case-insensitive, supports suffix matching)
+--allowlist-domain time.nist.gov --allowlist-domain pool.ntp.org
+
+# Load from file (supports IPs, CIDRs, and domains)
+--allowlist-file /path/to/allowlist.txt
+
+# Disable default file loading
+--no-default-allowlist
+```
+
+**Features:**
+
+- **CIDR support**: `203.0.113.0/24` preserves all IPs in that range
+- **Suffix matching**: `example.org` preserves `sub.example.org`, `db.corp.example.org`, etc.
+- **Wildcard domains**: `*.example.org` is equivalent to suffix matching on `example.org`
+- **IDNA/punycode**: Automatically handles internationalised domains (e.g., `bücher.example` ↔ `xn--bcher-kva.example`)
+- **Merged sources**: All CLI flags, files, and default files are combined
+
+**Note:** Items in allow-lists are never redacted in:
+
+- Raw text IP/domain references
+- URL hostnames
+- Bare FQDNs

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -12,7 +12,7 @@ than take them on trust.
 ## Results
 
 | Tool | Caught | Date tested |
-|---|---|---|
+| --- | --- | --- |
 | **pfsense-redactor 1.1.1** | **42 / 46** | 2026-07-28 |
 | ForesightCyber pfSense Config Anonymizer | 17 / 46 | 2026-07-28 |
 | netgate-xlsx | 11 / 46 | 2026-07-28 |
@@ -45,7 +45,7 @@ Four markers survive. Two are artefacts of how the corpus is written rather than
 gaps, which matters when comparing the columns:
 
 | Marker | Element | Why it survives |
-|---|---|---|
+| --- | --- | --- |
 | `CANARY_HAPROXYCERTS` | `config/ha_certificates` | **Corpus artefact.** The value is a short literal. Short values in certificate-named elements are deliberately preserved as *references* (a `certref`, a key id), because they help a reader understand config structure and are not key material. With real PEM or base64 content the same element redacts to `[REDACTED_CERT_OR_KEY]`. |
 | `CANARY_SSLOFFLOAD` | `config/ssloffloadcert` | Same. |
 | `CANARY_WGPUB` | `item/publickey` | **Deliberate.** A WireGuard *public* key is not a secret; it is in `SECRET_TAG_DENYLIST`. It is identifying, so redact it with `--aggressive` if that matters to you. |
@@ -99,7 +99,7 @@ number that nothing enforces drifts, so it is enforced.
 <summary>All 46 planted secrets</summary>
 
 | Path | Secret type | redactor 1.1.1 | ForesightCyber | netgate-xlsx |
-|---|---|:--:|:--:|:--:|
+| --- | --- | :--: | :--: | :--: |
 | `user/bcrypt-hash` | password hash | ✅ | ✅ | ✅ |
 | `user/md5-hash` | password hash | ✅ | ❌ | ❌ |
 | `user/nt-hash` | password hash | ✅ | ❌ | ❌ |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,151 @@
+# Canary corpus benchmark
+
+How much of a pfSense `config.xml` does a redaction tool actually catch?
+
+`tests/corpus/canary-corpus.xml` answers that with 46 planted secrets, each a
+unique `CANARY_*` marker. A marker surviving redaction is a leak, so counting
+survivors gives a score with no interpretation in between.
+
+The corpus ships with this repository so you can check the numbers below rather
+than take them on trust.
+
+## Results
+
+| Tool | Caught | Date tested |
+|---|---|---|
+| **pfsense-redactor 1.1.1** | **42 / 46** | 2026-07-28 |
+| ForesightCyber pfSense Config Anonymizer | 17 / 46 | 2026-07-28 |
+| netgate-xlsx | 11 / 46 | 2026-07-28 |
+
+Versions were not recorded for the two comparison tools; both were the current
+release at the time of testing.
+
+## Read this before quoting the numbers
+
+**The corpus was built alongside pfsense-redactor.** It grew out of bug reports
+filed against this tool — several of the 46 markers exist precisely because a
+1.0.10 or 1.1.0 release missed them. It therefore covers what this tool has been
+taught to look for, and a corpus assembled by either of the other projects would
+likely look different and score differently. That is a real selection effect,
+not a footnote.
+
+**The tools do not all share the same goal.** `netgate-xlsx` is oriented toward
+exporting configuration to a spreadsheet for review rather than sanitising it
+for sharing, so scoring it on secret coverage measures something it does not set
+out to do. Treat its number as context, not a verdict.
+
+**A high score is not a guarantee.** 42 / 46 on a corpus this tool was developed
+against says more about regression coverage than about an unseen configuration.
+Always read the output before sharing it — see
+[verifying output](verifying-output.md).
+
+## What pfsense-redactor does not catch
+
+Four markers survive. Two are artefacts of how the corpus is written rather than
+gaps, which matters when comparing the columns:
+
+| Marker | Element | Why it survives |
+|---|---|---|
+| `CANARY_HAPROXYCERTS` | `config/ha_certificates` | **Corpus artefact.** The value is a short literal. Short values in certificate-named elements are deliberately preserved as *references* (a `certref`, a key id), because they help a reader understand config structure and are not key material. With real PEM or base64 content the same element redacts to `[REDACTED_CERT_OR_KEY]`. |
+| `CANARY_SSLOFFLOAD` | `config/ssloffloadcert` | Same. |
+| `CANARY_WGPUB` | `item/publickey` | **Deliberate.** A WireGuard *public* key is not a secret; it is in `SECRET_TAG_DENYLIST`. It is identifying, so redact it with `--aggressive` if that matters to you. |
+| `CANARY_ATTR_PLAIN` | `config_note[@note]` | **Known limitation.** Free text in an XML attribute whose *name* is not sensitive. Attribute matching is name-driven, and pfSense barely uses attributes. No tool in this comparison caught it. |
+
+`netgate-xlsx` scores a pass on the two HAProxy rows because it redacts by
+element name regardless of content, which also removes the short references.
+Whether that is better depends on whether you would rather lose the reference or
+keep it.
+
+To confirm the HAProxy rows are content-dependent rather than a blind spot:
+
+```bash
+printf '%s\n' \
+  '<pfsense><installedpackages><p><config>' \
+  '<ha_certificates>MIIDXTCCAkWgAwIBAgIJAKL0UG+mRkSPMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFV</ha_certificates>' \
+  '</config></p></installedpackages></pfsense>' > /tmp/cert-probe.xml
+
+pfsense-redactor /tmp/cert-probe.xml --stdout
+# <ha_certificates>[REDACTED_CERT_OR_KEY]</ha_certificates>
+```
+
+## Reproducing this
+
+```bash
+pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
+  | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
+```
+
+Every marker printed is one that survived. Expect exactly four:
+
+```
+CANARY_ATTR_PLAIN
+CANARY_HAPROXYCERTS
+CANARY_SSLOFFLOAD
+CANARY_WGPUB
+```
+
+Run the same file through any other tool and count its survivors the same way.
+
+## Keeping the number honest
+
+`tests/integration/test_canary_corpus.py` pins this result in CI and fails in
+both directions: a fifth marker surviving is a redaction regression, and one of
+the four disappearing means this page is out of date. A published coverage
+number that nothing enforces drifts, so it is enforced.
+
+## Full results
+
+<details>
+<summary>All 46 planted secrets</summary>
+
+| Path | Secret type | redactor 1.1.1 | ForesightCyber | netgate-xlsx |
+|---|---|:--:|:--:|:--:|
+| `user/bcrypt-hash` | password hash | ✅ | ✅ | ✅ |
+| `user/md5-hash` | password hash | ✅ | ❌ | ❌ |
+| `user/nt-hash` | password hash | ✅ | ❌ | ❌ |
+| `user/authorizedkeys` | SSH keys | ✅ | ✅ | ✅ |
+| `user/ipsecpsk` | per-user IPsec PSK | ✅ | ❌ | ❌ |
+| `authserver/ldap_bindpw` | LDAP bind password | ✅ | ❌ | ❌ |
+| `authserver/radius_secret` | RADIUS secret | ✅ | ❌ | ✅ |
+| `zone/radiussecret` | captive portal RADIUS | ✅ | ❌ | ❌ |
+| `snmpd/rocommunity` | SNMP community | ✅ | ✅ | ❌ |
+| `snmpd/rwcommunity` | SNMP community | ✅ | ❌ | ❌ |
+| `wpa/passphrase` | WPA PSK | ✅ | ❌ | ❌ |
+| `phase1/pre-shared-key` | IPsec PSK | ✅ | ✅ | ✅ |
+| `mobilekey/pre-shared-key` | IPsec mobile PSK | ✅ | ✅ | ✅ |
+| `phase1/eap_password` | EAP credential | ✅ | ❌ | ❌ |
+| `openvpn-client/tls` | TLS key | ✅ | ✅ | ✅ |
+| `openvpn-client/auth_pass` | VPN password | ✅ | ✅ | ❌ |
+| `openvpn-client/custom_options` | inline blob | ✅ | ❌ | ❌ |
+| `item/privatekey` | WireGuard private key | ✅ | ✅ | ❌ |
+| `item/presharedkey` | WireGuard PSK | ✅ | ❌ | ❌ |
+| `item/publickey` | WireGuard public key (deny-listed) | ❌ | ✅ | ❌ |
+| `ppp/password` | PPPoE | ✅ | ✅ | ✅ |
+| `dyndns/password` | DynDNS | ✅ | ✅ | ✅ |
+| `dyndns/updateurl` | token in query string | ✅ | ❌ | ❌ |
+| `alias/url` | licence in query string | ✅ | ✅ | ❌ |
+| `alias/detail` | credentials in free text | ✅ | ✅ | ❌ |
+| `smtp/password` | SMTP | ✅ | ✅ | ✅ |
+| `smtp/passwordagain` | SMTP duplicate field | ✅ | ❌ | ❌ |
+| `telegram/api_key` | bot token | ✅ | ❌ | ❌ |
+| `pushover/apikey` | API key | ✅ | ❌ | ❌ |
+| `pushover/userkey` | user key | ✅ | ❌ | ❌ |
+| `config/maxmind_key` | pfBlockerNG licence | ✅ | ✅ | ❌ |
+| `item/accountkey` | ACME account key | ✅ | ❌ | ❌ |
+| `a_dnsprovider/dns_cf_token` | Cloudflare token | ✅ | ❌ | ❌ |
+| `config/ha_certificates` | HAProxy certs (see above) | ❌ | ❌ | ✅ |
+| `config/ssloffloadcert` | HAProxy cert (see above) | ❌ | ❌ | ✅ |
+| `config/influx_token` | InfluxDB token | ✅ | ❌ | ❌ |
+| `config/token` | bare token | ✅ | ❌ | ❌ |
+| `config/bearer_token` | bearer token | ✅ | ❌ | ❌ |
+| `config/access_key` | S3 access key | ✅ | ❌ | ❌ |
+| `config/secret_access_key` | S3 secret | ✅ | ❌ | ❌ |
+| `config/tlspskvalue` | Zabbix PSK | ✅ | ❌ | ❌ |
+| `config/upsd_users` | NUT password | ✅ | ✅ | ❌ |
+| `config/userparams` | Zabbix script path | ✅ | ✅ | ❌ |
+| `config/webhook_url` | Slack path token | ✅ | ❌ | ❌ |
+| `config_note[@secret]` | attribute | ✅ | ❌ | ❌ |
+| `config_note[@note]` | attribute free text | ❌ | ❌ | ❌ |
+| **Total** | | **42 / 46** | **17 / 46** | **11 / 46** |
+
+</details>

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,5 +1,7 @@
 # Canary corpus benchmark
 
+[← Documentation index](../README.md#documentation)
+
 How much of a pfSense `config.xml` does a redaction tool actually catch?
 
 `tests/corpus/canary-corpus.xml` answers that with 46 planted secrets, each a

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,7 @@
 # CLI reference
 
+[← Documentation index](../README.md#documentation)
+
 ## Requirements
 
 - **Python 3.9+**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,142 @@
+# CLI reference
+
+## Requirements
+
+- **Python 3.9+**
+
+## Usage
+
+### Basic usage
+
+```bash
+# Output filename auto-generated as config-redacted.xml
+pfsense-redactor config.xml
+
+# Or specify output filename explicitly
+pfsense-redactor config.xml redacted.xml
+```
+
+### Preserve private IPs (recommended)
+
+```bash
+pfsense-redactor config.xml redacted.xml --keep-private-ips
+```
+
+### Allow-list specific IPs and domains
+
+```bash
+# Preserve specific public services (never redact)
+pfsense-redactor config.xml --allowlist-ip 8.8.8.8 --allowlist-domain time.nist.gov
+
+# Preserve entire CIDR ranges
+pfsense-redactor config.xml --allowlist-ip 203.0.113.0/24
+
+# Use an allow-list file (supports IPs, CIDRs, and domains)
+pfsense-redactor config.xml --allowlist-file my-allowlist.txt
+```
+
+### Topology-safe anonymisation
+
+```bash
+pfsense-redactor config.xml redacted.xml --anonymise
+```
+
+### Allow internal DNS names
+
+```bash
+pfsense-redactor config.xml redacted.xml --no-redact-domains --keep-private-ips
+```
+
+### Aggressive mode
+
+```bash
+pfsense-redactor config.xml redacted.xml --aggressive
+```
+
+### Dry run
+
+```bash
+# Show statistics only
+pfsense-redactor config.xml --dry-run
+
+# Show statistics with sample redactions (safely masked)
+pfsense-redactor config.xml --dry-run-verbose
+```
+
+### Output to STDOUT
+
+```bash
+pfsense-redactor config.xml --stdout > redacted.xml
+```
+
+### In-place (danger)
+
+```bash
+pfsense-redactor config.xml --inplace --force
+```
+
+## Command-Line Flags Reference
+
+### Version & Help
+
+| Flag              | Description                   |
+| ----------------- | ----------------------------- |
+| `--version`       | Show program version and exit |
+| `--check-version` | Check for updates from PyPI   |
+| `-h, --help`      | Show help message and exit    |
+
+### Input/Output
+
+| Flag                     | Description                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `input`                  | Input pfSense config.xml file (positional argument)                                                     |
+| `output`                 | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
+| `--stdout`               | Write redacted XML to stdout instead of file                                                            |
+| `--inplace`              | Overwrite input file with redacted output (use with caution)                                            |
+| `--force`                | Overwrite output file if it already exists                                                              |
+| `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security)                                 |
+
+### Redaction Modes
+
+| Flag                     | Description                                                                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--keep-private-ips`     | Keep non-global IP addresses visible (RFC1918/ULA/loopback/link-local). Netmasks and unspecified addresses (0.0.0.0, ::) always preserved          |
+| `--no-keep-private-ips`  | When used with `--anonymise`, do NOT keep private IPs visible (mask all IPs)                                                                       |
+| `--anonymise`            | Use consistent aliases (IP_1, domain1.example) to preserve network topology. Implies `--keep-private-ips` unless `--no-keep-private-ips` specified |
+| `--aggressive`           | Broaden secret detection (high-entropy values, free-text option blocks, URL path tokens) and apply IP/domain redaction to all element text          |
+| `--no-redact-ips`        | Do not redact IP addresses                                                                                                                         |
+| `--no-redact-domains`    | Do not redact domain names                                                                                                                         |
+| `--redact-url-usernames` | Redact usernames in URLs (default: preserve usernames, always redact passwords)                                                                    |
+| `--redact-descriptions`  | Redact free-text descriptions and identifiers (`descr`, `detail`, `hostname`, `ssid`). Off by default as these aid troubleshooting                  |
+
+<details>
+<summary>Allow-lists</summary>
+
+- Allow-lists let you preserve specific well-known IPs and domains that don't leak private information.
+
+| Flag                        | Description                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--allowlist-ip IP_OR_CIDR` | IP address or CIDR network to never redact (repeatable). Applies to text and URLs                                        |
+| `--allowlist-domain DOMAIN` | Domain to never redact (repeatable, case-insensitive, supports suffix matching). Applies to bare FQDNs and URL hostnames |
+| `--allowlist-file PATH`     | File containing IPs, CIDR networks, and domains to never redact (one per line)                                           |
+| `--no-default-allowlist`    | Do not load default allow-list files (.pfsense-allowlist in current dir or ~/.pfsense-allowlist)                         |
+
+</details>
+
+<details>
+<summary>Testing & Diagnostics</summary>
+
+| Flag                | Description                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| `--dry-run`         | Show statistics only, do not write output file                          |
+| `--dry-run-verbose` | Show statistics with sample redactions (safely masked to prevent leaks) |
+| `--fail-on-warn`    | Exit with non-zero code if root tag is not 'pfsense' (useful in CI)     |
+
+</details>
+
+### Output Control
+
+| Flag            | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `-q, --quiet`   | Suppress progress messages (show only warnings and errors) |
+| `-v, --verbose` | Show detailed debug information                            |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-## Example
+## Before and after
 
 ### Input
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,103 @@
+# Examples
+
+## Example
+
+### Input
+
+```xml
+<openvpn>
+  <server>
+    <local>192.168.10.1</local>
+    <tlsauth>-----BEGIN OpenVPN Static key-----ABC123...</tlsauth>
+    <remote>198.51.100.10</remote>
+    <remote_port>443</remote_port>
+  </server>
+</openvpn>
+```
+
+### Output (`--keep-private-ips`)
+
+```xml
+<openvpn>
+  <server>
+    <local>192.168.10.1</local>
+    <tlsauth>[REDACTED]</tlsauth>
+    <remote>XXX.XXX.XXX.XXX</remote>
+    <remote_port>443</remote_port>
+  </server>
+</openvpn>
+```
+
+### Output (`--anonymise`)
+
+```xml
+<openvpn>
+  <server>
+    <local>IP_1</local>
+    <tlsauth>[REDACTED]</tlsauth>
+    <remote>IP_2</remote>
+    <remote_port>443</remote_port>
+  </server>
+</openvpn>
+```
+
+## Stats example
+
+```
+[+] Redaction summary:
+    - Passwords/keys/secrets: 4
+    - Certificates: 2
+    - IP addresses: 11
+    - MAC addresses: 3
+    - Domain names: 5
+    - Email addresses: 1
+    - URLs: 2
+```
+
+## Testing
+
+### Dry run summary
+
+```bash
+# Statistics only
+pfsense-redactor config.xml --dry-run
+
+# Statistics with sample redactions (safely masked to avoid leaks)
+pfsense-redactor config.xml --dry-run-verbose
+```
+
+**Sample output with `--dry-run-verbose`:**
+
+```
+[+] Redaction summary:
+    - Passwords/keys/secrets: 10
+    - Certificates: 6
+    - IP addresses: 26
+    - Domain names: 47
+
+[+] Samples of changes (limit N=5):
+    IP: 198.51.***.42 → XXX.XXX.XXX.XXX
+    IP: 2001:db8:*:****::1 → XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX
+    URL: https://198.51.***.42/admin → https://XXX.XXX.XXX.XXX/admin
+    FQDN: db.***.example.org → example.com
+    MAC: aa:bb:**:**:ee:ff → XX:XX:XX:XX:XX:XX
+    Secret: p****************d (len=18) → [REDACTED]
+    Cert/Key: PEM blob (len≈2048) → [REDACTED_CERT_OR_KEY]
+```
+
+**Sample masking policy** (prevents leaks in dry-run output):
+
+- **IP**: Keep first and last octet/segment, mask middle (e.g., `198.51.***.42`)
+- **URL**: Show full URL but mask host as above
+- **FQDN**: Keep TLD and one left label, mask rest (e.g., `db.***.example.org`)
+- **MAC**: Mask middle octets (e.g., `aa:bb:**:**:ee:ff`)
+- **Secret**: Show length and first/last 2 chars only (e.g., `p****************d (len=18)`)
+- **Cert/Key**: Just show placeholder with length (e.g., `PEM blob (len≈2048)`)
+
+### Recommended test flags
+
+| Purpose                      | Command                                  |
+| ---------------------------- | ---------------------------------------- |
+| Support & AI review          | `--keep-private-ips --no-redact-domains` |
+| Topology map w/o identifiers | `--anonymise`                            |
+| Nuke everything              | `--aggressive`                           |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,7 @@
 # Examples
 
+[← Documentation index](../README.md#documentation)
+
 ## Before and after
 
 ### Input

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,30 +1,28 @@
 # FAQ
 
-## FAQ
-
-### What does pfsense-redactor redact by default?
+## What does pfsense-redactor redact by default?
 
 pfsense-redactor removes secrets such as passwords, private keys, certificates, tokens, and shared secrets.  
 It also redacts public IP addresses, domains, MAC addresses, and URLs unless explicitly preserved.
 
-### Does pfsense-redactor anonymise or just remove data?
+## Does pfsense-redactor anonymise or just remove data?
 
 It supports both. Redaction removes sensitive values entirely, while anonymisation replaces identifiers with consistent placeholders so topology and relationships remain clear.
 
-### Will anonymisation break troubleshooting or topology analysis?
+## Will anonymisation break troubleshooting or topology analysis?
 
 No. Deterministic anonymisation ensures the same identifier is always replaced with the same alias, preserving logical relationships and routing flow.
 
-### Can I safely share the output with vendors or AI tools?
+## Can I safely share the output with vendors or AI tools?
 
 Yes. pfsense-redactor is designed for sharing configurations externally without exposing secrets or identifiable network information.  
 Redacted output is for analysis only and must not be restored to pfSense.
 
-### Does this understand pfSense-specific configuration structures?
+## Does this understand pfSense-specific configuration structures?
 
 Yes. Unlike generic XML redaction tools, pfsense-redactor understands pfSense configuration layouts, including VPNs, interfaces, gateways, and common package XML structures.
 
-### When should I use aggressive mode?
+## When should I use aggressive mode?
 
 Use `--aggressive` when sharing configurations publicly or when third-party packages may include unknown sensitive fields.
 
@@ -35,6 +33,6 @@ Aggressive mode broadens both secret detection and identifier rewriting. On top 
 - Redact credential-shaped URL **path** segments, such as Slack/Discord webhook tokens
 - Apply IP/domain redaction to all element text, not just known fields
 
-### Can I restore the redacted file to pfSense?
+## Can I restore the redacted file to pfSense?
 
 No. Redacted output is for analysis/sharing only and must never be imported back into pfSense.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,7 @@
 # FAQ
 
+[← Documentation index](../README.md#documentation)
+
 ## What does pfsense-redactor redact by default?
 
 pfsense-redactor removes secrets such as passwords, private keys, certificates, tokens, and shared secrets.  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,40 @@
+# FAQ
+
+## FAQ
+
+### What does pfsense-redactor redact by default?
+
+pfsense-redactor removes secrets such as passwords, private keys, certificates, tokens, and shared secrets.  
+It also redacts public IP addresses, domains, MAC addresses, and URLs unless explicitly preserved.
+
+### Does pfsense-redactor anonymise or just remove data?
+
+It supports both. Redaction removes sensitive values entirely, while anonymisation replaces identifiers with consistent placeholders so topology and relationships remain clear.
+
+### Will anonymisation break troubleshooting or topology analysis?
+
+No. Deterministic anonymisation ensures the same identifier is always replaced with the same alias, preserving logical relationships and routing flow.
+
+### Can I safely share the output with vendors or AI tools?
+
+Yes. pfsense-redactor is designed for sharing configurations externally without exposing secrets or identifiable network information.  
+Redacted output is for analysis only and must not be restored to pfSense.
+
+### Does this understand pfSense-specific configuration structures?
+
+Yes. Unlike generic XML redaction tools, pfsense-redactor understands pfSense configuration layouts, including VPNs, interfaces, gateways, and common package XML structures.
+
+### When should I use aggressive mode?
+
+Use `--aggressive` when sharing configurations publicly or when third-party packages may include unknown sensitive fields.
+
+Aggressive mode broadens both secret detection and identifier rewriting. On top of the default behaviour it will:
+
+- Redact unrecognised high-entropy values (base64/hex/PEM-shaped) in any element, rather than reporting them
+- Redact free-text option blocks (`custom_options`, `userparams`, `upsd_users`, `advanced`, …) wholesale
+- Redact credential-shaped URL **path** segments, such as Slack/Discord webhook tokens
+- Apply IP/domain redaction to all element text, not just known fields
+
+### Can I restore the redacted file to pfSense?
+
+No. Redacted output is for analysis/sharing only and must never be imported back into pfSense.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,7 @@
 # Security
 
+[← Documentation index](../README.md#documentation)
+
 ## Threat model
 
 The failure that matters is **failing to redact**. Output is produced in order to

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,117 @@
+# Security
+
+## Threat model
+
+The failure that matters is **failing to redact**. Output is produced in order to
+be shared outside the firewall, so a missed secret is disclosed to whoever
+receives it. Everything below follows from that: where a judgement call exists,
+this tool over-redacts rather than under-redacts, and surfaces what it chose to
+keep so you can audit it.
+
+Verify before sharing — see [verifying output](verifying-output.md) — and see
+[the benchmark](benchmark.md) for measured coverage and known gaps.
+
+## What gets redacted
+
+Secrets are found by **element name**, not by value shape, because a real SNMP
+community (`public`) or WPA passphrase looks like ordinary text. Matching is
+substring-based, since the spellings that leak are the concatenated ones
+pfSense and its packages actually emit — `rocommunity`, `radiussecret`,
+`passwordagain` — with a deny-list for the false positives that creates
+(`keylen`, `certref`, `password_type`).
+
+Credentials embedded in URLs are handled separately:
+
+| Location | Default | `--aggressive` |
+|---|---|---|
+| `user:password@host` | password redacted | same |
+| `?token=…` query parameter | redacted | same |
+| Path segment (Slack/Discord webhook token) | kept | redacted |
+
+Path segments are kept by default because pfBlockerNG feed URLs legitimately
+carry long path components that redaction would destroy. An element *named* for a
+secret — `<webhook_url>` — is redacted whole regardless of mode, but
+`<slack_url>` or a bare `<url>` is not. If your configuration sends
+notifications, use `--aggressive`.
+
+Recognised credential formats in path segments include AWS access key IDs
+(exactly 20 characters), Telegram bot tokens (`bot<id>:<secret>`, where the
+colon defeats a naive base64 test) and Slack/Discord tokens with no digits in
+them.
+
+## Input handling
+
+Input declaring a `<!DOCTYPE>` is **refused**. pfSense never emits one, so its
+presence means the file did not come from pfSense untouched.
+
+This is deliberately not described as an XXE fix. Python's
+`xml.etree.ElementTree` does not resolve external entities — a `SYSTEM` entity
+raises `ParseError` — so there is no file disclosure and no SSRF. What it does
+do is expand *internal* entities, where a few hundred bytes of nested
+definitions expand to gigabytes. The whole XML prolog is scanned rather than a
+fixed-size prefix, so a declaration cannot hide behind a large comment, and a
+prolog beyond 1 MiB is refused outright to bound the work a hostile file can
+demand.
+
+## Sharing the output
+
+> **Never restore the redacted file to pfSense.**
+
+Redacted output is for **analysis only**, because:
+
+- CDATA and comments are removed by XML parser
+- PEM blocks and binary data are collapsed
+- Some optional metadata fields may be stripped
+
+Always keep the **original secure copy**.
+
+## Path safety
+
+The tool includes built-in protections against malicious file path operations:
+
+**Default behaviour (secure):**
+
+- Only relative paths are allowed by default
+- Directory traversal (`../../../etc/passwd`) is blocked
+- Paths with null bytes are rejected
+- Writing to system directories (`/etc`, `/sys`, `/proc`, `/Windows/System32`, etc.) is blocked
+- Safe locations (home directory, current working directory, temp directories) are automatically allowed
+
+**Using `--allow-absolute-paths`:**
+
+- Enables absolute paths for intentional use cases
+- Still blocks writes to sensitive system directories
+- Still blocks directory traversal attempts
+- Useful when you need to specify full paths explicitly
+
+**Examples:**
+
+```bash
+# Safe: relative path (default)
+pfsense-redactor config.xml output.xml
+
+# Blocked: absolute path without flag
+pfsense-redactor /etc/config.xml output.xml
+# Error: Absolute paths not allowed (use --allow-absolute-paths)
+
+# Blocked: directory traversal
+pfsense-redactor ../../../etc/passwd output.xml
+# Error: Path contains directory traversal components (..)
+
+# Blocked: writing to system directory (even with flag)
+pfsense-redactor config.xml /etc/output.xml --allow-absolute-paths
+# Error: Cannot write to sensitive system directory
+
+# Allowed: absolute path to safe location with flag
+pfsense-redactor ~/config.xml ~/output.xml --allow-absolute-paths
+
+# Blocked: in-place editing of system files
+pfsense-redactor /etc/hosts --inplace --force --allow-absolute-paths
+# Error: Cannot use --inplace with this file
+```
+
+**Protected system directories:**
+
+- Unix/Linux: `/etc`, `/sys`, `/proc`, `/dev`, `/boot`, `/root`, `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/lib`, `/lib64`, `/var/log`, `/var/run`, `/tmp`, `/run`
+- Windows: `C:\Windows`, `C:\Windows\System32`, `C:\Program Files`, `C:\ProgramData`
+- Critical files: `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, etc.

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,21 +23,39 @@ pfSense and its packages actually emit — `rocommunity`, `radiussecret`,
 Credentials embedded in URLs are handled separately:
 
 | Location | Default | `--aggressive` |
-|---|---|---|
+| --- | --- | --- |
 | `user:password@host` | password redacted | same |
 | `?token=…` query parameter | redacted | same |
-| Path segment (Slack/Discord webhook token) | kept | redacted |
+| Path token on a known webhook host | redacted | same |
+| Path segment on any other host | kept | redacted |
 
 Path segments are kept by default because pfBlockerNG feed URLs legitimately
-carry long path components that redaction would destroy. An element *named* for a
-secret — `<webhook_url>` — is redacted whole regardless of mode, but
-`<slack_url>` or a bare `<url>` is not. If your configuration sends
-notifications, use `--aggressive`.
+carry long path components that redaction would destroy — a corrupted config is
+its own kind of failure.
+
+The exception is endpoints where the path token *is* the credential, since
+anyone holding the URL can post as that integration. For those the token is
+redacted in every mode:
+
+| Endpoint | Matched as |
+| --- | --- |
+| Slack | `hooks.slack.com` + `/services/` |
+| Discord | `discord.com`, `discordapp.com`, `ptb.`/`canary.` variants + `/api/webhooks/` |
+| Telegram | `api.telegram.org` + `/bot` |
+
+Hosts are matched **exactly, never by suffix**, so `hooks.slack.com.example.net`
+does not inherit the rule; and the path prefix must match too, so an ordinary
+`discord.com/channels/…` link is untouched. Everything else still needs
+`--aggressive`.
 
 Recognised credential formats in path segments include AWS access key IDs
 (exactly 20 characters), Telegram bot tokens (`bot<id>:<secret>`, where the
 colon defeats a naive base64 test) and Slack/Discord tokens with no digits in
 them.
+
+Before 1.1.2 this depended on the element name: `<webhook_url>` matched the
+secret-name pattern and was redacted whole, but the same URL in `<slack_url>`,
+`<notifyurl>` or a plain `<url>` kept its token unless `--aggressive` was used.
 
 ## Input handling
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,10 +1,8 @@
 # Use cases
 
-## Use Cases
-
 Common command patterns depending on who you’re sharing with.
 
-### Sharing with Netgate TAC Support
+## Sharing with Netgate TAC Support
 
 ```bash
 # On the firewall (recommended for TAC)
@@ -14,7 +12,7 @@ Common command patterns depending on who you’re sharing with.
 pfsense-redactor config_sanitised.xml support-safe.xml --keep-private-ips --no-redact-domains
 ```
 
-### Sharing with AI tools
+## Sharing with AI tools
 
 Use `--aggressive` if you have third-party packages or aren’t sure where secrets live.
 
@@ -30,7 +28,7 @@ pfsense-redactor config.xml ai-ready.xml --anonymise --no-keep-private-ips --agg
 # Now safe to upload to AI tools for configuration analysis
 ```
 
-### Vendor/MSP Handoffs
+## Vendor/MSP Handoffs
 
 ```bash
 # Option A: Preserve private IPs for troubleshooting context
@@ -42,14 +40,14 @@ pfsense-redactor config.xml vendor-share.xml --anonymise
 pfsense-redactor config.xml vendor-share.xml --anonymise --no-keep-private-ips
 ```
 
-### Security Audits
+## Security Audits
 
 ```bash
 # Preview what will be redacted before sharing
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
-### Automated Compliance Workflows
+## Automated Compliance Workflows
 
 ```bash
 # CI/CD integration for automated sanitisation

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,105 @@
+# Use cases
+
+## Use Cases
+
+Common command patterns depending on who you’re sharing with.
+
+### Sharing with Netgate TAC Support
+
+```bash
+# On the firewall (recommended for TAC)
+/usr/local/sbin/diag_sanitize.php /conf/config.xml > /conf/config_sanitised.xml
+
+# Off-box: additional anonymisation before sharing further
+pfsense-redactor config_sanitised.xml support-safe.xml --keep-private-ips --no-redact-domains
+```
+
+### Sharing with AI tools
+
+Use `--aggressive` if you have third-party packages or aren’t sure where secrets live.
+
+```bash
+# Topology-preserving anonymisation (private IPs are kept visible by default with --anonymise)
+pfsense-redactor config.xml ai-ready.xml --anonymise --aggressive
+# Now safe to upload to AI tools for configuration analysis
+```
+
+```bash
+# Anonymise everything (including private IPs)
+pfsense-redactor config.xml ai-ready.xml --anonymise --no-keep-private-ips --aggressive
+# Now safe to upload to AI tools for configuration analysis
+```
+
+### Vendor/MSP Handoffs
+
+```bash
+# Option A: Preserve private IPs for troubleshooting context
+pfsense-redactor config.xml vendor-share.xml --anonymise
+```
+
+```bash
+# Option B: Anonymise everything (including private IPs) for stricter privacy
+pfsense-redactor config.xml vendor-share.xml --anonymise --no-keep-private-ips
+```
+
+### Security Audits
+
+```bash
+# Preview what will be redacted before sharing
+pfsense-redactor config.xml --dry-run-verbose
+```
+
+### Automated Compliance Workflows
+
+```bash
+# CI/CD integration for automated sanitisation
+pfsense-redactor $INPUT_CONFIG $OUTPUT_CONFIG --aggressive --fail-on-warn
+```
+
+## Relationship to pfSense built-in sanitisation
+
+pfSense includes a built-in configuration sanitisation script:
+
+```bash
+/usr/local/sbin/diag_sanitize.php /conf/config.xml > /conf/config_sanitised.xml
+```
+
+This official tool runs **on the firewall itself** and is primarily intended for safely sharing configurations with Netgate support. It removes high-value secrets (password hashes, pre-shared keys, certificates, etc.) while preserving the original network topology.
+
+**pfsense-redactor is complementary, not a replacement.**
+
+| Built-in `diag_sanitize.php`         | pfsense-redactor                                                  |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| Runs on pfSense only                 | Runs anywhere (workstation, CI, automation)                       |
+| PHP, internal to pfSense             | Python, standalone, MIT-licensed                                  |
+| Fixed sanitisation behaviour         | Configurable redaction and anonymisation                          |
+| Removes secrets                      | Removes secrets **and** can anonymise IPs, domains, MACs and URLs |
+| Best suited to Netgate support (TAC) | Best suited to vendors, consultants, AI tools and forums          |
+
+pfsense-redactor exists to cover use cases where:
+
+- the configuration has already been exported,
+- you do not wish to run additional tooling on the firewall,
+- or you require **privacy-preserving anonymisation** in addition to basic secret removal.
+
+Both tools share the same goal: preventing accidental disclosure of sensitive information when sharing pfSense configurations.
+
+## Comparison with Alternatives
+
+<details>
+<summary>Comparison with Alternatives</summary>
+
+| Feature                 | pfsense-redactor  | Generic XML Tools | Manual Redaction | Built-in diag_sanitize.php |
+| ----------------------- | ----------------- | ----------------- | ---------------- | -------------------------- |
+| pfSense-aware structure | ✅                | ❌                | ⚠️ Manual        | ✅                         |
+| Runs off-firewall       | ✅                | ✅                | ✅               | ❌ (pfSense only)          |
+| Network anonymisation   | ✅                | ❌                | ⚠️ Error-prone   | ❌                         |
+| Topology preservation   | ✅                | ❌                | ⚠️ Error-prone   | ✅                         |
+| Configurable modes      | ✅ multiple modes | ❌                | N/A              | ❌ Fixed                   |
+| CIDR allow-lists        | ✅                | ❌                | ⚠️ Error-prone   | ❌                         |
+| CI/CD integration       | ✅                | ⚠️                | ⚠️ Error-prone   | ❌                         |
+| Cross-platform          | ✅                | ⚠️                | ✅               | ❌                         |
+| WireGuard/IPsec aware   | ✅                | ❌                | ⚠️               | ✅                         |
+| Zero dependencies       | ✅                | ⚠️ Varies         | ✅               | ✅                         |
+
+</details>

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,5 +1,7 @@
 # Use cases
 
+[← Documentation index](../README.md#documentation)
+
 Common command patterns depending on who you’re sharing with.
 
 ## Sharing with Netgate TAC Support

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -52,10 +52,10 @@ gitleaks dir redacted.xml --no-banner
 ### What that actually buys you
 
 Measured, not assumed — gitleaks 8.30.1 against a config containing six real
-secrets:
+secrets, run against 1.1.1:
 
-| Secret | gitleaks | redactor (default) | redactor (`--aggressive`) |
-|---|:--:|:--:|:--:|
+| Secret | gitleaks | redactor 1.1.1 (default) | redactor 1.1.2 (default) |
+| --- | :--: | :--: | :--: |
 | `<rocommunity>public` | ❌ | ✅ | ✅ |
 | `<passphrase>CorrectHorseBattery` | ❌ | ✅ | ✅ |
 | `<ldap_bindpw>Sw0rdf1sh!` | ❌ | ✅ | ✅ |
@@ -63,8 +63,10 @@ secrets:
 | `<secret_access_key>` | ❌ | ✅ | ✅ |
 | `<slack_url>` webhook token | **✅** | **❌** | ✅ |
 
-gitleaks found one of the six — and it was the one this tool misses by default.
-That single row is the argument for running both.
+gitleaks found one of the six — and it was the one this tool was missing.
+**That row is why this page exists**: the finding was reported and fixed in
+1.1.2, which now redacts path tokens on known webhook hosts in every mode. An
+independent scanner earned its keep on the first run.
 
 **Why gitleaks missed the other five:** an SNMP community of `public` and a
 passphrase of `CorrectHorseBattery` have no distinguishing shape; nothing about
@@ -72,15 +74,13 @@ the value says "secret". Only the element name does. It also skipped the AWS key
 because `AKIAIOSFODNN7EXAMPLE` is Amazon's documented example key and is
 allowlisted — worth knowing if you test with it.
 
-**Why this tool missed the Slack token by default:** webhook credentials live in
-the URL *path*, and path-segment redaction is gated behind `--aggressive`
-because feed URLs (pfBlockerNG and similar) legitimately carry long path
-segments that would otherwise be destroyed. The element name decides it:
-`<webhook_url>` matches the secret-name pattern and is redacted whole, but
-`<slack_url>`, `<notifyurl>` and a bare `<url>` are not.
+That asymmetry is the point, and it did not go away with the fix. The two tools
+fail in opposite directions, so a second opinion is still worth having on a
+config this one has not seen.
 
-If your config sends notifications, use `--aggressive`, or check those elements
-by hand.
+Webhook tokens on hosts other than Slack, Discord and Telegram still need
+`--aggressive`, since a long path segment on an unrecognised host is as likely
+to be a feed URL as a credential.
 
 ### A clean scan is not a clean file
 

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -1,0 +1,112 @@
+# Verifying redacted output
+
+Redaction is not a thing to take on trust. This page covers the checks built
+into the tool, and how to get a second opinion from a scanner that fails
+differently.
+
+## 1. Read the summary — especially what was *kept*
+
+Every run prints what it redacted. More usefully, it also reports what it
+deliberately did **not**:
+
+```
+[!] 1 unrecognised high-entropy value(s) retained. Review before sharing:
+    - pfsense/installedpackages/mycustompkg/config/blob
+    Re-run with --aggressive to redact these automatically.
+```
+
+These are values that look like key material in elements the tool does not
+recognise — typically third-party package fields. It reports the element path
+rather than the value, so the warning is safe to paste into a ticket.
+
+This warning is the direct answer to "what did you leave behind". Do not ignore
+it, and re-run with `--aggressive` if any path looks like it holds a secret.
+
+## 2. Preview before you share
+
+```bash
+pfsense-redactor config.xml --dry-run-verbose
+```
+
+Shows counts plus masked before/after examples, so you can confirm the right
+things are being caught without writing a file. Samples are masked — the
+preview never prints a live secret to your terminal or CI log.
+
+## 3. Get a second opinion
+
+An independent secret scanner such as [gitleaks](https://github.com/gitleaks/gitleaks)
+is worth running over the output, because it fails in the opposite direction to
+this tool:
+
+- **pfsense-redactor keys off element names.** `<rocommunity>`, `<passphrase>`,
+  `<ldap_bindpw>` are secrets because of what they are called, whatever they
+  contain.
+- **gitleaks keys off value shape.** It matches AWS key formats, Slack webhook
+  URLs, PEM blocks and high-entropy strings, whatever element they sit in.
+
+```bash
+pfsense-redactor config.xml redacted.xml
+gitleaks dir redacted.xml --no-banner
+```
+
+### What that actually buys you
+
+Measured, not assumed — gitleaks 8.30.1 against a config containing six real
+secrets:
+
+| Secret | gitleaks | redactor (default) | redactor (`--aggressive`) |
+|---|:--:|:--:|:--:|
+| `<rocommunity>public` | ❌ | ✅ | ✅ |
+| `<passphrase>CorrectHorseBattery` | ❌ | ✅ | ✅ |
+| `<ldap_bindpw>Sw0rdf1sh!` | ❌ | ✅ | ✅ |
+| `<access_key>` AWS key id | ❌ | ✅ | ✅ |
+| `<secret_access_key>` | ❌ | ✅ | ✅ |
+| `<slack_url>` webhook token | **✅** | **❌** | ✅ |
+
+gitleaks found one of the six — and it was the one this tool misses by default.
+That single row is the argument for running both.
+
+**Why gitleaks missed the other five:** an SNMP community of `public` and a
+passphrase of `CorrectHorseBattery` have no distinguishing shape; nothing about
+the value says "secret". Only the element name does. It also skipped the AWS key
+because `AKIAIOSFODNN7EXAMPLE` is Amazon's documented example key and is
+allowlisted — worth knowing if you test with it.
+
+**Why this tool missed the Slack token by default:** webhook credentials live in
+the URL *path*, and path-segment redaction is gated behind `--aggressive`
+because feed URLs (pfBlockerNG and similar) legitimately carry long path
+segments that would otherwise be destroyed. The element name decides it:
+`<webhook_url>` matches the secret-name pattern and is redacted whole, but
+`<slack_url>`, `<notifyurl>` and a bare `<url>` are not.
+
+If your config sends notifications, use `--aggressive`, or check those elements
+by hand.
+
+### A clean scan is not a clean file
+
+Do not read "no leaks found" as proof. On this project's own 46-secret
+[canary corpus](benchmark.md), gitleaks reports **no findings at all** — before
+any redaction. The planted markers are low-entropy placeholder strings, which is
+the same reason it misses a real SNMP community.
+
+A scanner that finds nothing may mean the file is clean, or that the secrets do
+not look like secrets. Use it to catch what this tool missed, never to certify
+that nothing was missed.
+
+## 4. Diff the two files
+
+For a config small enough to read, nothing beats looking:
+
+```bash
+diff <(xmllint --format config.xml) <(xmllint --format redacted.xml) | less
+```
+
+Every line that did *not* change is a line you are choosing to share.
+
+## Reporting a miss
+
+If you find a secret that survived, please open an issue. A minimal
+`config.xml` fragment with the value replaced by a marker such as
+`CANARY_MYSECRET` is ideal — that is exactly the shape of
+[the corpus](../tests/corpus/canary-corpus.xml), and it can be added to it so
+the miss stays fixed.

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -1,5 +1,7 @@
 # Verifying redacted output
 
+[← Documentation index](../README.md#documentation)
+
 Redaction is not a thing to take on trust. This page covers the checks built
 into the tool, and how to get a second opinion from a scanner that fails
 differently.

--- a/tests/corpus/canary-corpus.xml
+++ b/tests/corpus/canary-corpus.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<!--
+  Canary corpus: 46 planted secrets, each a unique CANARY_* marker.
+
+  Every value here is synthetic. Domains use the reserved .example TLD
+  (RFC 2606), addresses are RFC 1918 or RFC 5737 documentation ranges, and MAC
+  addresses come from the IANA documentation block. Nothing in this file is or
+  ever was real.
+
+  A marker surviving redaction is a leak, so the count of survivors is the
+  score. tests/integration/test_canary_corpus.py pins which four survive and
+  why; docs/benchmark.md explains each, and records the results for other tools
+  measured against this same file.
+
+  docs/benchmark.md carries the exact command to score it yourself. It cannot
+  be repeated here: an XML comment may not contain a double hyphen, which every
+  flag in it starts with.
+-->
+<pfsense>
+  <version>23.09.1</version>
+  <system>
+    <hostname>fw-hq-01</hostname>
+    <domain>internal.acme-corp.example</domain>
+    <user>
+      <name>jsmith</name>
+      <bcrypt-hash>CANARY_BCRYPT</bcrypt-hash>
+      <md5-hash>CANARY_MD5</md5-hash>
+      <nt-hash>CANARY_NTHASH</nt-hash>
+      <authorizedkeys>CANARY_AUTHORIZEDKEYS</authorizedkeys>
+      <ipsecpsk>CANARY_USERIPSECPSK</ipsecpsk>
+    </user>
+    <authserver>
+      <type>ldap</type>
+      <ldap_binddn>cn=svc,dc=acme</ldap_binddn>
+      <ldap_bindpw>CANARY_LDAPBINDPW</ldap_bindpw>
+      <radius_secret>CANARY_RADIUSSECRET</radius_secret>
+    </authserver>
+    <ssh><sshdkeyonly>enabled</sshdkeyonly></ssh>
+  </system>
+  <snmpd>
+    <rocommunity>CANARY_ROCOMMUNITY</rocommunity>
+    <rwcommunity>CANARY_RWCOMMUNITY</rwcommunity>
+  </snmpd>
+  <interfaces>
+    <wan><if>igb0</if><ipaddr>203.0.113.142</ipaddr><subnet>29</subnet><gateway>203.0.113.129</gateway><mac>00:1b:44:11:3a:b7</mac></wan>
+    <opt1><if>ath0</if><wireless>
+      <ssid>ACME-Corp-WiFi</ssid>
+      <wpa><passphrase>CANARY_WPAPASSPHRASE</passphrase><wpa_mode>2</wpa_mode></wpa>
+    </wireless></opt1>
+  </interfaces>
+  <openvpn>
+    <openvpn-client>
+      <auth_user>vpnsvc</auth_user>
+      <auth_pass>CANARY_OVPNAUTHPASS</auth_pass>
+      <tls>CANARY_OVPNTLS</tls>
+      <custom_options>askpass CANARY_INLINE_CUSTOMOPT</custom_options>
+    </openvpn-client>
+  </openvpn>
+  <wireguard>
+    <tunnels><item>
+      <privatekey>CANARY_WGPRIV</privatekey>
+      <peers><item><presharedkey>CANARY_WGPRESHARED</presharedkey><publickey>CANARY_WGPUB</publickey></item></peers>
+    </item></tunnels>
+  </wireguard>
+  <ipsec>
+    <phase1><pre-shared-key>CANARY_IPSECPSK</pre-shared-key><eap_password>CANARY_EAPPASS</eap_password></phase1>
+    <mobilekey><ident>road</ident><pre-shared-key>CANARY_MOBILEPSK</pre-shared-key></mobilekey>
+  </ipsec>
+  <captiveportal><zone><radiussecret>CANARY_CPRADIUSSECRET</radiussecret></zone></captiveportal>
+  <dyndnses><dyndns>
+    <username>acct12345</username>
+    <password>CANARY_DYNDNSPASS</password>
+    <updateurl>https://api.dnsprov.example/update?token=CANARY_URLTOKEN&amp;host=fw</updateurl>
+  </dyndns></dyndnses>
+  <notifications>
+    <smtp><password>CANARY_SMTPPASS</password><passwordagain>CANARY_SMTPPASS2</passwordagain></smtp>
+    <telegram><api_key>CANARY_TELEGRAMKEY</api_key><chatid>-100123456</chatid></telegram>
+    <pushover><apikey>CANARY_PUSHOVERKEY</apikey><userkey>CANARY_PUSHOVERUSER</userkey></pushover>
+  </notifications>
+  <aliases>
+    <alias><name>badips</name><url>https://feeds.example.net/list.txt?license=CANARY_FEEDLICENSE</url>
+    <detail>ISP account 998877, portal login admin/CANARY_INDESCR</detail></alias>
+  </aliases>
+  <installedpackages>
+    <pfblockerng><config>
+      <maxmind_key>CANARY_MAXMINDKEY</maxmind_key>
+      <dnsbl_webpage>x</dnsbl_webpage>
+    </config></pfblockerng>
+    <acme>
+      <accountkeys><item><name>le-prod</name><accountkey>CANARY_ACMEACCOUNTKEY</accountkey></item></accountkeys>
+      <certificates><item><a_dnsprovider><dns_cf_token>CANARY_CFTOKEN</dns_cf_token><dns_cf_email>dns@acme-corp.example</dns_cf_email></a_dnsprovider></item></certificates>
+    </acme>
+    <haproxy><config>
+      <ha_certificates>CANARY_HAPROXYCERTS</ha_certificates>
+      <ssloffloadcert>CANARY_SSLOFFLOAD</ssloffloadcert>
+      <advanced>Zm9vYmFy</advanced>
+    </config></haproxy>
+    <telegraf><config><influx_token>CANARY_INFLUXTOKEN</influx_token><token>CANARY_BARETOKEN</token></config></telegraf>
+    <zabbixagentlts><config><tlspskvalue>CANARY_ZABBIXPSK</tlspskvalue><userparams>UserParameter=x,cat /root/CANARY_PATH</userparams></config></zabbixagentlts>
+    <nut><config><upsd_users>[admin] password=CANARY_NUTPASS</upsd_users></config></nut>
+    <backup><config><secret_access_key>CANARY_S3SECRET</secret_access_key><access_key>CANARY_S3ACCESS</access_key></config></backup>
+    <mycustompkg><config>
+      <webhook_url>https://hooks.slack.example/services/T00/B00/CANARY_SLACKPATHTOKEN</webhook_url>
+      <bearer_token>CANARY_BEARER</bearer_token>
+      <blob>Q0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZ</blob>
+      <config_note secret="CANARY_ATTR_SECRET" note="ISP pin CANARY_ATTR_PLAIN">x</config_note>
+    </config></mycustompkg>
+  </installedpackages>
+  <dhcpd><lan><staticmap><mac>ac:de:48:00:11:22</mac><hostname>ceo-laptop</hostname><ipaddr>192.168.10.55</ipaddr><descr>CEO Jane Doe personal MBP</descr></staticmap></lan></dhcpd>
+  <ppps><ppp><username>isp-acct-99887@isp.example</username><password>CANARY_PPPOEPASS</password></ppp></ppps>
+  <syslog><remoteserver>logs.acme-corp.example</remoteserver></syslog>
+  <revision><description>admin@203.0.113.142 (Local Database)</description></revision>
+</pfsense>

--- a/tests/integration/test_canary_corpus.py
+++ b/tests/integration/test_canary_corpus.py
@@ -48,18 +48,36 @@ EXPECTED_SURVIVORS = {
 
 
 def redact_corpus(*flags):
-    """Redact the corpus to stdout and return the output"""
+    """Redact the corpus to stdout, returning the whole CompletedProcess
+
+    The full result rather than just stdout, because the retained-value warning
+    these tests also check is written to stderr.
+    """
     result = subprocess.run(
         [sys.executable, '-m', 'pfsense_redactor', str(CORPUS), '--stdout', *flags],
         capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
     )
     assert result.returncode == 0, f'redaction failed: {result.stderr}'
-    return result.stdout
+    return result
 
 
-def survivors(output):
+def survivors(result):
     """Markers still present in redacted output"""
-    return set(CANARY_RE.findall(output))
+    return set(CANARY_RE.findall(result.stdout))
+
+
+# Module-scoped: redacting the corpus is a subprocess spawn, and every test
+# below wants one of these same two runs.
+@pytest.fixture(scope='module', name='default_run')
+def default_run_fixture():
+    """The corpus redacted in default mode"""
+    return redact_corpus()
+
+
+@pytest.fixture(scope='module', name='aggressive_run')
+def aggressive_run_fixture():
+    """The corpus redacted under --aggressive, which the benchmark publishes"""
+    return redact_corpus('--aggressive')
 
 
 class TestCorpusIntegrity:
@@ -89,9 +107,9 @@ class TestCorpusIntegrity:
 class TestAggressiveScore:
     """The published headline: 42 of 46 under --aggressive"""
 
-    def test_exactly_the_known_survivors(self):
+    def test_exactly_the_known_survivors(self, aggressive_run):
         """Fails in both directions - regression, or a stale benchmark doc"""
-        found = survivors(redact_corpus('--aggressive'))
+        found = survivors(aggressive_run)
 
         unexpected = found - set(EXPECTED_SURVIVORS)
         assert not unexpected, (
@@ -105,9 +123,9 @@ class TestAggressiveScore:
             'docs/benchmark.md and EXPECTED_SURVIVORS: ' + ', '.join(sorted(fixed))
         )
 
-    def test_published_score_is_42_of_46(self):
-        """The exact number docs/benchmark.md states"""
-        caught = TOTAL_CANARIES - len(survivors(redact_corpus('--aggressive')))
+    def test_published_score_is_42_of_46(self, aggressive_run):
+        """The count of secrets caught, which docs/benchmark.md publishes"""
+        caught = TOTAL_CANARIES - len(survivors(aggressive_run))
 
         assert caught == 42
 
@@ -124,19 +142,19 @@ class TestDefaultModeIsNotWorse:
     actually use from drifting apart from it unnoticed.
     """
 
-    def test_default_mode_survivors_are_a_superset(self):
+    def test_default_mode_survivors_are_a_superset(self, default_run, aggressive_run):
         """Anything --aggressive leaves, default mode may also leave - not less"""
-        default_survivors = survivors(redact_corpus())
-        aggressive_survivors = survivors(redact_corpus('--aggressive'))
+        default_survivors = survivors(default_run)
+        aggressive_survivors = survivors(aggressive_run)
 
         assert aggressive_survivors <= default_survivors, (
             'aggressive mode leaked something default mode caught, which '
             'inverts the intended relationship between the two'
         )
 
-    def test_default_mode_still_catches_the_core_secrets(self):
+    def test_default_mode_still_catches_the_core_secrets(self, default_run):
         """A floor, so default mode cannot quietly regress toward doing nothing"""
-        caught = TOTAL_CANARIES - len(survivors(redact_corpus()))
+        caught = TOTAL_CANARIES - len(survivors(default_run))
 
         assert caught >= 35, f'default mode caught only {caught}/{TOTAL_CANARIES}'
 
@@ -148,12 +166,8 @@ class TestRetainedValuesAreReported:
     behind", and docs/verifying-output.md tells people to read it.
     """
 
-    def test_high_entropy_retained_is_reported(self):
+    def test_high_entropy_retained_is_reported(self, default_run):
         """The warning names the element path, not just a count"""
-        result = subprocess.run(
-            [sys.executable, '-m', 'pfsense_redactor', str(CORPUS), '--stdout'],
-            capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
-        )
-
-        assert 'high-entropy' in result.stderr
-        assert '--aggressive' in result.stderr, 'the warning should say how to fix it'
+        assert 'high-entropy' in default_run.stderr
+        assert '--aggressive' in default_run.stderr, \
+            'the warning should say how to fix it'

--- a/tests/integration/test_canary_corpus.py
+++ b/tests/integration/test_canary_corpus.py
@@ -1,0 +1,159 @@
+"""
+Scores the published canary corpus and pins the result.
+
+tests/corpus/canary-corpus.xml carries 46 planted secrets, each a unique
+CANARY_* marker. A marker surviving redaction is a leak, so the survivors are
+the score, and docs/benchmark.md publishes it.
+
+A published number that nothing enforces drifts. These tests fail in both
+directions on purpose:
+
+- a fifth marker surviving is a redaction regression
+- one of the four disappearing means the benchmark doc is now stale
+
+Either way the failure names which marker moved, so the fix is obvious.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+CORPUS = PROJECT_ROOT / 'tests' / 'corpus' / 'canary-corpus.xml'
+CANARY_RE = re.compile(r'CANARY_[A-Z0-9_]+')
+
+TOTAL_CANARIES = 46
+
+# The four survivors, and why each is not simply a bug. Kept here rather than
+# as a bare set so a failure explains itself without opening the benchmark doc.
+EXPECTED_SURVIVORS = {
+    'CANARY_HAPROXYCERTS': (
+        'corpus artefact - the marker is a short literal, and short values in '
+        'cert-named elements are preserved as references. Real PEM redacts.'
+    ),
+    'CANARY_SSLOFFLOAD': (
+        'corpus artefact - same as CANARY_HAPROXYCERTS.'
+    ),
+    'CANARY_WGPUB': (
+        'deliberate - a WireGuard *public* key is not a secret, and is in '
+        'SECRET_TAG_DENYLIST.'
+    ),
+    'CANARY_ATTR_PLAIN': (
+        'known limitation - free text in an attribute whose name is not '
+        'sensitive, so SENSITIVE_ATTR_PATTERN does not match it.'
+    ),
+}
+
+
+def redact_corpus(*flags):
+    """Redact the corpus to stdout and return the output"""
+    result = subprocess.run(
+        [sys.executable, '-m', 'pfsense_redactor', str(CORPUS), '--stdout', *flags],
+        capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
+    )
+    assert result.returncode == 0, f'redaction failed: {result.stderr}'
+    return result.stdout
+
+
+def survivors(output):
+    """Markers still present in redacted output"""
+    return set(CANARY_RE.findall(output))
+
+
+class TestCorpusIntegrity:
+    """The corpus itself, before any redaction"""
+
+    def test_corpus_exists_and_is_shipped(self):
+        """docs/benchmark.md points here, and MANIFEST.in ships tests/**.xml"""
+        assert CORPUS.exists(), f'{CORPUS} is missing'
+
+    def test_planted_secret_count(self):
+        """The denominator in the published score"""
+        planted = set(CANARY_RE.findall(CORPUS.read_text(encoding='utf-8')))
+
+        assert len(planted) == TOTAL_CANARIES
+
+    def test_no_real_addresses(self):
+        """Only documentation and private ranges belong in a published fixture
+
+        81.2.69.x was swapped out: it is MaxMind demo data but a genuinely
+        assigned range, which has no place in a file this project publishes.
+        """
+        text = CORPUS.read_text(encoding='utf-8')
+
+        assert '81.2.69.' not in text
+
+
+class TestAggressiveScore:
+    """The published headline: 42 of 46 under --aggressive"""
+
+    def test_exactly_the_known_survivors(self):
+        """Fails in both directions - regression, or a stale benchmark doc"""
+        found = survivors(redact_corpus('--aggressive'))
+
+        unexpected = found - set(EXPECTED_SURVIVORS)
+        assert not unexpected, (
+            'redaction regression - these leaked and should not have: '
+            + ', '.join(sorted(unexpected))
+        )
+
+        fixed = set(EXPECTED_SURVIVORS) - found
+        assert not fixed, (
+            'these are now redacted, so the score improved. Update '
+            'docs/benchmark.md and EXPECTED_SURVIVORS: ' + ', '.join(sorted(fixed))
+        )
+
+    def test_published_score_is_42_of_46(self):
+        """The exact number docs/benchmark.md states"""
+        caught = TOTAL_CANARIES - len(survivors(redact_corpus('--aggressive')))
+
+        assert caught == 42
+
+    @pytest.mark.parametrize('marker', sorted(EXPECTED_SURVIVORS))
+    def test_each_survivor_is_accounted_for(self, marker):
+        """Every survivor has a recorded reason, so none is an unexplained miss"""
+        assert EXPECTED_SURVIVORS[marker].strip()
+
+
+class TestDefaultModeIsNotWorse:
+    """Default mode catches less than --aggressive, but must not leak more
+
+    The benchmark is run with --aggressive; this guards the mode most people
+    actually use from drifting apart from it unnoticed.
+    """
+
+    def test_default_mode_survivors_are_a_superset(self):
+        """Anything --aggressive leaves, default mode may also leave - not less"""
+        default_survivors = survivors(redact_corpus())
+        aggressive_survivors = survivors(redact_corpus('--aggressive'))
+
+        assert aggressive_survivors <= default_survivors, (
+            'aggressive mode leaked something default mode caught, which '
+            'inverts the intended relationship between the two'
+        )
+
+    def test_default_mode_still_catches_the_core_secrets(self):
+        """A floor, so default mode cannot quietly regress toward doing nothing"""
+        caught = TOTAL_CANARIES - len(survivors(redact_corpus()))
+
+        assert caught >= 35, f'default mode caught only {caught}/{TOTAL_CANARIES}'
+
+
+class TestRetainedValuesAreReported:
+    """Whatever is not redacted must at least be surfaced for review
+
+    _print_retained_warning is the built-in answer to "what did you leave
+    behind", and docs/verifying-output.md tells people to read it.
+    """
+
+    def test_high_entropy_retained_is_reported(self):
+        """The warning names the element path, not just a count"""
+        result = subprocess.run(
+            [sys.executable, '-m', 'pfsense_redactor', str(CORPUS), '--stdout'],
+            capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
+        )
+
+        assert 'high-entropy' in result.stderr
+        assert '--aggressive' in result.stderr, 'the warning should say how to fix it'

--- a/tests/unit/test_docs_links.py
+++ b/tests/unit/test_docs_links.py
@@ -1,0 +1,120 @@
+"""
+Tests for documentation links.
+
+Splitting the README into docs/ broke a relative link on the first attempt:
+`allowlist.example` resolved from the repository root, but not from inside
+docs/. Nothing caught it but a manual check, so these tests exist.
+
+They also pin the two rules that are easy to violate without noticing:
+
+- the README is the PyPI long_description, and PyPI does not resolve relative
+  Markdown links, so links out of the README must be absolute
+- every docs page needs a way back to the index, or arriving from a search
+  result is a dead end
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+DOCS_DIR = PROJECT_ROOT / 'docs'
+README = PROJECT_ROOT / 'README.md'
+
+# [text](target) where target is not a URL and not a bare #anchor
+RELATIVE_LINK_RE = re.compile(r'\]\((?!https?://|mailto:|#)([^)#]+)(?:#[^)]*)?\)')
+BREADCRUMB = '[← Documentation index](../README.md#documentation)'
+
+DOC_PAGES = sorted(DOCS_DIR.glob('*.md'))
+
+
+def relative_links(path):
+    """Every relative link target in a Markdown file"""
+    return RELATIVE_LINK_RE.findall(path.read_text(encoding='utf-8'))
+
+
+def headings(path):
+    """Heading lines, ignoring fenced code blocks
+
+    Shell examples are full of '# comment' lines. Counting those as headings
+    reports five H1s in a file that has one.
+    """
+    found, in_fence = [], False
+    for line in path.read_text(encoding='utf-8').splitlines():
+        if line.startswith('```'):
+            in_fence = not in_fence
+            continue
+        if not in_fence and re.match(r'^#{1,6} ', line):
+            found.append(line)
+    return found
+
+
+@pytest.mark.parametrize('page', DOC_PAGES, ids=lambda p: p.name)
+class TestDocPages:
+    """Rules every page under docs/ must satisfy"""
+
+    def test_relative_links_resolve(self, page):
+        """A link to a file that is not there is worse than no link"""
+        broken = [
+            target for target in relative_links(page)
+            if not (page.parent / target).resolve().exists()
+        ]
+
+        assert not broken, f'{page.name} links to missing: {", ".join(broken)}'
+
+    def test_has_breadcrumb_back_to_index(self, page):
+        """Arriving from a search result should not be a dead end"""
+        head = page.read_text(encoding='utf-8').split('\n\n')[:3]
+
+        assert any(BREADCRUMB in part for part in head), (
+            f'{page.name} has no link back to the documentation index'
+        )
+
+    def test_starts_with_a_single_h1(self, page):
+        """One title per page, and it comes first"""
+        found = headings(page)
+        h1s = [line for line in found if line.startswith('# ')]
+
+        assert found[0].startswith('# '), f'{page.name} does not open with an H1'
+        assert len(h1s) == 1, f'{page.name} has {len(h1s)} H1 headings'
+
+    def test_heading_levels_do_not_skip(self, page):
+        """H1 straight to H3 reads as a missing section
+
+        Removing the duplicate H2s during review left orphaned H3s behind, so
+        this is a mistake already made once.
+        """
+        levels = [len(line.split(' ', 1)[0]) for line in headings(page)]
+        skips = [(a, b) for a, b in zip(levels, levels[1:]) if b > a + 1]
+
+        assert not skips, f'{page.name} skips heading levels: {skips}'
+
+
+class TestReadme:
+    """The README is also the PyPI package page, which constrains its links"""
+
+    def test_no_relative_links_to_docs(self):
+        """PyPI does not resolve relative Markdown links
+
+        A relative docs/ link renders as a broken link on the package page,
+        which is the first thing many people see.
+        """
+        content = README.read_text(encoding='utf-8')
+
+        assert '](docs/' not in content, (
+            'README links to docs/ relatively; use the full GitHub URL so the '
+            'link works on PyPI as well'
+        )
+
+    def test_every_doc_page_is_listed(self):
+        """A page nothing links to is a page nobody finds"""
+        content = README.read_text(encoding='utf-8')
+        unlisted = [p.name for p in DOC_PAGES if f'docs/{p.name}' not in content]
+
+        assert not unlisted, f'not linked from README: {", ".join(unlisted)}'
+
+    def test_documentation_anchor_exists(self):
+        """Every breadcrumb points at this heading, so it must be there"""
+        content = README.read_text(encoding='utf-8')
+
+        assert re.search(r'^## Documentation$', content, re.MULTILINE)


### PR DESCRIPTION
Documentation only — no version bump, no behaviour change.

## README: 716 → 150 lines

It doubles as the PyPI `long_description`, so every flag, the allow-list syntax,
the security model and the FAQ sat between a new reader and getting started.
Now: what it is, install, four recipes, and an index into `docs/`.

Links to `docs/` are **absolute GitHub URLs on purpose** — PyPI does not resolve
relative Markdown links, so the package page would render them broken. Links
*between* docs are relative, which is correct on GitHub. `twine check` passes on
both artifacts, so the new page renders.

## The corpus now ships

The 46-secret comparison had been run against three tools, but the corpus lived
outside the repo, so nobody could check the numbers. `tests/corpus/canary-corpus.xml`
fixes that — and `MANIFEST.in` already covered `tests/**.xml`, so it lands in
the sdist with no packaging change (verified).

Its `81.2.69.x` addresses are swapped for RFC 5737 ranges. MaxMind demo data,
but a genuinely assigned range, which has no place in a published fixture.
Scoring is unaffected — those are not canaries.

`docs/benchmark.md` publishes the result **with the caveats that make it
meaningful**: the corpus grew out of bug reports against this tool, so it covers
what this tool has been taught to find; and netgate-xlsx is aimed at spreadsheet
export rather than sanitisation, so its number is context, not a verdict.

**The four misses stay in the table.** Removing them was considered and
rejected. Two are corpus artefacts — short literals in cert-named elements,
preserved as *references*, which redact correctly with real PEM (command in the
doc to prove it). One is deliberate: a WireGuard *public* key is not a secret.
The fourth is a genuine limitation no tool caught. The corpus ships, so any
reader reproduces all four in a minute; hiding them would cost more credibility
than the misses do.

`tests/integration/test_canary_corpus.py` pins the score in CI and fails **in
both directions** — a fifth marker surviving is a regression, one of the four
disappearing means the doc is stale. I verified it actually fails both ways
rather than assuming:

```
AssertionError: redaction regression - these leaked and should not have: CANARY_REGRESSION_PROBE
AssertionError: these are now redacted, so the score improved. Update docs/benchmark.md ...: CANARY_WGPUB
```

## gitleaks — measured, and it changed the conclusion

`docs/verifying-output.md` was written against real gitleaks 8.30.1 output, not
from memory. Against a config with six realistic secrets it found **exactly
one** — the Slack webhook token, which is the one this tool misses by default:

| Secret | gitleaks | redactor (default) | redactor (`--aggressive`) |
|---|:--:|:--:|:--:|
| `<rocommunity>public` | ❌ | ✅ | ✅ |
| `<passphrase>` | ❌ | ✅ | ✅ |
| `<ldap_bindpw>` | ❌ | ✅ | ✅ |
| `<access_key>` AWS id | ❌ | ✅ | ✅ |
| `<secret_access_key>` | ❌ | ✅ | ✅ |
| `<slack_url>` webhook | **✅** | **❌** | ✅ |

That row is the honest argument for running both — and it surfaced a **real
default-mode gap** worth a follow-up: only `<webhook_url>` matches the
secret-name pattern, so `<slack_url>`, `<notifyurl>` and a bare `<url>` keep
their token unless `--aggressive` is used. Path-segment redaction is gated
behind aggressive so pfBlockerNG feed URLs are not destroyed, which is
defensible, but a known webhook host is unambiguous. **Not fixed here** — that
is behaviour, and belongs in its own PR with snapshot and canary verification.

The page also warns against the obvious misreading: on the canary corpus
gitleaks reports nothing at all *before* any redaction, because the markers are
low-entropy placeholders. A clean scan is not a clean file.

No `--verify` flag. Documented as a recipe first; it would need PATH detection,
subprocess handling, a graceful "not installed" path and exit-code semantics.
Worth building only if the recipe proves useful.

## Verification

- 592 passed / 593 collected (12 new), reference snapshots unmoved
- `pylint` exits 0 both configs; flake8 C901 and `check_structure.py` clean
- `python -m build` + `twine check` → PASSED on wheel and sdist
- Corpus and its test confirmed present in the sdist
- Every command in the new docs run verbatim and produce the documented output
- `grep '](docs/' README.md` returns nothing — no relative links to break on PyPI
