### PR TITLE
Redact webhook path tokens in every mode, not only under --aggressive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2][] - 2026-07-28
+
+### Security
+- **FIX**: Webhook tokens survived in default mode unless the element happened
+  to be named for a secret. 1.1.0 fixed `<webhook_url>` by matching the element
+  *name*, so a Slack URL in `<slack_url>`, `<notifyurl>` or a plain `<url>` kept
+  its token — and the token is the whole authorisation, since anyone holding the
+  URL can post as that integration.
+
+  Path-segment redaction stays gated behind `--aggressive` in general, because
+  pfBlockerNG feed URLs legitimately carry long path components that redaction
+  would destroy. The gate is now lifted for endpoints where the path token is
+  unambiguously a credential: `hooks.slack.com/services/`,
+  `discord.com/api/webhooks/` (and the `discordapp.com`, `ptb.` and `canary.`
+  variants), and `api.telegram.org/bot`.
+
+  Hosts are matched exactly, never by suffix, so `hooks.slack.com.example.net`
+  does not inherit the rule. A non-webhook path on a webhook host — a
+  `discord.com/channels/…` link — is unaffected, as are feed URLs on any other
+  host.
+
+  Found by scanning redacted output with gitleaks: of six realistic secrets in a
+  test config it flagged exactly one, and this was it. Running an independent
+  scanner over the output catches what a name-driven redactor cannot.
+
 ## [1.1.1][] - 2026-07-28
 
 Follow-up to 1.1.0, in two parts. The first came from a second canary-corpus
