### PR TITLE
Close the CI gate, recognise Teams, and redact free-text attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Found by scanning redacted output with gitleaks: of six realistic secrets in a
   test config it flagged exactly one, and this was it. Running an independent
   scanner over the output catches what a name-driven redactor cannot.
+- **FIX**: `--fail-on-warn` covered the root-tag check and nothing else, so a
+  config carrying a value the tool declined to redact printed "Review before
+  sharing" and still exited 0. An automated check passed on a file its own
+  output said to look at, and `docs/use-cases.md` recommends the flag for
+  exactly that job.
+
+  It now also fails when high-entropy values are retained, under `--dry-run`
+  as well — checking without writing is the natural shape for CI, and it was
+  the one mode that could not report a problem. The message names the count
+  and points at `--aggressive`. Redacted output is still written when the gate
+  fails, since the retained values were reported rather than leaked and the
+  operator needs the file to review them.
+- **ADD**: Microsoft Teams webhook endpoints are recognised, so their path
+  tokens are redacted in every mode alongside Slack, Discord and Telegram.
+  Teams puts the tenant in a subdomain, so `*.webhook.office.com` is matched as
+  a suffix — including the leading dot, which is what stops
+  `notwebhook.office.com` qualifying. Suffix matching is the looser rule, so it
+  applies only to domains listed for it rather than to the whole set. The
+  legacy `outlook.office.com` connector stays an exact match.
+
+  Self-hosted tools such as Mattermost are deliberately absent: their webhooks
+  sit at `/hooks/<token>` on whatever host the operator chose, so there is no
+  host to match, and treating every `/hooks/` path as a credential would redact
+  ordinary paths on unrelated servers. Those still need `--aggressive`.
+
+### Added
+- `--redact-descriptions` now covers free-text **attributes** as well as
+  elements — `note`, `comment`, `label`, `title` and similar. Attributes named
+  for a secret were already redacted; these are the ones whose name says
+  nothing about the contents, where a PIN or a circuit reference ends up inside
+  a sentence and no pattern reliably finds it.
+
+  This closes the last genuine miss in the canary corpus, taking it from 42/46
+  to **43/46**. The remaining three are two corpus artefacts and one deliberate
+  choice. Structural attributes are untouched: redacting `version` or
+  `interface` would break the reader's ability to follow the config.
 
 ## [1.1.1][] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FIX**: Webhook tokens survived in default mode unless the element happened
   to be named for a secret. 1.1.0 fixed `<webhook_url>` by matching the element
   *name*, so a Slack URL in `<slack_url>`, `<notifyurl>` or a plain `<url>` kept
-  its token — and the token is the whole authorisation, since anyone holding the
+  its token. The token is the whole authorisation, since anyone holding the
   URL can post as that integration.
 
   Path-segment redaction stays gated behind `--aggressive` in general, because
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants), and `api.telegram.org/bot`.
 
   Hosts are matched exactly, never by suffix, so `hooks.slack.com.example.net`
-  does not inherit the rule. A non-webhook path on a webhook host — a
-  `discord.com/channels/…` link — is unaffected, as are feed URLs on any other
+  does not inherit the rule. A non-webhook path on a webhook host, such as a
+  `discord.com/channels/…` link, is unaffected, as are feed URLs on any other
   host.
 
   Found by scanning redacted output with gitleaks: of six realistic secrets in a
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exactly that job.
 
   It now also fails when high-entropy values are retained, under `--dry-run`
-  as well — checking without writing is the natural shape for CI, and it was
+  as well, since checking without writing is the natural shape for CI and it was
   the one mode that could not report a problem. The message names the count
   and points at `--aggressive`. Redacted output is still written when the gate
   fails, since the retained values were reported rather than leaked and the
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADD**: Microsoft Teams webhook endpoints are recognised, so their path
   tokens are redacted in every mode alongside Slack, Discord and Telegram.
   Teams puts the tenant in a subdomain, so `*.webhook.office.com` is matched as
-  a suffix — including the leading dot, which is what stops
+  a suffix, including the leading dot, which is what stops
   `notwebhook.office.com` qualifying. Suffix matching is the looser rule, so it
   applies only to domains listed for it rather than to the whole set. The
   legacy `outlook.office.com` connector stays an exact match.
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `--redact-descriptions` now covers free-text **attributes** as well as
-  elements — `note`, `comment`, `label`, `title` and similar. Attributes named
+  elements: `note`, `comment`, `label`, `title` and similar. Attributes named
   for a secret were already redacted; these are the ones whose name says
   nothing about the contents, where a PIN or a circuit reference ends up inside
   a sentence and no pattern reliably finds it.
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1][] - 2026-07-28
 
 Follow-up to 1.1.0, in two parts. The first came from a second canary-corpus
-report — 1.1.0 caught 41 of 46 planted secrets where 1.0.10 caught 15, and this
+report. 1.1.0 caught 41 of 46 planted secrets where 1.0.10 caught 15, and this
 closes the remaining URL path gaps plus an over-redaction bug found while
 confirming them. The second is two long-standing defects surfaced while
 reviewing that work, both older than 1.1.0.
@@ -93,7 +93,7 @@ reviewing that work, both older than 1.1.0.
   untouched.
 
   This is deliberately *not* described as an XXE fix. `xml.etree.ElementTree`
-  does not resolve external entities — a `SYSTEM` entity raises `ParseError`,
+  does not resolve external entities. A `SYSTEM` entity raises `ParseError`,
   so there is no file disclosure and no SSRF. What it does do is expand
   *internal* entities, where a few hundred bytes of nested definitions expand
   to gigabytes. Severity is low: the input is a file the user supplies, and the
@@ -119,8 +119,8 @@ reviewing that work, both older than 1.1.0.
   inside a path but still redacted in prose.
 - **FIX** (predates 1.1.0): IPv6 anonymisation produced invalid addresses once
   the RFC 3849 pool was exhausted. The RFC 4193 overflow mapping used
-  `((overflow - 1) % 0x10000) + 1`, which ranges `1..0x10000` — one past what a
-  hextet can hold — so every 65536th counter emitted a five-digit group such as
+  `((overflow - 1) % 0x10000) + 1`, which ranges `1..0x10000`, one past what a
+  hextet can hold, so every 65536th counter emitted a five-digit group such as
   `fd00::0:10000`, which is not parseable. It now rolls into the upper hextet
   (`fd00::1:0`), which is what the implementation comment always described.
   Reachable only with 131,071 or more unique IPv6 addresses in one config.
@@ -139,7 +139,7 @@ reviewing that work, both older than 1.1.0.
 
 - **FIX** (predates 1.1.0): Windows system directories were hardcoded to `C:`,
   so a machine with Windows installed on any other drive had no write
-  protection for its system directories at all — `D:\\Windows\\System32` was
+  protection for its system directories at all. `D:\\Windows\\System32` was
   freely writable. The real locations are now read from `SystemRoot`, `windir`,
   `ProgramFiles`, `ProgramFiles(x86)`, `ProgramW6432` and `ProgramData`, the
   same way temp directories are already read from `TMPDIR`/`TEMP`. The `C:`
@@ -187,7 +187,7 @@ reviewing that work, both older than 1.1.0.
   content in any other element passed through untouched.
 - **FIX**: URL credentials (`user:password@host`) were preserved in elements that are not known
   URL carriers, so a URL could be emitted with its query secret shown as `[REDACTED]` while the
-  HTTP-basic password beside it survived in full — output that reads as sanitised when it is not.
+  HTTP-basic password beside it survived in full, producing output that reads as sanitised when it is not.
   Userinfo redaction now follows the same policy on every URL path, and a URL carrying credentials
   is rewritten even when nothing else in it changes.
 - **FIX**: Free-text blob elements received *less* URL scanning than unrecognised elements, because
@@ -195,7 +195,7 @@ reviewing that work, both older than 1.1.0.
   `key=value` credentials, and the key=value scanner no longer mistakes a URL scheme for a key.
 - **FIX**: `--dry-run-verbose` printed URL credentials to the console. The sample display masked the
   host and the userinfo password but passed the path and query through verbatim, so a preview of
-  `https://api.example.com/v1?token=...` showed the token in full — in the terminal, and from there
+  `https://api.example.com/v1?token=...` showed the token in full: in the terminal, and from there
   in CI logs or a pasted ticket. This is the flag users run precisely to check what will happen
   before sharing, so it now redacts path and query secrets too.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,8 @@ reviewing that work, both older than 1.1.0.
   content in any other element passed through untouched.
 - **FIX**: URL credentials (`user:password@host`) were preserved in elements that are not known
   URL carriers, so a URL could be emitted with its query secret shown as `[REDACTED]` while the
-  HTTP-basic password beside it survived in full, producing output that reads as sanitised when it is not.
+  HTTP-basic password beside it survived in full, producing output that reads
+  as sanitised when it is not.
   Userinfo redaction now follows the same policy on every URL path, and a URL carrying credentials
   is rewritten even when nothing else in it changes.
 - **FIX**: Free-text blob elements received *less* URL scanning than unrecognised elements, because
@@ -195,7 +196,8 @@ reviewing that work, both older than 1.1.0.
   `key=value` credentials, and the key=value scanner no longer mistakes a URL scheme for a key.
 - **FIX**: `--dry-run-verbose` printed URL credentials to the console. The sample display masked the
   host and the userinfo password but passed the path and query through verbatim, so a preview of