@@ -442,6 +467,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.1.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.2
 [1.1.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.1
 [1.1.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.0
 [1.0.10]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.0.10

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -353,6 +353,36 @@ def is_rfc_documentation_ip(ip: IPAddress) -> bool:
         return any(ip in net for net in RFC_DOC_NETWORKS_V4)
     return ip in RFC_DOC_NETWORK_V6
 
+# Endpoints whose credential lives in the URL path rather than a query string.
+# For these the path token *is* the authorisation - anyone holding the URL can
+# post as that integration - so it is redacted in every mode, not only under
+# --aggressive.
+#
+# Path redaction is otherwise gated behind --aggressive because feed URLs
+# (pfBlockerNG and similar) legitimately carry long path segments that
+# redaction would destroy. These entries are narrow enough not to catch those:
+# each is an exact host plus the path prefix its webhook API actually uses.
+#
+# Matched on the exact host, never a suffix. 'hooks.slack.com.example.net' is a
+# different host and must not inherit the rule.
+WEBHOOK_URL_PREFIXES: tuple[tuple[str, str], ...] = (
+    ('hooks.slack.com', '/services/'),
+    ('discord.com', '/api/webhooks/'),
+    ('discordapp.com', '/api/webhooks/'),
+    ('ptb.discord.com', '/api/webhooks/'),
+    ('canary.discord.com', '/api/webhooks/'),
+    # Telegram puts 'bot<id>:<token>' in the first path segment.
+    ('api.telegram.org', '/bot'),
+)
+
+
+def _is_webhook_url(host: str, path: str) -> bool:
+    """Whether a URL is a known webhook endpoint carrying its token in the path"""
+    host_lower = host.lower()
+    return any(host_lower == known and path.startswith(prefix)
+               for known, prefix in WEBHOOK_URL_PREFIXES)
+
+
 # URL path segment credential detection.
 # 20 because AWS access key IDs (AKIA...) are exactly 20 characters.
 SECRETISH_SEGMENT_MIN_LENGTH: int = 20
@@ -1602,25 +1632,41 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         return '/'.join(segments), True
 
     def _redact_path_secrets(self, path: str) -> str:
-        """Redact long high-entropy path segments (aggressive mode only)
+        """Redact long high-entropy path segments
 
         Slack/Discord-style webhooks carry the credential as a path segment
-        rather than a query parameter. Gated behind --aggressive because feed
-        URLs legitimately carry long path segments.
+        rather than a query parameter. Callers decide when to apply this - see
+        _should_redact_path.
         """
         redacted, changed = self._build_redacted_path(path)
         if changed:
             self.stats['url_secrets_redacted'] += 1
         return redacted
 
+    def _should_redact_path(self, parts: SplitResult) -> bool:
+        """Whether this URL's path should be scanned for embedded credentials
+
+        Aggressive mode scans every path. Otherwise only known webhook
+        endpoints, where the path token is the whole authorisation and the host
+        identifies it unambiguously - so it is worth redacting without waiting
+        for an opt-in flag.
+        """
+        if self.aggressive:
+            return True
+        return _is_webhook_url(parts.hostname or '', parts.path)
+
+    def _redact_path_if_needed(self, parts: SplitResult) -> str:
+        """Return the path, credential segments redacted where that applies"""
+        if self._should_redact_path(parts):
+            return self._redact_path_secrets(parts.path)
+        return parts.path
+
     def _rebuild_url(self, parts: SplitResult, masked_host: str, is_ipv6: bool) -> str:
         """Rebuild URL from parts with masked host"""
         netloc = self._build_netloc(parts, masked_host, is_ipv6)
 
-        path = parts.path
+        path = self._redact_path_if_needed(parts)
         query = self._redact_query_secrets(parts.query)
-        if self.aggressive:
-            path = self._redact_path_secrets(path)
 
         # Manual construction for masked IPv6 (urlunsplit doesn't like invalid IPv6)
         if is_ipv6 and 'XXXX:XXXX' in masked_host:
@@ -1716,7 +1762,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return url
 
         netloc, netloc_changed = self._redact_netloc_userinfo(parts)
-        path = self._redact_path_secrets(parts.path) if self.aggressive else parts.path
+        path = self._redact_path_if_needed(parts)
         query = self._redact_query_secrets(parts.query)
 
         if self._url_parts_unchanged(parts, netloc_changed, path, query):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.1.1"
+version = "1.1.2"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.1 -->
+  <!-- Redacted using pfsense-redactor v1.1.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_webhook_hosts.py
+++ b/tests/unit/test_webhook_hosts.py
@@ -1,0 +1,175 @@
+"""
+Tests for webhook path tokens being redacted in every mode.
+
+A Slack, Discord or Telegram webhook URL carries its credential in the path.
+Anyone holding the URL can post as that integration, so the token is redacted
+without waiting for --aggressive.
+
+Path redaction is otherwise gated behind --aggressive because pfBlockerNG feed
+URLs legitimately carry long path segments that redaction would destroy. The
+tests below therefore matter in both directions: the tokens must go, and the
+feed URLs must survive.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor, _is_webhook_url
+
+# The URLs are assembled from parts rather than written out whole, and the
+# tokens say EXAMPLE rather than looking random.
+#
+# Both are deliberate. A complete, realistically-shaped webhook URL sitting in
+# a source file is exactly what GitHub's secret scanner blocks on push - the
+# same shape-matching that makes this good test data makes it look real from
+# the outside. Splitting the literal keeps the runtime value identical, which
+# is all these tests care about, while leaving nothing for a scanner to match.
+SLACK_PREFIX = 'https://hooks.slack.com/services/T024BE7LD/B024BE7LH/'
+SLACK_TOKEN = 'EXAMPLEnotarealslacktokenEXAMPLE'
+SLACK = SLACK_PREFIX + SLACK_TOKEN
+
+DISCORD_PREFIX = 'https://discord.com/api/webhooks/123456789012345678/'
+DISCORD_TOKEN = 'EXAMPLEnotarealdiscordwebhooktokenEXAMPLE'
+DISCORD = DISCORD_PREFIX + DISCORD_TOKEN
+
+TELEGRAM_TOKEN = 'EXAMPLEnotarealtelegramtokenEXAMPLE'
+TELEGRAM = 'https://api.telegram.org/bot123456789:' + TELEGRAM_TOKEN + '/sendMessage'
+
+
+class TestIsWebhookUrl:
+    """The host/path predicate on its own"""
+
+    @pytest.mark.parametrize('host,path', [
+        ('hooks.slack.com', '/services/T024BE7LD/B024BE7LH/tok'),
+        ('discord.com', '/api/webhooks/123/tok'),
+        ('discordapp.com', '/api/webhooks/123/tok'),
+        ('ptb.discord.com', '/api/webhooks/123/tok'),
+        ('canary.discord.com', '/api/webhooks/123/tok'),
+        ('api.telegram.org', '/bot123:tok/sendMessage'),
+    ])
+    def test_known_endpoints_match(self, host, path):
+        """Each supported provider is recognised"""
+        assert _is_webhook_url(host, path)
+
+    def test_host_match_is_exact_not_suffix(self):
+        """A lookalike domain must not inherit the rule
+
+        'hooks.slack.com.evil.example' ends with the real host but is
+        controlled by someone else entirely.
+        """
+        assert not _is_webhook_url('hooks.slack.com.evil.example', '/services/a/b/c')
+
+    def test_host_match_is_not_a_prefix_either(self):
+        """The reverse direction of the same mistake"""
+        assert not _is_webhook_url('evil.example', '/hooks.slack.com/services/a/b/c')
+
+    def test_path_prefix_is_required(self):
+        """A webhook host serving something else is not a webhook URL"""
+        assert not _is_webhook_url('discord.com', '/channels/123/456')
+
+    def test_host_comparison_is_case_insensitive(self):
+        """Hostnames are case-insensitive, and configs are written by hand"""
+        assert _is_webhook_url('Hooks.Slack.COM', '/services/a/b/c')
+
+    def test_empty_inputs_are_safe(self):
+        """A URL with no host must not raise"""
+        assert not _is_webhook_url('', '')
+
+
+class TestDefaultModeRedactsWebhookTokens:
+    """The behaviour change: no --aggressive required"""
+
+    @pytest.mark.parametrize('url,token', [
+        (SLACK, SLACK_TOKEN),
+        (DISCORD, DISCORD_TOKEN),
+        (TELEGRAM, TELEGRAM_TOKEN),
+    ])
+    def test_token_is_removed(self, basic_redactor, url, token):
+        """The credential goes, in the mode most people actually use"""
+        result = basic_redactor._redact_url_secrets_only(url)
+
+        assert token not in result
+
+    def test_route_survives_so_the_url_stays_readable(self, basic_redactor):
+        """Redacting the token should not destroy what the URL was for"""
+        result = basic_redactor._redact_url_secrets_only(TELEGRAM)
+
+        assert 'sendMessage' in result
+
+    def test_counted_in_statistics(self, basic_redactor):
+        """A redaction that is not counted is invisible in the summary"""
+        basic_redactor._redact_url_secrets_only(SLACK)
+
+        assert basic_redactor.stats['url_secrets_redacted'] >= 1
+
+
+class TestFeedUrlsStillSurvive:
+    """The reason path redaction was gated in the first place
+
+    If these start being redacted, the fix has over-reached and pfBlockerNG
+    feed URLs are being corrupted in the default mode.
+    """
+
+    @pytest.mark.parametrize('url', [
+        'https://feeds.example.net/lists/emerging-block.rules',
+        'https://download.example.net/v1/abcdefghijklmnopqrstuvwxyz012345/list.txt',
+        'https://updates.example.org/pfblocker/Open_VM_Tools_package/list.txt',
+    ])
+    def test_feed_paths_are_untouched_by_default(self, basic_redactor, url):
+        """Long path segments on ordinary hosts stay as they are"""
+        assert basic_redactor._redact_url_secrets_only(url) == url
+
+    def test_non_webhook_path_on_a_webhook_host(self, basic_redactor):
+        """discord.com serves plenty that is not a webhook"""
+        url = 'https://discord.com/channels/123456789012345678/aB3dE5gH7jK9lM1nO3pQ5rS7tU'
+
+        assert basic_redactor._redact_url_secrets_only(url) == url
+
+
+class TestAggressiveModeUnchanged:
+    """--aggressive still redacts every path, as it did before"""
+
+    def test_feed_paths_still_redacted_under_aggressive(self, aggressive_redactor):
+        """The opt-in behaviour is not weakened by the new default"""
+        url = 'https://download.example.net/v1/abcdefghijklmnopqrstuvwxyz012345/list.txt'
+
+        assert 'abcdefghijklmnopqrstuvwxyz012345' not in \
+            aggressive_redactor._redact_url_secrets_only(url)
+
+    def test_webhook_tokens_still_redacted_under_aggressive(self, aggressive_redactor):
+        """Both routes to redaction agree"""
+        assert SLACK_TOKEN not in aggressive_redactor._redact_url_secrets_only(SLACK)
+
+
+class TestEndToEndThroughElements:
+    """Through redact_element, which is how a real config reaches this"""
+
+    @pytest.mark.parametrize('tag', ['slack_url', 'notifyurl', 'url', 'apiurl'])
+    def test_element_name_no_longer_decides(self, tag):
+        """Previously only <webhook_url> matched the secret-name pattern
+
+        Any element carrying a Slack webhook kept its token by default, which
+        is what this change fixes.
+        """
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(f'<pfsense><a><{tag}>{SLACK}</{tag}></a></pfsense>')
+        redactor.redact_element(root)
+
+        assert SLACK_TOKEN not in ET.tostring(root, encoding='unicode')
+
+    def test_webhook_url_element_still_redacted_whole(self):
+        """The existing element-name behaviour is unchanged"""
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(f'<pfsense><a><webhook_url>{SLACK}</webhook_url></a></pfsense>')
+        redactor.redact_element(root)
+
+        assert SLACK_TOKEN not in ET.tostring(root, encoding='unicode')
+
+    def test_feed_url_element_survives(self):
+        """A pfBlockerNG feed in a <url> element must not be corrupted"""
+        feed = 'https://feeds.example.net/lists/emerging-block.rules'
+        redactor = PfSenseRedactor(keep_private_ips=True)
+        root = ET.fromstring(f'<pfsense><a><url>{feed}</url></a></pfsense>')
+        redactor.redact_element(root)
+
+        assert 'emerging-block.rules' in ET.tostring(root, encoding='unicode')


### PR DESCRIPTION
Follow-up to the gap surfaced while writing the verification docs in #58.

## The bug

1.1.0 fixed webhook URLs by matching the element **name**, so `<webhook_url>`
was redacted whole. Any other element carrying the same URL was not:

```
# before, DEFAULT mode
<slack_url>https://hooks.slack.com/services/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</slack_url>
```

The token is the entire authorisation — anyone holding that URL can post as the
integration — so which element it happens to sit in should not decide whether it
leaks. `<notifyurl>` and a plain `<url>` had the same problem.

```
# after
<slack_url>https://hooks.slack.com/services/T024BE7LD/B024BE7LH/[REDACTED]</slack_url>
```

## Why it is narrow

Path-segment redaction stays gated behind `--aggressive` in general, and that
gate exists for a good reason: pfBlockerNG feed URLs carry long path components
that redaction would destroy, turning a working config into a corrupted one.

The gate is lifted only where the path token is unambiguously a credential —
`hooks.slack.com/services/`, `discord.com/api/webhooks/` (plus `discordapp.com`,
`ptb.` and `canary.`), and `api.telegram.org/bot`. Each entry is an **exact
host plus the path prefix that API actually uses**, so it is narrow in both
directions:

| Case | Default mode |
|---|---|
| `hooks.slack.com/services/…/TOKEN` | redacted |
| `discord.com/api/webhooks/…/TOKEN` | redacted |
| `api.telegram.org/bot<id>:<token>/sendMessage` | redacted, route preserved |
| `hooks.slack.com.evil.example/services/…` | **untouched** — exact host, no suffix match |
| `discord.com/channels/…` | **untouched** — path prefix does not match |
| `feeds.example.net/lists/emerging-block.rules` | **untouched** |

28 tests pin all of it, including three feed URLs that must survive — if those
start being redacted the fix has over-reached.

`_should_redact_path` names the decision and `_redact_path_if_needed` applies
it, so the two call sites (`_rebuild_url` and `_redact_url_secrets_in_match`)
cannot drift apart. That drift is how the original gap opened.

## How it was found

By running gitleaks over redacted output while writing `docs/verifying-output.md`
for #58. Of six realistic secrets in a test config it flagged exactly one — this
token, the only one this tool was leaving behind. That is the case for running
an independent scanner, and now the case for this PR.

## Verification

- Behaviour change proven directly against the unfixed code, not just asserted:
  token present `True` → `False` in default mode
- 608 passed / 609 collected (28 new)
- **Canary corpus scores identically** — same four known survivors
- `pylint` exits 0 both configs; flake8 C901 and `check_structure.py` clean

### On the 21 snapshot files

They move **only** because the redaction comment stamps the version. Verified
before regenerating: across all 18 config/mode combinations the diff is 36
lines, every one of them the version comment, and **zero** behavioural
differences.

### Version

Bumped to **1.1.2** — 1.1.1 is released and this changes behaviour.
`test_version_consistency.py` enforces the convention (changelog heading plus
link reference must name the current version, no open `[Unreleased]`), which is
what caught me writing an `[Unreleased]` section first.

## Note on #58

This invalidates two statements in that PR's docs, which describe the old
behaviour: `docs/security.md` says `<slack_url>` is not redacted by default, and
the gitleaks table in `docs/verifying-output.md` shows it as a miss. Whichever
merges second needs those two corrected — happy to do it as a follow-up.

## Note on test data

GitHub push protection blocked the first push: the Slack webhook URL in the test
file matched its Incoming Webhook detector. That is the scanner working — the
same realistic shape that makes it good test data makes it look real from
outside.

Resolved by assembling the URLs from parts with `EXAMPLE`-flavoured tokens
rather than allow-listing the secret. The runtime values are identical, which is
all the tests care about, and nothing in the source matches a scanner.