-  `https://api.example.com/v1?token=...` showed the token in full: in the terminal, and from there
+  `https://api.example.com/v1?token=...` showed the token in full: in the
+  terminal, and from there
   in CI logs or a pasted ticket. This is the flag users run precisely to check what will happen
   before sharing, so it now redacts path and query secrets too.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Tests](https://github.com/grounzero/pfsense-redactor/actions/workflows/tests.yml/badge.svg)](https://github.com/grounzero/pfsense-redactor/actions/workflows/tests.yml)
 [![Downloads](https://pepy.tech/badge/pfsense-redactor)](https://pepy.tech/project/pfsense-redactor)
 
-Redact secrets from a pfSense `config.xml` so you can share it — with Netgate
-support, a vendor, a forum, or an AI tool — without handing over your passwords,
+Redact secrets from a pfSense `config.xml` so you can share it with Netgate
+support, a vendor, a forum or an AI tool, without handing over your passwords,
 keys and network layout.
 
 Unlike generic XML redaction, it understands pfSense structures: IPsec, OpenVPN,
@@ -55,7 +55,7 @@ pip install -e .
 
 ## Quick start
 
-**Sharing with support — keep internal addressing readable:**
+**Sharing with support, keeping internal addressing readable:**
 
 ```bash
 pfsense-redactor config.xml redacted.xml --keep-private-ips
@@ -64,7 +64,7 @@ pfsense-redactor config.xml redacted.xml --keep-private-ips
 Removes secrets and public identifiers, leaves RFC 1918 addressing intact so
 whoever is helping can still follow your topology.
 
-**Sharing with a vendor, forum or AI tool — anonymise identifiers:**
+**Sharing with a vendor, forum or AI tool, anonymising identifiers:**
 
 ```bash
 pfsense-redactor config.xml redacted.xml --anonymise
@@ -97,8 +97,8 @@ Measured against a 46-secret canary corpus that ships with the repository:
 | ForesightCyber Config Anonymizer | 17 / 46 |
 | netgate-xlsx | 11 / 46 |
 
-The corpus was built alongside this tool, which biases it — and the four misses
-are documented rather than hidden. Run it yourself:
+The corpus was built alongside this tool, which biases it. The four misses are
+documented rather than hidden. Run it yourself:
 
 ```bash
 pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
@@ -113,7 +113,7 @@ Full method, caveats and per-secret results in
 > **Never restore a redacted file to pfSense.** Comments, CDATA and some
 > metadata do not survive the round trip. Keep your original.
 
-Read the run summary — it reports high-entropy values it deliberately *kept*,
+Read the run summary. It reports high-entropy values it deliberately *kept*,
 with their element paths, so you can audit them. For a second opinion from a
 scanner that fails differently, see
 [verifying output](https://github.com/grounzero/pfsense-redactor/blob/main/docs/verifying-output.md).
@@ -123,7 +123,7 @@ scanner that fails differently, see
 | Guide | Covers |
 | --- | --- |
 | [CLI reference](https://github.com/grounzero/pfsense-redactor/blob/main/docs/cli-reference.md) | Every flag, with examples |
-| [Use cases](https://github.com/grounzero/pfsense-redactor/blob/main/docs/use-cases.md) | Netgate TAC, AI tools, MSP handoff, audits — and how this relates to `diag_sanitize.php` |
+| [Use cases](https://github.com/grounzero/pfsense-redactor/blob/main/docs/use-cases.md) | Netgate TAC, AI tools, MSP handoff, audits, and how this relates to `diag_sanitize.php` |
 | [Allow-lists](https://github.com/grounzero/pfsense-redactor/blob/main/docs/allow-lists.md) | Keep specific IPs, CIDRs and domains readable |
 | [Security](https://github.com/grounzero/pfsense-redactor/blob/main/docs/security.md) | Threat model, what gets redacted, path safety |
 | [Verifying output](https://github.com/grounzero/pfsense-redactor/blob/main/docs/verifying-output.md) | Checking the result, and using gitleaks alongside |
@@ -135,7 +135,7 @@ scanner that fails differently, see
 ## Contributing
 
 Issues and pull requests are welcome. If you find a secret that survives
-redaction, that is the most valuable report there is — a minimal fragment with
+redaction, that is the most valuable report there is. A minimal fragment with
 the value replaced by a `CANARY_*` marker can go straight into the corpus so the
 miss stays fixed.
 
@@ -148,4 +148,4 @@ pytest
 
 ## Licence
 
-MIT — see [LICENSE](https://github.com/grounzero/pfsense-redactor/blob/main/LICENSE).
+MIT. See [LICENSE](https://github.com/grounzero/pfsense-redactor/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Measured against a 46-secret canary corpus that ships with the repository:
 
 | Tool | Caught |
 | --- | --- |
-| **pfsense-redactor 1.1.1** | **42 / 46** |
+| **pfsense-redactor** | **42 / 46** (43 with `--redact-descriptions`) |
 | ForesightCyber Config Anonymizer | 17 / 46 |
 | netgate-xlsx | 11 / 46 |
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -15,7 +15,7 @@ than take them on trust.
 
 | Tool | Caught | Date tested |
 | --- | --- | --- |
-| **pfsense-redactor 1.1.1** | **42 / 46** | 2026-07-28 |
+| **pfsense-redactor** | **42 / 46** (43 / 46 with `--redact-descriptions`) | 2026-07-28 |
 | ForesightCyber pfSense Config Anonymizer | 17 / 46 | 2026-07-28 |
 | netgate-xlsx | 11 / 46 | 2026-07-28 |
 
@@ -51,7 +51,7 @@ gaps, which matters when comparing the columns:
 | `CANARY_HAPROXYCERTS` | `config/ha_certificates` | **Corpus artefact.** The value is a short literal. Short values in certificate-named elements are deliberately preserved as *references* (a `certref`, a key id), because they help a reader understand config structure and are not key material. With real PEM or base64 content the same element redacts to `[REDACTED_CERT_OR_KEY]`. |
 | `CANARY_SSLOFFLOAD` | `config/ssloffloadcert` | Same. |
 | `CANARY_WGPUB` | `item/publickey` | **Deliberate.** A WireGuard *public* key is not a secret; it is in `SECRET_TAG_DENYLIST`. It is identifying, so redact it with `--aggressive` if that matters to you. |
-| `CANARY_ATTR_PLAIN` | `config_note[@note]` | **Known limitation.** Free text in an XML attribute whose *name* is not sensitive. Attribute matching is name-driven, and pfSense barely uses attributes. No tool in this comparison caught it. |
+| `CANARY_ATTR_PLAIN` | `config_note[@note]` | **Caught with `--redact-descriptions`** (since 1.1.2), which now covers free-text attributes as well as elements. Not caught by default, because a note is often the most useful thing in a config to whoever is reading it. No other tool in this comparison caught it in any mode. |
 
 `netgate-xlsx` scores a pass on the two HAProxy rows because it redacts by
 element name regardless of content, which also removes the short references.
@@ -85,6 +85,8 @@ CANARY_HAPROXYCERTS
 CANARY_SSLOFFLOAD
 CANARY_WGPUB
 ```
+
+Add `--redact-descriptions` and `CANARY_ATTR_PLAIN` goes too, leaving three.
 
 Run the same file through any other tool and count its survivors the same way.
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -25,7 +25,7 @@ release at the time of testing.
 ## Read this before quoting the numbers
 
 **The corpus was built alongside pfsense-redactor.** It grew out of bug reports
-filed against this tool — several of the 46 markers exist precisely because a
+filed against this tool, and several of the 46 markers exist precisely because a
 1.0.10 or 1.1.0 release missed them. It therefore covers what this tool has been
 taught to look for, and a corpus assembled by either of the other projects would
 likely look different and score differently. That is a real selection effect,
@@ -38,7 +38,7 @@ out to do. Treat its number as context, not a verdict.
 
 **A high score is not a guarantee.** 42 / 46 on a corpus this tool was developed
 against says more about regression coverage than about an unseen configuration.
-Always read the output before sharing it — see
+Always read the output before sharing it. See
 [verifying output](verifying-output.md).
 
 ## What pfsense-redactor does not catch

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -109,7 +109,7 @@ pfsense-redactor config.xml --inplace --force
 | `--no-redact-ips`        | Do not redact IP addresses                                                                                                                         |
 | `--no-redact-domains`    | Do not redact domain names                                                                                                                         |
 | `--redact-url-usernames` | Redact usernames in URLs (default: preserve usernames, always redact passwords)                                                                    |
-| `--redact-descriptions`  | Redact free-text descriptions and identifiers (`descr`, `detail`, `hostname`, `ssid`). Off by default as these aid troubleshooting                  |
+| `--redact-descriptions`  | Redact free-text descriptions and identifiers (`descr`, `detail`, `hostname`, `ssid`) and free-text **attributes** (`note`, `comment`, `label`, …). Off by default as these aid troubleshooting |
 
 <details>
 <summary>Allow-lists</summary>
@@ -132,7 +132,7 @@ pfsense-redactor config.xml --inplace --force
 | ------------------- | ----------------------------------------------------------------------- |
 | `--dry-run`         | Show statistics only, do not write output file                          |
 | `--dry-run-verbose` | Show statistics with sample redactions (safely masked to prevent leaks) |
-| `--fail-on-warn`    | Exit with non-zero code if root tag is not 'pfsense' (useful in CI)     |
+| `--fail-on-warn`    | Exit non-zero if the root tag is not 'pfsense', **or** if high-entropy values were retained for review. Works with `--dry-run`, so CI can check without writing |
 
 </details>
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,7 @@ receives it. Everything below follows from that: where a judgement call exists,
 this tool over-redacts rather than under-redacts, and surfaces what it chose to
 keep so you can audit it.
 
-Verify before sharing — see [verifying output](verifying-output.md) — and see
+Verify before sharing: see [verifying output](verifying-output.md), and see
 [the benchmark](benchmark.md) for measured coverage and known gaps.
 
 ## What gets redacted
@@ -18,8 +18,8 @@ Verify before sharing — see [verifying output](verifying-output.md) — and se
 Secrets are found by **element name**, not by value shape, because a real SNMP
 community (`public`) or WPA passphrase looks like ordinary text. Matching is
 substring-based, since the spellings that leak are the concatenated ones
-pfSense and its packages actually emit — `rocommunity`, `radiussecret`,
-`passwordagain` — with a deny-list for the false positives that creates
+pfSense and its packages actually emit: `rocommunity`, `radiussecret`,
+`passwordagain`. A deny-list handles the false positives that creates
 (`keylen`, `certref`, `password_type`).
 
 Credentials embedded in URLs are handled separately:
@@ -32,8 +32,8 @@ Credentials embedded in URLs are handled separately:
 | Path segment on any other host | kept | redacted |
 
 Path segments are kept by default because pfBlockerNG feed URLs legitimately
-carry long path components that redaction would destroy — a corrupted config is
-its own kind of failure.
+carry long path components that redaction would destroy, and a corrupted config
+is its own kind of failure.
 
 The exception is endpoints where the path token *is* the credential, since
 anyone holding the URL can post as that integration. For those the token is
@@ -48,7 +48,7 @@ redacted in every mode:
 | Teams (per-tenant) | any `*.webhook.office.com` + `/webhookb2/` |
 
 Hosts are matched **exactly** apart from Teams, which puts the tenant in a
-subdomain and so is matched on the suffix `.webhook.office.com` — the leading
+subdomain and so is matched on the suffix `.webhook.office.com`. The leading
 dot is what stops `notwebhook.office.com` qualifying. Either way the path
 prefix must match too, so an ordinary `discord.com/channels/…` link is
 untouched. Everything else still needs `--aggressive`.
@@ -72,8 +72,8 @@ Input declaring a `<!DOCTYPE>` is **refused**. pfSense never emits one, so its
 presence means the file did not come from pfSense untouched.
 
 This is deliberately not described as an XXE fix. Python's
-`xml.etree.ElementTree` does not resolve external entities — a `SYSTEM` entity
-raises `ParseError` — so there is no file disclosure and no SSRF. What it does
+`xml.etree.ElementTree` does not resolve external entities. A `SYSTEM` entity
+raises `ParseError`, so there is no file disclosure and no SSRF. What it does
 do is expand *internal* entities, where a few hundred bytes of nested
 definitions expand to gigabytes. The whole XML prolog is scanned rather than a
 fixed-size prefix, so a declaration cannot hide behind a large comment, and a

--- a/docs/security.md
+++ b/docs/security.md
@@ -44,11 +44,18 @@ redacted in every mode:
 | Slack | `hooks.slack.com` + `/services/` |
 | Discord | `discord.com`, `discordapp.com`, `ptb.`/`canary.` variants + `/api/webhooks/` |
 | Telegram | `api.telegram.org` + `/bot` |
+| Teams | `outlook.office.com`/`outlook.office365.com` + `/webhook/` |
+| Teams (per-tenant) | any `*.webhook.office.com` + `/webhookb2/` |
 
-Hosts are matched **exactly, never by suffix**, so `hooks.slack.com.example.net`
-does not inherit the rule; and the path prefix must match too, so an ordinary
-`discord.com/channels/…` link is untouched. Everything else still needs
-`--aggressive`.
+Hosts are matched **exactly** apart from Teams, which puts the tenant in a
+subdomain and so is matched on the suffix `.webhook.office.com` — the leading
+dot is what stops `notwebhook.office.com` qualifying. Either way the path
+prefix must match too, so an ordinary `discord.com/channels/…` link is
+untouched. Everything else still needs `--aggressive`.
+
+Self-hosted tools such as Mattermost are deliberately absent: their webhooks
+sit at `/hooks/<token>` on whatever host the operator chose, so there is no
+host to match on.
 
 Recognised credential formats in path segments include AWS access key IDs
 (exactly 20 characters), Telegram bot tokens (`bot<id>:<secret>`, where the

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -56,6 +56,18 @@ pfsense-redactor config.xml --dry-run-verbose
 pfsense-redactor $INPUT_CONFIG $OUTPUT_CONFIG --aggressive --fail-on-warn
 ```
 
+`--fail-on-warn` exits non-zero if the root tag is wrong, or if the tool left
+any high-entropy value in place for review. With `--aggressive` those values are
+redacted rather than retained, so the gate passes; drop `--aggressive` and the
+job fails instead, listing the element paths to look at.
+
+To check a configuration without writing anything, which is often what a
+pipeline wants:
+
+```bash
+pfsense-redactor $INPUT_CONFIG --dry-run --fail-on-warn
+```
+
 ## Relationship to pfSense built-in sanitisation
 
 pfSense includes a built-in configuration sanitisation script:

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -6,7 +6,7 @@ Redaction is not a thing to take on trust. This page covers the checks built
 into the tool, and how to get a second opinion from a scanner that fails
 differently.
 
-## 1. Read the summary — especially what was *kept*
+## 1. Read the summary, especially what was *kept*
 
 Every run prints what it redacted. More usefully, it also reports what it
 deliberately did **not**:
@@ -18,23 +18,36 @@ deliberately did **not**:
 ```
 
 These are values that look like key material in elements the tool does not
-recognise — typically third-party package fields. It reports the element path
+recognise, typically third-party package fields. It reports the element path
 rather than the value, so the warning is safe to paste into a ticket.
 
 This warning is the direct answer to "what did you leave behind". Do not ignore
 it, and re-run with `--aggressive` if any path looks like it holds a secret.
 
-## 2. Preview before you share
+## 2. Let CI check it for you
+
+The same warning drives an exit code, so a pipeline can gate on it:
+
+```bash
+pfsense-redactor config.xml --dry-run --fail-on-warn
+```
+
+Non-zero means either the root tag is not `pfsense`, or values were retained for
+review. Nothing is written, so this is safe to run on every commit. Adding
+`--aggressive` redacts those values instead of retaining them, which makes the
+gate pass.
+
+## 3. Preview before you share
 
 ```bash
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
 Shows counts plus masked before/after examples, so you can confirm the right
-things are being caught without writing a file. Samples are masked — the
+things are being caught without writing a file. Samples are masked, so the
 preview never prints a live secret to your terminal or CI log.
 
-## 3. Get a second opinion
+## 4. Get a second opinion
 
 An independent secret scanner such as [gitleaks](https://github.com/gitleaks/gitleaks)
 is worth running over the output, because it fails in the opposite direction to
@@ -53,7 +66,7 @@ gitleaks dir redacted.xml --no-banner
 
 ### What that actually buys you
 
-Measured, not assumed — gitleaks 8.30.1 against a config containing six real
+Measured, not assumed. gitleaks 8.30.1 against a config containing six real
 secrets, run against 1.1.1:
 
 | Secret | gitleaks | redactor 1.1.1 (default) | redactor 1.1.2 (default) |
@@ -65,7 +78,7 @@ secrets, run against 1.1.1:
 | `<secret_access_key>` | ❌ | ✅ | ✅ |
 | `<slack_url>` webhook token | **✅** | **❌** | ✅ |
 
-gitleaks found one of the six — and it was the one this tool was missing.
+gitleaks found one of the six, and it was the one this tool was missing.
 **That row is why this page exists**: the finding was reported and fixed in
 1.1.2, which now redacts path tokens on known webhook hosts in every mode. An
 independent scanner earned its keep on the first run.
@@ -74,7 +87,7 @@ independent scanner earned its keep on the first run.
 passphrase of `CorrectHorseBattery` have no distinguishing shape; nothing about
 the value says "secret". Only the element name does. It also skipped the AWS key
 because `AKIAIOSFODNN7EXAMPLE` is Amazon's documented example key and is
-allowlisted — worth knowing if you test with it.
+allowlisted, which is worth knowing if you test with it.
 
 That asymmetry is the point, and it did not go away with the fix. The two tools
 fail in opposite directions, so a second opinion is still worth having on a
@@ -87,7 +100,7 @@ to be a feed URL as a credential.
 ### A clean scan is not a clean file
 
 Do not read "no leaks found" as proof. On this project's own 46-secret
-[canary corpus](benchmark.md), gitleaks reports **no findings at all** — before
+[canary corpus](benchmark.md), gitleaks reports **no findings at all**, before
 any redaction. The planted markers are low-entropy placeholder strings, which is
 the same reason it misses a real SNMP community.
 
@@ -95,7 +108,7 @@ A scanner that finds nothing may mean the file is clean, or that the secrets do
 not look like secrets. Use it to catch what this tool missed, never to certify
 that nothing was missed.
 
-## 4. Diff the two files
+## 5. Diff the two files
 
 For a config small enough to read, nothing beats looking:
 
@@ -109,6 +122,6 @@ Every line that did *not* change is a line you are choosing to share.
 
 If you find a secret that survived, please open an issue. A minimal
 `config.xml` fragment with the value replaced by a marker such as
-`CANARY_MYSECRET` is ideal — that is exactly the shape of
+`CANARY_MYSECRET` is ideal. That is exactly the shape of
 [the corpus](../tests/corpus/canary-corpus.xml), and it can be added to it so
 the miss stays fixed.

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -409,14 +409,23 @@ WEBHOOK_URL_SUFFIXES: tuple[tuple[str, str], ...] = (
 
 
 def _is_webhook_url(host: str, path: str) -> bool:
-    """Whether a URL is a known webhook endpoint carrying its token in the path"""
-    host_lower = host.lower()
+    """Whether a URL is a known webhook endpoint carrying its token in the path
 
-    if any(host_lower == known and path.startswith(prefix)
+    The path is compared case-insensitively even though RFC 3986 makes paths
+    case-sensitive. Every prefix here is lowercase, so folding case can only
+    add matches, never remove one, and the additions are all still webhook
+    URLs: '/Services/' on hooks.slack.com is not something else. Comparing
+    exactly meant a config written with '/Services/' kept its token, which is
+    the failure this whole rule exists to prevent.
+    """
+    host_lower = host.lower()
+    path_lower = path.lower()
+
+    if any(host_lower == known and path_lower.startswith(prefix)
            for known, prefix in WEBHOOK_URL_PREFIXES):
         return True
 
-    return any(host_lower.endswith(suffix) and path.startswith(prefix)
+    return any(host_lower.endswith(suffix) and path_lower.startswith(prefix)
                for suffix, prefix in WEBHOOK_URL_SUFFIXES)
 
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -240,6 +240,19 @@ DESCRIPTION_ELEMENTS: frozenset[str] = frozenset({
     'descr', 'detail', 'hostname', 'ssid',
 })
 
+# Attribute names holding free prose rather than structure. Redacted under
+# --redact-descriptions, the same flag and for the same reason as the elements
+# above: an operator's note is where a PIN, a circuit reference or a personal
+# name ends up, and no pattern reliably picks those out of a sentence.
+#
+# SENSITIVE_ATTR_PATTERN already catches attributes *named* for a secret. This
+# covers the ones whose name says nothing, which is why the value has to go
+# wholesale rather than be scanned.
+DESCRIPTION_ATTRIBUTES: frozenset[str] = frozenset({
+    'descr', 'description', 'note', 'notes', 'detail', 'details',
+    'comment', 'comments', 'label', 'title',
+})
+
 # key<sep>value scanner for BLOB_TEXT_ELEMENTS. Matches anywhere in a line, not
 # just at its start, so '[admin] password=secret' (NUT upsd_users format) is
 # caught as well as a bare 'password=secret'.
@@ -373,14 +386,38 @@ WEBHOOK_URL_PREFIXES: tuple[tuple[str, str], ...] = (
     ('canary.discord.com', '/api/webhooks/'),
     # Telegram puts 'bot<id>:<token>' in the first path segment.
     ('api.telegram.org', '/bot'),
+    # Microsoft Teams, connector-style (the pre-Workflows endpoint).
+    ('outlook.office.com', '/webhook/'),
+    ('outlook.office365.com', '/webhook/'),
 )
+
+# Providers that put the tenant in a subdomain, so the host cannot be matched
+# exactly. Matched as a suffix *including the leading dot*, which is what stops
+# 'eviloutlook.office.com' or 'notwebhook.office.com' from qualifying.
+#
+# Kept apart from WEBHOOK_URL_PREFIXES on purpose. Suffix matching is the looser
+# rule and the easier one to get wrong, so it applies only to domains listed
+# here rather than to the whole set.
+WEBHOOK_URL_SUFFIXES: tuple[tuple[str, str], ...] = (
+    ('.webhook.office.com', '/webhookb2/'),
+)
+
+# Deliberately absent: Mattermost, Rocket.Chat and other self-hosted tools put
+# their webhooks at '/hooks/<token>' on whatever host the operator chose. There
+# is no host to match, and treating any '/hooks/' path as a credential would
+# redact ordinary paths on unrelated servers. Those need --aggressive.
 
 
 def _is_webhook_url(host: str, path: str) -> bool:
     """Whether a URL is a known webhook endpoint carrying its token in the path"""
     host_lower = host.lower()
-    return any(host_lower == known and path.startswith(prefix)
-               for known, prefix in WEBHOOK_URL_PREFIXES)
+
+    if any(host_lower == known and path.startswith(prefix)
+           for known, prefix in WEBHOOK_URL_PREFIXES):
+        return True
+
+    return any(host_lower.endswith(suffix) and path.startswith(prefix)
+               for suffix, prefix in WEBHOOK_URL_SUFFIXES)
 
 
 # URL path segment credential detection.
@@ -2230,10 +2267,23 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return True
         return False
 
+    def _should_redact_attribute(self, attr: str) -> bool:
+        """Whether an attribute's value should be removed on the strength of its name
+
+        Two reasons: the name denotes a secret, or the name denotes free prose
+        and --redact-descriptions was asked for. The second is opt-in because
+        notes and labels are often the most useful part of a config to a reader.
+        """
+        if SENSITIVE_ATTR_PATTERN.search(attr):
+            return True
+        if not self.redact_descriptions:
+            return False
+        return attr.lower() in DESCRIPTION_ATTRIBUTES
+
     def _redact_sensitive_attributes(self, element: ET.Element) -> None:
-        """Redact attributes with sensitive names using anchored regex patterns"""
+        """Redact attributes whose name says the value should not be shared"""
         for attr in list(element.attrib.keys()):
-            if SENSITIVE_ATTR_PATTERN.search(attr):
+            if self._should_redact_attribute(attr):
                 original = element.attrib[attr]
                 element.attrib[attr] = '[REDACTED]'
                 self.stats['secrets_redacted'] += 1
@@ -2447,7 +2497,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             if dry_run:
                 self.logger.info("[+] Dry run - no files modified")
                 self._print_stats()
-                return True
+                return self._retained_values_are_acceptable()
 
             # Add redaction comment to the root element
             self._add_redaction_comment(root)
@@ -2460,7 +2510,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # Print summary (always print, logger routes to correct stream)
             self._print_stats()
 
-            return True
+            return self._retained_values_are_acceptable()
 
         except ET.ParseError as e:
             self.logger.error("[!] Error parsing XML: %s", e)
@@ -2471,6 +2521,29 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         except (ValueError, TypeError) as e:
             self.logger.error("[!] Error processing configuration: %s", e)
             return False
+
+    def _retained_values_are_acceptable(self) -> bool:
+        """Whether the run should be treated as successful
+
+        False only under --fail-on-warn, and only when high-entropy values were
+        left in place. The warning naming them has already been printed.
+
+        Without this the flag covered the root-tag check alone, so a CI job
+        could pass on a file the tool had just told the operator to review
+        before sharing. A gate that cannot fail is not a gate.
+        """
+        if not self.fail_on_warn:
+            return True
+        if not self.stats['high_entropy_retained']:
+            return True
+
+        self.logger.error(
+            "[!] Failing because --fail-on-warn is set and %d high-entropy "
+            "value(s) were retained. Re-run with --aggressive to redact them, "
+            "or review the paths listed above.",
+            self.stats['high_entropy_retained']
+        )
+        return False
 
     def _print_stats(self) -> None:
         """Print redaction statistics using logger"""

--- a/tests/integration/test_canary_corpus.py
+++ b/tests/integration/test_canary_corpus.py
@@ -135,6 +135,28 @@ class TestAggressiveScore:
         assert EXPECTED_SURVIVORS[marker].strip()
 
 
+class TestDescriptionsRaiseTheScore:
+    """--redact-descriptions closes the one survivor that is a real gap
+
+    The other three are a deliberate choice and two corpus artefacts, so this
+    is as far as the corpus can be taken without redacting things that are not
+    secrets.
+    """
+
+    def test_score_is_43_of_46(self):
+        """The number docs/benchmark.md publishes for this mode"""
+        left = survivors(redact_corpus('--aggressive', '--redact-descriptions'))
+
+        assert TOTAL_CANARIES - len(left) == 43
+
+    def test_it_is_the_attribute_marker_that_moves(self):
+        """Specifically the free-text attribute, not something else"""
+        left = survivors(redact_corpus('--aggressive', '--redact-descriptions'))
+
+        assert 'CANARY_ATTR_PLAIN' not in left
+        assert left == set(EXPECTED_SURVIVORS) - {'CANARY_ATTR_PLAIN'}
+
+
 class TestDefaultModeIsNotWorse:
     """Default mode catches less than --aggressive, but must not leak more
 

--- a/tests/unit/test_fail_on_warn.py
+++ b/tests/unit/test_fail_on_warn.py
@@ -7,15 +7,18 @@ an automated check passed on a file its own output said to look at.
 
 docs/use-cases.md recommends this flag for CI, so the gap was between what it
 was documented to do and what it did.
+
+Two layers here on purpose. The predicate and redact_config are exercised
+in-process, which is precise and needs no coverage hook; the exit codes are
+exercised through the CLI, because a return value that never reaches a shell is
+not a gate. CLI runs go through the cli_runner fixture rather than a bare
+subprocess.run so the child inherits COVERAGE_PROCESS_START.
 """
-import re
-import subprocess
-import sys
-from pathlib import Path
+import xml.etree.ElementTree as ET
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).parent.parent.parent
+from pfsense_redactor.redactor import PfSenseRedactor
 
 # A high-entropy value in an element the tool does not recognise: retained by
 # default, reported for review, and redacted under --aggressive.
@@ -26,116 +29,161 @@ UNKNOWN_BLOB = (
 )
 
 CLEAN_CONFIG = '<?xml version="1.0"?><pfsense><version>23.09</version></pfsense>'
+WRONG_ROOT = '<?xml version="1.0"?><notpfsense><a>1</a></notpfsense>'
 
 
-def run(tmp_path, xml, *flags):
-    """Redact a config to stdout and return the CompletedProcess"""
+def redact(tmp_path, xml, **kwargs):
+    """Redact in-process. Returns (redactor, success)"""
     source = tmp_path / 'config.xml'
     source.write_text(xml, encoding='utf-8')
-    return subprocess.run(
-        [sys.executable, '-m', 'pfsense_redactor', str(source), '--stdout', *flags],
-        capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
+    redactor = PfSenseRedactor(**kwargs)
+    ok = redactor.redact_config(str(source), str(tmp_path / 'out.xml'))
+    return redactor, ok
+
+
+def run_cli(cli_runner, tmp_path, xml, *flags):
+    """Redact through the CLI. Returns (exit_code, stdout, stderr)"""
+    source = tmp_path / 'config.xml'
+    source.write_text(xml, encoding='utf-8')
+    return cli_runner.run(
+        str(source), flags=['--stdout', *flags], expect_success=False
     )
 
 
-class TestRetainedValuesFailTheBuild:
-    """The behaviour change"""
+class TestTheGatePredicate:
+    """_retained_values_are_acceptable, on its own"""
 
-    def test_retained_value_warns_but_passes_without_the_flag(self, tmp_path):
-        """Default behaviour is unchanged - the warning is advisory"""
-        result = run(tmp_path, UNKNOWN_BLOB)
+    def test_passes_when_the_flag_is_not_set(self):
+        """Retained values are advisory by default"""
+        redactor = PfSenseRedactor(fail_on_warn=False)
+        redactor.stats['high_entropy_retained'] = 3
 
-        assert result.returncode == 0
-        assert 'high-entropy' in result.stderr
+        assert redactor._retained_values_are_acceptable() is True
 
-    def test_retained_value_fails_with_the_flag(self, tmp_path):
-        """The gate now closes on exactly the case the warning describes"""
-        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+    def test_passes_when_nothing_was_retained(self):
+        """The flag alone is not a failure"""
+        redactor = PfSenseRedactor(fail_on_warn=True)
 
-        assert result.returncode != 0
-        assert 'high-entropy' in result.stderr
+        assert redactor._retained_values_are_acceptable() is True
 
-    def test_failure_message_says_how_to_resolve_it(self, tmp_path):
+    def test_fails_when_both_are_true(self):
+        """The one combination that should stop a build"""
+        redactor = PfSenseRedactor(fail_on_warn=True)
+        redactor.stats['high_entropy_retained'] = 1
+
+        assert redactor._retained_values_are_acceptable() is False
+
+    def test_failure_is_logged_with_the_count_and_a_remedy(self, caplog):
         """A CI failure is only useful if it says what to do next"""
-        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+        redactor = PfSenseRedactor(fail_on_warn=True)
+        redactor.stats['high_entropy_retained'] = 2
 
-        assert '--aggressive' in result.stderr
+        redactor._retained_values_are_acceptable()
+
+        assert '2' in caplog.text
+        assert '--aggressive' in caplog.text
+
+
+class TestRedactConfigReturnValue:
+    """The predicate reaching redact_config's return, in-process"""
+
+    def test_retained_value_returns_false_with_the_flag(self, tmp_path):
+        """The write still happens; only the reported success changes"""
+        redactor, ok = redact(tmp_path, UNKNOWN_BLOB, fail_on_warn=True)
+
+        assert redactor.stats['high_entropy_retained'] == 1
+        assert ok is False
+        assert (tmp_path / 'out.xml').exists(), 'output should still be written'
+
+    def test_retained_value_returns_true_without_the_flag(self, tmp_path):
+        """Default behaviour is unchanged"""
+        _, ok = redact(tmp_path, UNKNOWN_BLOB)
+
+        assert ok is True
 
     def test_aggressive_redacts_them_so_the_gate_passes(self, tmp_path):
-        """The documented remedy actually works
+        """The documented remedy works: nothing retained, nothing to fail on"""
+        redactor, ok = redact(tmp_path, UNKNOWN_BLOB, fail_on_warn=True, aggressive=True)
 
-        --aggressive redacts these values, so nothing is retained and there is
-        nothing left to fail on.
-        """
-        result = run(tmp_path, UNKNOWN_BLOB, '--aggressive', '--fail-on-warn')
-
-        assert result.returncode == 0
-        assert 'high-entropy' not in result.stderr
+        assert redactor.stats['high_entropy_retained'] == 0
+        assert ok is True
 
     def test_clean_config_passes(self, tmp_path):
         """No retained values means no failure, flag or not"""
-        assert run(tmp_path, CLEAN_CONFIG, '--fail-on-warn').returncode == 0
+        _, ok = redact(tmp_path, CLEAN_CONFIG, fail_on_warn=True)
 
+        assert ok is True
 
-class TestDryRunIsGatedToo:
-    """--dry-run is the natural CI shape: check without writing anything"""
-
-    def test_dry_run_fails_on_retained_values(self, tmp_path):
+    def test_dry_run_is_gated_too(self, tmp_path):
         """Checking without writing must still be able to fail
 
         Otherwise the least destructive way to run this in CI is also the one
         that cannot report a problem.
         """
-        result = run(tmp_path, UNKNOWN_BLOB, '--dry-run', '--fail-on-warn')
+        source = tmp_path / 'config.xml'
+        source.write_text(UNKNOWN_BLOB, encoding='utf-8')
+        redactor = PfSenseRedactor(fail_on_warn=True)
 
-        assert result.returncode != 0
+        ok = redactor.redact_config(str(source), None, dry_run=True)
+
+        assert ok is False
 
     def test_dry_run_without_the_flag_still_passes(self, tmp_path):
         """--dry-run alone stays advisory"""
-        assert run(tmp_path, UNKNOWN_BLOB, '--dry-run').returncode == 0
+        source = tmp_path / 'config.xml'
+        source.write_text(UNKNOWN_BLOB, encoding='utf-8')
 
-
-class TestRootTagCheckStillWorks:
-    """The behaviour the flag already had must not be lost"""
+        assert PfSenseRedactor().redact_config(str(source), None, dry_run=True) is True
 
     def test_wrong_root_tag_still_fails(self, tmp_path):
-        """This was the flag's original and only job"""
-        result = run(tmp_path, '<?xml version="1.0"?><notpfsense><a>1</a></notpfsense>',
-                     '--fail-on-warn')
+        """The flag's original job must not be lost"""
+        _, ok = redact(tmp_path, WRONG_ROOT, fail_on_warn=True)
 
-        assert result.returncode != 0
-        assert 'root tag' in result.stderr.lower()
+        assert ok is False
 
-    def test_wrong_root_tag_warns_without_the_flag(self, tmp_path):
+    def test_wrong_root_tag_only_warns_without_the_flag(self, tmp_path):
         """Still a warning rather than an error by default"""
-        result = run(tmp_path, '<?xml version="1.0"?><notpfsense><a>1</a></notpfsense>')
+        _, ok = redact(tmp_path, WRONG_ROOT)
 
-        assert result.returncode == 0
-        assert 'root tag' in result.stderr.lower()
+        assert ok is True
 
 
-class TestExitCodeIsUsableInCI:
-    """What a pipeline actually consumes"""
+class TestExitCodeReachesTheShell:
+    """A return value a pipeline never sees is not a gate"""
 
-    @pytest.mark.parametrize('flags,expected_zero', [
+    @pytest.mark.parametrize('flags,expect_zero', [
         ((), True),
         (('--fail-on-warn',), False),
         (('--aggressive', '--fail-on-warn'), True),
         (('--dry-run', '--fail-on-warn'), False),
     ])
-    def test_exit_codes(self, tmp_path, flags, expected_zero):
+    def test_exit_codes(self, cli_runner, tmp_path, flags, expect_zero):
         """The full matrix, so a change to any one path is visible"""
-        result = run(tmp_path, UNKNOWN_BLOB, *flags)
+        exit_code, _, _ = run_cli(cli_runner, tmp_path, UNKNOWN_BLOB, *flags)
 
-        assert (result.returncode == 0) is expected_zero
+        assert (exit_code == 0) is expect_zero
 
-    def test_output_is_still_written_when_the_gate_fails(self, tmp_path):
+    def test_failure_message_reaches_stderr(self, cli_runner, tmp_path):
+        """The operator needs to see why, not just a non-zero code"""
+        _, _, stderr = run_cli(cli_runner, tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+
+        assert 'high-entropy' in stderr
+        assert '--aggressive' in stderr
+
+    def test_output_is_still_written_when_the_gate_fails(self, cli_runner, tmp_path):
         """Failing the build must not mean losing the redacted file
 
-        The retained values were reported, not leaked - the operator still
+        The retained values were reported, not leaked, so the operator still
         wants the output in order to review those paths.
         """
-        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+        exit_code, stdout, _ = run_cli(cli_runner, tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
 
-        assert result.returncode != 0
-        assert re.search(r'<pfsense>', result.stdout), 'redacted output should still be produced'
+        assert exit_code != 0
+        assert ET.fromstring(stdout).tag == 'pfsense'
+
+    def test_wrong_root_tag_exit_code(self, cli_runner, tmp_path):
+        """The pre-existing behaviour, through the shell"""
+        exit_code, _, stderr = run_cli(cli_runner, tmp_path, WRONG_ROOT, '--fail-on-warn')
+
+        assert exit_code != 0
+        assert 'root tag' in stderr.lower()

--- a/tests/unit/test_fail_on_warn.py
+++ b/tests/unit/test_fail_on_warn.py
@@ -1,0 +1,141 @@
+"""
+Tests for --fail-on-warn as a CI gate.
+
+The flag used to cover the root-tag check alone. A config carrying a value the
+tool declined to redact printed "Review before sharing" and still exited 0, so
+an automated check passed on a file its own output said to look at.
+
+docs/use-cases.md recommends this flag for CI, so the gap was between what it
+was documented to do and what it did.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+# A high-entropy value in an element the tool does not recognise: retained by
+# default, reported for review, and redacted under --aggressive.
+UNKNOWN_BLOB = (
+    '<?xml version="1.0"?><pfsense><installedpackages><mypkg><config>'
+    '<blob>MIIDXTCCAkWgAwIBAgIJAKL0UG6mRkSPMA0GCSqGSIb3DQEBCwUAMEUxCzAJBg</blob>'
+    '</config></mypkg></installedpackages></pfsense>'
+)
+
+CLEAN_CONFIG = '<?xml version="1.0"?><pfsense><version>23.09</version></pfsense>'
+
+
+def run(tmp_path, xml, *flags):
+    """Redact a config to stdout and return the CompletedProcess"""
+    source = tmp_path / 'config.xml'
+    source.write_text(xml, encoding='utf-8')
+    return subprocess.run(
+        [sys.executable, '-m', 'pfsense_redactor', str(source), '--stdout', *flags],
+        capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
+    )
+
+
+class TestRetainedValuesFailTheBuild:
+    """The behaviour change"""
+
+    def test_retained_value_warns_but_passes_without_the_flag(self, tmp_path):
+        """Default behaviour is unchanged - the warning is advisory"""
+        result = run(tmp_path, UNKNOWN_BLOB)
+
+        assert result.returncode == 0
+        assert 'high-entropy' in result.stderr
+
+    def test_retained_value_fails_with_the_flag(self, tmp_path):
+        """The gate now closes on exactly the case the warning describes"""
+        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+
+        assert result.returncode != 0
+        assert 'high-entropy' in result.stderr
+
+    def test_failure_message_says_how_to_resolve_it(self, tmp_path):
+        """A CI failure is only useful if it says what to do next"""
+        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+
+        assert '--aggressive' in result.stderr
+
+    def test_aggressive_redacts_them_so_the_gate_passes(self, tmp_path):
+        """The documented remedy actually works
+
+        --aggressive redacts these values, so nothing is retained and there is
+        nothing left to fail on.
+        """
+        result = run(tmp_path, UNKNOWN_BLOB, '--aggressive', '--fail-on-warn')
+
+        assert result.returncode == 0
+        assert 'high-entropy' not in result.stderr
+
+    def test_clean_config_passes(self, tmp_path):
+        """No retained values means no failure, flag or not"""
+        assert run(tmp_path, CLEAN_CONFIG, '--fail-on-warn').returncode == 0
+
+
+class TestDryRunIsGatedToo:
+    """--dry-run is the natural CI shape: check without writing anything"""
+
+    def test_dry_run_fails_on_retained_values(self, tmp_path):
+        """Checking without writing must still be able to fail
+
+        Otherwise the least destructive way to run this in CI is also the one
+        that cannot report a problem.
+        """
+        result = run(tmp_path, UNKNOWN_BLOB, '--dry-run', '--fail-on-warn')
+
+        assert result.returncode != 0
+
+    def test_dry_run_without_the_flag_still_passes(self, tmp_path):
+        """--dry-run alone stays advisory"""
+        assert run(tmp_path, UNKNOWN_BLOB, '--dry-run').returncode == 0
+
+
+class TestRootTagCheckStillWorks:
+    """The behaviour the flag already had must not be lost"""
+
+    def test_wrong_root_tag_still_fails(self, tmp_path):
+        """This was the flag's original and only job"""
+        result = run(tmp_path, '<?xml version="1.0"?><notpfsense><a>1</a></notpfsense>',
+                     '--fail-on-warn')
+
+        assert result.returncode != 0
+        assert 'root tag' in result.stderr.lower()
+
+    def test_wrong_root_tag_warns_without_the_flag(self, tmp_path):
+        """Still a warning rather than an error by default"""
+        result = run(tmp_path, '<?xml version="1.0"?><notpfsense><a>1</a></notpfsense>')
+
+        assert result.returncode == 0
+        assert 'root tag' in result.stderr.lower()
+
+
+class TestExitCodeIsUsableInCI:
+    """What a pipeline actually consumes"""
+
+    @pytest.mark.parametrize('flags,expected_zero', [
+        ((), True),
+        (('--fail-on-warn',), False),
+        (('--aggressive', '--fail-on-warn'), True),
+        (('--dry-run', '--fail-on-warn'), False),
+    ])
+    def test_exit_codes(self, tmp_path, flags, expected_zero):
+        """The full matrix, so a change to any one path is visible"""
+        result = run(tmp_path, UNKNOWN_BLOB, *flags)
+
+        assert (result.returncode == 0) is expected_zero
+
+    def test_output_is_still_written_when_the_gate_fails(self, tmp_path):
+        """Failing the build must not mean losing the redacted file
+
+        The retained values were reported, not leaked - the operator still
+        wants the output in order to review those paths.
+        """
+        result = run(tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
+
+        assert result.returncode != 0
+        assert re.search(r'<pfsense>', result.stdout), 'redacted output should still be produced'

--- a/tests/unit/test_sensitive_attribute_anchoring.py
+++ b/tests/unit/test_sensitive_attribute_anchoring.py
@@ -230,3 +230,75 @@ class TestSensitiveAttributeAnchoring:
 
         assert root.find('message').get('signature') == '[REDACTED]'
         assert redactor.stats['secrets_redacted'] == 1
+
+
+class TestDescriptionAttributes:
+    """Free-prose attributes, redacted only under --redact-descriptions
+
+    SENSITIVE_ATTR_PATTERN catches attributes *named* for a secret. These are
+    the ones whose name says nothing about the contents - a note, a label - and
+    where the value has to go wholesale because no pattern picks a PIN or a
+    circuit reference out of a sentence.
+
+    Opt-in for the same reason description elements are: notes are often the
+    most useful part of a config to whoever is reading it.
+    """
+
+    NOTE_XML = '<config><config_note note="ISP pin 4815" secret="s3cret">x</config_note></config>'
+
+    def test_free_text_attribute_kept_by_default(self):
+        """Default runs keep notes, which is what makes a config readable"""
+        root = ET.fromstring(self.NOTE_XML)
+
+        PfSenseRedactor().redact_element(root)
+
+        assert root.find('config_note').get('note') == 'ISP pin 4815'
+
+    def test_free_text_attribute_kept_under_aggressive_alone(self):
+        """--aggressive is about identifiers, not about discarding prose"""
+        root = ET.fromstring(self.NOTE_XML)
+
+        PfSenseRedactor(aggressive=True).redact_element(root)
+
+        assert root.find('config_note').get('note') == 'ISP pin 4815'
+
+    def test_free_text_attribute_redacted_with_the_flag(self):
+        """--redact-descriptions covers attributes as well as elements"""
+        root = ET.fromstring(self.NOTE_XML)
+
+        PfSenseRedactor(redact_descriptions=True).redact_element(root)
+
+        assert root.find('config_note').get('note') == '[REDACTED]'
+
+    def test_secret_named_attribute_redacted_regardless(self):
+        """The existing name-based rule is unchanged by any of this"""
+        root = ET.fromstring(self.NOTE_XML)
+
+        PfSenseRedactor().redact_element(root)
+
+        assert root.find('config_note').get('secret') == '[REDACTED]'
+
+    def test_structural_attributes_survive_the_flag(self):
+        """--redact-descriptions must not strip attributes that carry meaning
+
+        Redacting a version or an interface name would break the reader's
+        ability to follow the config, which is the thing this tool exists to
+        preserve.
+        """
+        xml = '<config><rule version="1.0" interface="wan" type="pass"/></config>'
+        root = ET.fromstring(xml)
+
+        PfSenseRedactor(redact_descriptions=True).redact_element(root)
+
+        rule = root.find('rule')
+        assert rule.get('version') == '1.0'
+        assert rule.get('interface') == 'wan'
+        assert rule.get('type') == 'pass'
+
+    def test_attribute_name_match_is_case_insensitive(self):
+        """Configs are written by hand, and Note is as likely as note"""
+        root = ET.fromstring('<config><x Note="private remark"/></config>')
+
+        PfSenseRedactor(redact_descriptions=True).redact_element(root)
+
+        assert root.find('x').get('Note') == '[REDACTED]'

--- a/tests/unit/test_webhook_hosts.py
+++ b/tests/unit/test_webhook_hosts.py
@@ -71,6 +71,33 @@ class TestIsWebhookUrl:
         """Hostnames are case-insensitive, and configs are written by hand"""
         assert _is_webhook_url('Hooks.Slack.COM', '/services/a/b/c')
 
+    @pytest.mark.parametrize('path', [
+        '/Services/T024BE7LD/B024BE7LH/tok',
+        '/SERVICES/T024BE7LD/B024BE7LH/tok',
+    ])
+    def test_path_comparison_is_case_insensitive(self, path):
+        """RFC 3986 makes paths case-sensitive, but matching exactly leaked
+
+        Every prefix here is lowercase, so folding case can only add matches,
+        and '/Services/' on hooks.slack.com is still a webhook.
+        """
+        assert _is_webhook_url('hooks.slack.com', path)
+
+    def test_mixed_case_path_token_is_redacted(self, basic_redactor):
+        """End to end: the case that survived before"""
+        url = 'https://hooks.slack.com/Services/T024BE7LD/B024BE7LH/' + SLACK_TOKEN
+
+        assert SLACK_TOKEN not in basic_redactor._redact_url_secrets_only(url)
+
+    def test_case_folding_does_not_widen_the_host_rule(self):
+        """Only the path is folded; the host rules are unchanged
+
+        A lookalike must not become a match just because the path now
+        compares loosely.
+        """
+        assert not _is_webhook_url('hooks.slack.com.evil.example', '/Services/a/b/c')
+        assert not _is_webhook_url('notwebhook.office.com', '/WebhookB2/x')
+
     def test_empty_inputs_are_safe(self):
         """A URL with no host must not raise"""
         assert not _is_webhook_url('', '')

--- a/tests/unit/test_webhook_hosts.py
+++ b/tests/unit/test_webhook_hosts.py
@@ -76,6 +76,52 @@ class TestIsWebhookUrl:
         assert not _is_webhook_url('', '')
 
 
+TEAMS_TOKEN = 'EXAMPLEnotarealteamswebhooktokenEXAMPLE'
+TEAMS = ('https://acme.webhook.office.com/webhookb2/abc-def@ghi-jkl/'
+         'IncomingWebhook/' + TEAMS_TOKEN + '/mno-pqr')
+
+
+class TestTenantSubdomainEndpoints:
+    """Teams puts the tenant in the subdomain, so the host cannot be exact
+
+    Suffix matching is the looser rule and the easier one to get wrong, so it
+    applies only to the domains listed for it - these tests pin both halves.
+    """
+
+    def test_teams_tenant_subdomain_matches(self):
+        """Any tenant under webhook.office.com is a webhook host"""
+        assert _is_webhook_url('acme.webhook.office.com', '/webhookb2/x')
+        assert _is_webhook_url('contoso.webhook.office.com', '/webhookb2/x')
+
+    def test_leading_dot_stops_a_lookalike(self):
+        """'notwebhook.office.com' ends with the string but is a different domain
+
+        The suffix carries a leading dot precisely so this cannot match.
+        """
+        assert not _is_webhook_url('notwebhook.office.com', '/webhookb2/x')
+
+    def test_suffix_still_requires_the_path_prefix(self):
+        """A tenant host serving something else is not a webhook URL"""
+        assert not _is_webhook_url('acme.webhook.office.com', '/some/other/path')
+
+    def test_legacy_connector_host_is_exact(self):
+        """outlook.office.com has no tenant subdomain, so it stays an exact match"""
+        assert _is_webhook_url('outlook.office.com', '/webhook/x')
+        assert not _is_webhook_url('eviloutlook.office.com', '/webhook/x')
+
+    def test_teams_token_redacted_by_default(self, basic_redactor):
+        """End to end, without --aggressive"""
+        assert TEAMS_TOKEN not in basic_redactor._redact_url_secrets_only(TEAMS)
+
+    def test_self_hosted_webhooks_are_not_guessed(self):
+        """Mattermost-style '/hooks/<token>' on an arbitrary host stays out
+
+        There is no host to match on, and treating every '/hooks/' path as a
+        credential would redact ordinary paths on unrelated servers.
+        """
+        assert not _is_webhook_url('chat.example.net', '/hooks/sometoken')
+
+
 class TestDefaultModeRedactsWebhookTokens:
     """The behaviour change: no --aggressive required"""
 


### PR DESCRIPTION
Three additions for 1.1.2, each closing a gap this session surfaced.

## 1. `--fail-on-warn` is actually a gate

It covered the root-tag check and nothing else. Measured before the change:

```
--fail-on-warn      exit=0
[!] 1 unrecognised high-entropy value(s) retained. Review before sharing:
    - pfsense/installedpackages/mycustompkg/config/blob
```

The flag is set, the tool says review this, **the build goes green** — and
`docs/use-cases.md` recommends this flag for CI.

It now fails when high-entropy values are retained, **including under
`--dry-run`**, which is the natural shape for CI and was the one mode that could
not report a problem. The message names the count and points at `--aggressive`,
because a CI failure is only useful if it says what to do next.

Output is still written when the gate fails: the retained values were reported,
not leaked, and the operator needs the file to review those paths.

| Flags | Before | After |
|---|:--:|:--:|
| *(none)* | 0 | 0 |
| `--fail-on-warn` | 0 | **1** |
| `--dry-run --fail-on-warn` | 0 | **1** |
| `--aggressive --fail-on-warn` | 0 | 0 |

## 2. Microsoft Teams webhooks

Teams puts the tenant in a subdomain, so it cannot use the exact-host rule the
other providers do. Matched on the suffix `.webhook.office.com` — **with the
leading dot**, which is what stops `notwebhook.office.com` qualifying — and the
path prefix is still required.

Suffix matching is the looser rule and the easier one to get wrong, so it lives
in its own list rather than loosening the whole set. The legacy
`outlook.office.com` connector stays an exact match.

**Mattermost and friends are deliberately absent.** Their webhooks sit at
`/hooks/<token>` on whatever host the operator chose, so there is nothing to
match on, and treating every `/hooks/` path as a credential would redact
ordinary paths on unrelated servers. Those still need `--aggressive`.

## 3. Free-text attributes under `--redact-descriptions`

Attributes *named* for a secret were already redacted. These are the ones whose
name says nothing — `note`, `comment`, `label` — where a PIN or a circuit
reference sits inside a sentence and no pattern finds it, so the value goes
wholesale.

Opt-in rather than part of `--aggressive`, matching how description *elements*
already behave: a note is often the most useful thing in a config to whoever is
reading it. Structural attributes are untouched, and a test pins that —
redacting `version` or `interface` would break the reader's ability to follow
the config.

**This closes the last genuine miss in the canary corpus: 42/46 → 43/46** with
the flag. The remaining three are two corpus artefacts and one deliberate
choice, so that is as far as the corpus goes without redacting things that are
not secrets. `docs/benchmark.md` and the README are updated accordingly.

## Verification

- 683 passed / 684 collected (+28 new), **reference snapshots unchanged** —
  none of the three fires on the sample configs
- `pylint` exits 0 both configs; flake8 C901 and `check_structure.py` clean
- `twine check` PASSED on wheel and sdist
- Corpus verified at 42/46 default and 43/46 with `--redact-descriptions`
- Lookalike hosts confirmed blocked: `notwebhook.office.com`,
  `eviloutlook.office.com`, `hooks.slack.com.evil.example`
