### PR TITLE
Resolve certificate references, and measure the corpus bias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,82 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0][] - 2026-07-28
+
+Three changes to how coverage is decided and measured. Two close gaps the canary
+corpus had been reporting since it was published; the third replaces the
+benchmark's written admission of bias with a measurement of it.
+
+Against the 46-secret canary corpus, `--aggressive` now catches 44 where 1.1.2
+caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
+
+### Security
+- **FIX**: A short value in a certificate-named element was kept on the strength
+  of its length alone. Under 50 characters and without a PEM header, it was
+  assumed to be a `refid` reference rather than key material.
+
+  References are worth keeping: they are not secret, and they let a reader
+  follow the structure of the config. But length is a proxy for meaning, so
+  anything short enough was kept whatever it actually was. `<ha_certificates>`
+  and `<ssloffloadcert>` were the two canary markers this let through.
+
+  The config already declares which references exist. Every `<refid>` in the
+  file is now collected before redaction starts, and a short value in a
+  certificate-named element is kept only if it resolves against that list.
+  Values resolving to nothing are redacted as secrets. Where a value carries
+  several references, as HAProxy's can, all of them must resolve: a partial
+  match means the value is not purely a reference list.
+
+  A config declaring no `<refid>` at all therefore loses its short certificate
+  values. That is deliberate, and follows the threat model: absent evidence that
+  a value is a reference, treat it as a secret.
+
+  Elements that hold certificate material directly (`<crt>`, `<cert>`,
+  `<public-key>`) are untouched by this. A short value in one of those is a
+  truncated key, not a reference, so resolving it would answer the wrong
+  question.
+
+- **FIX**: `--fail-on-warn` could not see key material in an XML attribute.
+  `SENSITIVE_ATTR_PATTERN` matches an attribute's *name*, so a blob sitting in
+  an attribute named something unremarkable was neither redacted nor counted
+  among the retained high-entropy values the gate reads. A CI check passed on a
+  file whose own output had never mentioned it.
+
+  Attribute values are now entropy-checked the same way element values have
+  been: reported for review by default, with the attribute named in the path
+  (`telemetry[@endpoint_id]`), and redacted under `--aggressive`.
+
+  Reported rather than redacted by default because no pfSense config examined in
+  testing uses XML attributes at all. This covers third-party packages rather
+  than an observed leak, and rewriting values by default on that evidence would
+  over-redact for everyone.
+
+  This does **not** close the `config_note[@note]` canary, and is not meant to.
+  That marker is prose, and the entropy heuristic requires 32 or more characters
+  with no spaces. `--redact-descriptions` is what covers it, as it has since
+  1.1.2.
+
+### Changed
+- Redacting an already-redacted file is now a no-op for certificate elements.
+  Without the placeholder check added here, `[REDACTED_CERT_OR_KEY]` failed to
+  resolve as a reference on a second pass and degraded to the less informative
+  `[REDACTED]`.
+
+### Documentation
+- `docs/benchmark.md` now reports where the corpus came from as a measurement
+  rather than a caveat. Every released version was re-run against it to find
+  which release first caught each marker: 15 were already caught by 1.0.10, 26
+  document a gap 1.1.0 closed, and one each for 1.1.1 and 1.1.2. **31 of 46
+  markers, 67%, were planted against ground the tool did not yet hold, and none
+  of the 46 came from outside this project.** That second number is the honest
+  limit of the benchmark, and it is now stated as a number rather than a
+  disclaimer.
+- `tests/corpus/canary-corpus.xml` is frozen at 46 markers, enforced by test. It
+  is the file the two comparison tools were scored against, and that table stops
+  meaning anything the moment its denominator moves.
+- New `tests/corpus/canary-corpus-supplementary.xml` for markers added since,
+  scored separately and with no known survivors. Contributed markers go here.
+
 ## [1.1.2][] - 2026-07-28
 
 ### Security
@@ -505,6 +581,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.2.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.0
 [1.1.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.2
 [1.1.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.1
 [1.1.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.0

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ Measured against a 46-secret canary corpus that ships with the repository:
 
 | Tool | Caught |
 | --- | --- |
-| **pfsense-redactor** | **42 / 46** (43 with `--redact-descriptions`) |
+| **pfsense-redactor** | **44 / 46** (45 with `--redact-descriptions`) |
 | ForesightCyber Config Anonymizer | 17 / 46 |
 | netgate-xlsx | 11 / 46 |
 
-The corpus was built alongside this tool, which biases it. The four misses are
-documented rather than hidden. Run it yourself:
+The corpus was built alongside this tool, which biases it. Every released
+version was re-run against it to measure by how much: 31 of the 46 markers were
+planted against gaps this tool had, and none came from outside the project. Both
+misses are documented rather than hidden. Run it yourself:
 
 ```bash
 pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -15,60 +15,88 @@ than take them on trust.
 
 | Tool | Caught | Date tested |
 | --- | --- | --- |
-| **pfsense-redactor** | **42 / 46** (43 / 46 with `--redact-descriptions`) | 2026-07-28 |
+| **pfsense-redactor 1.2.0** | **44 / 46** (45 / 46 with `--redact-descriptions`) | 2026-07-28 |
 | ForesightCyber pfSense Config Anonymizer | 17 / 46 | 2026-07-28 |
 | netgate-xlsx | 11 / 46 | 2026-07-28 |
 
 Versions were not recorded for the two comparison tools; both were the current
 release at the time of testing.
 
+The corpus file has not changed since those two tools were scored against it.
+This tool's number moved because the tool changed, not because the test did.
+
 ## Read this before quoting the numbers
 
 **The corpus was built alongside pfsense-redactor.** It grew out of bug reports
-filed against this tool, and several of the 46 markers exist precisely because a
-1.0.10 or 1.1.0 release missed them. It therefore covers what this tool has been
-taught to look for, and a corpus assembled by either of the other projects would
-likely look different and score differently. That is a real selection effect,
-not a footnote.
+filed against this tool, and most of the 46 markers exist precisely because some
+earlier release missed them. That is a real selection effect, and the section
+below puts a number on it rather than leaving it as a disclaimer.
 
 **The tools do not all share the same goal.** `netgate-xlsx` is oriented toward
 exporting configuration to a spreadsheet for review rather than sanitising it
 for sharing, so scoring it on secret coverage measures something it does not set
 out to do. Treat its number as context, not a verdict.
 
-**A high score is not a guarantee.** 42 / 46 on a corpus this tool was developed
+**A high score is not a guarantee.** 44 / 46 on a corpus this tool was developed
 against says more about regression coverage than about an unseen configuration.
 Always read the output before sharing it. See
 [verifying output](verifying-output.md).
 
+## How biased is this corpus, exactly
+
+Every released version was re-run against the corpus to find out. A marker's
+origin is the release that first caught it, which is a measurement rather than a
+recollection:
+
+| Origin | Markers | What it measures |
+| --- | --: | --- |
+| Already caught by 1.0.10 | 15 | Coverage the tool had before the corpus existed |
+| First caught in 1.1.0 | 26 | A gap 1.0.10 had |
+| First caught in 1.1.1 | 1 | A gap 1.1.0 had |
+| First caught in 1.1.2 | 1 | A gap 1.1.1 had |
+| First caught in 1.2.0 | 2 | A gap 1.1.2 had |
+| Still surviving | 1 | Deliberate; see below |
+| **Contributed from outside this project** | **0** | |
+
+So **31 of 46 markers, 67%, were planted against ground this tool did not yet
+hold**, and 30 of those have since been closed. That is what the corpus is good
+at: it measures regression discipline, and it demonstrably drove four releases.
+
+**None of the 46 came from anyone else.** That is the honest limit of this
+benchmark and the number worth watching. A corpus assembled by someone with a
+different configuration, a different package set or a different idea of what
+counts as a secret would score differently, and nothing here can tell you by how
+much. If you have such a case, see [contributing a marker](#contributing-a-marker).
+
 ## What pfsense-redactor does not catch
 
-Four markers survive. Two are artefacts of how the corpus is written rather than
-gaps, which matters when comparing the columns:
+Two markers survive `--aggressive`:
 
 | Marker | Element | Why it survives |
 | --- | --- | --- |
-| `CANARY_HAPROXYCERTS` | `config/ha_certificates` | **Corpus artefact.** The value is a short literal. Short values in certificate-named elements are deliberately preserved as *references* (a `certref`, a key id), because they help a reader understand config structure and are not key material. With real PEM or base64 content the same element redacts to `[REDACTED_CERT_OR_KEY]`. |
-| `CANARY_SSLOFFLOAD` | `config/ssloffloadcert` | Same. |
 | `CANARY_WGPUB` | `item/publickey` | **Deliberate.** A WireGuard *public* key is not a secret; it is in `SECRET_TAG_DENYLIST`. It is identifying, so redact it with `--aggressive` if that matters to you. |
-| `CANARY_ATTR_PLAIN` | `config_note[@note]` | **Caught with `--redact-descriptions`** (since 1.1.2), which now covers free-text attributes as well as elements. Not caught by default, because a note is often the most useful thing in a config to whoever is reading it. No other tool in this comparison caught it in any mode. |
+| `CANARY_ATTR_PLAIN` | `config_note[@note]` | **Caught with `--redact-descriptions`** (since 1.1.2), which covers free-text attributes as well as elements. Not caught by default, because a note is often the most useful thing in a config to whoever is reading it. No other tool in this comparison caught it in any mode. |
 
-`netgate-xlsx` scores a pass on the two HAProxy rows because it redacts by
-element name regardless of content, which also removes the short references.
-Whether that is better depends on whether you would rather lose the reference or
-keep it.
+### The two that were closed in 1.2.0
 
-To confirm the HAProxy rows are content-dependent rather than a blind spot:
+`config/ha_certificates` and `config/ssloffloadcert` survived until 1.2.0, and
+the reason is worth recording because the fix was not "add another element
+name".
 
-```bash
-printf '%s\n' \
-  '<pfsense><installedpackages><p><config>' \
-  '<ha_certificates>MIIDXTCCAkWgAwIBAgIJAKL0UG+mRkSPMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFV</ha_certificates>' \
-  '</config></p></installedpackages></pfsense>' > /tmp/cert-probe.xml
+A short value in a certificate-named element used to be kept on the strength of
+its length: under 50 characters and without a PEM header, it was assumed to be a
+`refid` reference rather than key material, and references are useful to keep
+because they let a reader follow the structure. That is a proxy for meaning, and
+anything short enough sailed through.
 
-pfsense-redactor /tmp/cert-probe.xml --stdout
-# <ha_certificates>[REDACTED_CERT_OR_KEY]</ha_certificates>
-```
+Since 1.2.0 the value is resolved against the `<refid>` elements the config
+actually declares. A reference that resolves is still kept. One that resolves to
+nothing is redacted, because nothing in the file accounts for it. A config
+carrying no `<refid>` at all therefore loses its short certificate values, which
+is over-redaction in the safe direction.
+
+`netgate-xlsx` also scores a pass on these two rows, by redacting on element
+name regardless of content, which removes the resolvable references as well.
 
 ## Reproducing this
 
@@ -77,79 +105,117 @@ pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
   | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
 ```
 
-Every marker printed is one that survived. Expect exactly four:
+Every marker printed is one that survived. Expect exactly two:
 
 ```
 CANARY_ATTR_PLAIN
-CANARY_HAPROXYCERTS
-CANARY_SSLOFFLOAD
 CANARY_WGPUB
 ```
 
-Add `--redact-descriptions` and `CANARY_ATTR_PLAIN` goes too, leaving three.
+Add `--redact-descriptions` and `CANARY_ATTR_PLAIN` goes too, leaving one.
 
 Run the same file through any other tool and count its survivors the same way.
+
+## Contributing a marker
+
+The gap in this benchmark is outside input, so a marker that survives is more
+useful to this project than one that does not.
+
+New markers go in `tests/corpus/canary-corpus-supplementary.xml`, never in
+`canary-corpus.xml`. The frozen corpus is what the other two tools were scored
+against, and that table stops meaning anything the moment its denominator moves.
+The supplementary corpus is scored separately and has no known survivors, so
+anything surviving it is a bug.
+
+Use a synthetic value, a unique `CANARY_*` marker, the reserved `.example` TLD
+(RFC 2606) and documentation address ranges. A note on where the pattern comes
+from is worth more than the marker itself.
 
 ## Keeping the number honest
 
 `tests/integration/test_canary_corpus.py` pins this result in CI and fails in
-both directions: a fifth marker surviving is a redaction regression, and one of
-the four disappearing means this page is out of date. A published coverage
-number that nothing enforces drifts, so it is enforced.
+both directions: a third marker surviving is a redaction regression, and one of
+the two disappearing means this page is out of date. It also pins the frozen
+corpus at exactly 46 markers, so the denominator cannot drift by accident. A
+published coverage number that nothing enforces drifts, so it is enforced.
 
 ## Full results
 
 <details>
 <summary>All 46 planted secrets</summary>
 
-| Path | Secret type | redactor 1.1.1 | ForesightCyber | netgate-xlsx |
-| --- | --- | :--: | :--: | :--: |
-| `user/bcrypt-hash` | password hash | ✅ | ✅ | ✅ |
-| `user/md5-hash` | password hash | ✅ | ❌ | ❌ |
-| `user/nt-hash` | password hash | ✅ | ❌ | ❌ |
-| `user/authorizedkeys` | SSH keys | ✅ | ✅ | ✅ |
-| `user/ipsecpsk` | per-user IPsec PSK | ✅ | ❌ | ❌ |
-| `authserver/ldap_bindpw` | LDAP bind password | ✅ | ❌ | ❌ |
-| `authserver/radius_secret` | RADIUS secret | ✅ | ❌ | ✅ |
-| `zone/radiussecret` | captive portal RADIUS | ✅ | ❌ | ❌ |
-| `snmpd/rocommunity` | SNMP community | ✅ | ✅ | ❌ |
-| `snmpd/rwcommunity` | SNMP community | ✅ | ❌ | ❌ |
-| `wpa/passphrase` | WPA PSK | ✅ | ❌ | ❌ |
-| `phase1/pre-shared-key` | IPsec PSK | ✅ | ✅ | ✅ |
-| `mobilekey/pre-shared-key` | IPsec mobile PSK | ✅ | ✅ | ✅ |
-| `phase1/eap_password` | EAP credential | ✅ | ❌ | ❌ |
-| `openvpn-client/tls` | TLS key | ✅ | ✅ | ✅ |
-| `openvpn-client/auth_pass` | VPN password | ✅ | ✅ | ❌ |
-| `openvpn-client/custom_options` | inline blob | ✅ | ❌ | ❌ |
-| `item/privatekey` | WireGuard private key | ✅ | ✅ | ❌ |
-| `item/presharedkey` | WireGuard PSK | ✅ | ❌ | ❌ |
-| `item/publickey` | WireGuard public key (deny-listed) | ❌ | ✅ | ❌ |
-| `ppp/password` | PPPoE | ✅ | ✅ | ✅ |
-| `dyndns/password` | DynDNS | ✅ | ✅ | ✅ |
-| `dyndns/updateurl` | token in query string | ✅ | ❌ | ❌ |
-| `alias/url` | licence in query string | ✅ | ✅ | ❌ |
-| `alias/detail` | credentials in free text | ✅ | ✅ | ❌ |
-| `smtp/password` | SMTP | ✅ | ✅ | ✅ |
-| `smtp/passwordagain` | SMTP duplicate field | ✅ | ❌ | ❌ |
-| `telegram/api_key` | bot token | ✅ | ❌ | ❌ |
-| `pushover/apikey` | API key | ✅ | ❌ | ❌ |
-| `pushover/userkey` | user key | ✅ | ❌ | ❌ |
-| `config/maxmind_key` | pfBlockerNG licence | ✅ | ✅ | ❌ |
-| `item/accountkey` | ACME account key | ✅ | ❌ | ❌ |
-| `a_dnsprovider/dns_cf_token` | Cloudflare token | ✅ | ❌ | ❌ |
-| `config/ha_certificates` | HAProxy certs (see above) | ❌ | ❌ | ✅ |
-| `config/ssloffloadcert` | HAProxy cert (see above) | ❌ | ❌ | ✅ |
-| `config/influx_token` | InfluxDB token | ✅ | ❌ | ❌ |
-| `config/token` | bare token | ✅ | ❌ | ❌ |
-| `config/bearer_token` | bearer token | ✅ | ❌ | ❌ |
-| `config/access_key` | S3 access key | ✅ | ❌ | ❌ |
-| `config/secret_access_key` | S3 secret | ✅ | ❌ | ❌ |
-| `config/tlspskvalue` | Zabbix PSK | ✅ | ❌ | ❌ |
-| `config/upsd_users` | NUT password | ✅ | ✅ | ❌ |
-| `config/userparams` | Zabbix script path | ✅ | ✅ | ❌ |
-| `config/webhook_url` | Slack path token | ✅ | ❌ | ❌ |
-| `config_note[@secret]` | attribute | ✅ | ❌ | ❌ |
-| `config_note[@note]` | attribute free text | ❌ | ❌ | ❌ |
-| **Total** | | **42 / 46** | **17 / 46** | **11 / 46** |
+Origin is the release that first caught the marker, measured by re-running each
+released version against this corpus.
+
+| Path | Secret type | Origin | redactor 1.2.0 | ForesightCyber | netgate-xlsx |
+| --- | --- | --- | :--: | :--: | :--: |
+| `user/bcrypt-hash` | password hash | 1.0.10 | ✅ | ✅ | ✅ |
+| `user/md5-hash` | password hash | 1.0.10 | ✅ | ❌ | ❌ |
+| `user/nt-hash` | password hash | 1.0.10 | ✅ | ❌ | ❌ |
+| `user/authorizedkeys` | SSH keys | 1.1.0 | ✅ | ✅ | ✅ |
+| `user/ipsecpsk` | per-user IPsec PSK | 1.1.0 | ✅ | ❌ | ❌ |
+| `authserver/ldap_bindpw` | LDAP bind password | 1.0.10 | ✅ | ❌ | ❌ |
+| `authserver/radius_secret` | RADIUS secret | 1.0.10 | ✅ | ❌ | ✅ |
+| `zone/radiussecret` | captive portal RADIUS | 1.1.0 | ✅ | ❌ | ❌ |
+| `snmpd/rocommunity` | SNMP community | 1.1.0 | ✅ | ✅ | ❌ |
+| `snmpd/rwcommunity` | SNMP community | 1.1.0 | ✅ | ❌ | ❌ |
+| `wpa/passphrase` | WPA PSK | 1.1.0 | ✅ | ❌ | ❌ |
+| `phase1/pre-shared-key` | IPsec PSK | 1.0.10 | ✅ | ✅ | ✅ |
+| `mobilekey/pre-shared-key` | IPsec mobile PSK | 1.0.10 | ✅ | ✅ | ✅ |
+| `phase1/eap_password` | EAP credential | 1.1.0 | ✅ | ❌ | ❌ |
+| `openvpn-client/tls` | TLS key | 1.0.10 | ✅ | ✅ | ✅ |
+| `openvpn-client/auth_pass` | VPN password | 1.1.0 | ✅ | ✅ | ❌ |
+| `openvpn-client/custom_options` | inline blob | 1.1.0 | ✅ | ❌ | ❌ |
+| `item/privatekey` | WireGuard private key | 1.0.10 | ✅ | ✅ | ❌ |
+| `item/presharedkey` | WireGuard PSK | 1.1.0 | ✅ | ❌ | ❌ |
+| `item/publickey` | WireGuard public key (deny-listed) | open | ❌ | ✅ | ❌ |
+| `ppp/password` | PPPoE | 1.0.10 | ✅ | ✅ | ✅ |
+| `dyndns/password` | DynDNS | 1.0.10 | ✅ | ✅ | ✅ |
+| `dyndns/updateurl` | token in query string | 1.1.0 | ✅ | ❌ | ❌ |
+| `alias/url` | licence in query string | 1.1.0 | ✅ | ✅ | ❌ |
+| `alias/detail` | credentials in free text | 1.1.0 | ✅ | ✅ | ❌ |
+| `smtp/password` | SMTP | 1.0.10 | ✅ | ✅ | ✅ |
+| `smtp/passwordagain` | SMTP duplicate field | 1.1.0 | ✅ | ❌ | ❌ |
+| `telegram/api_key` | bot token | 1.0.10 | ✅ | ❌ | ❌ |
+| `pushover/apikey` | API key | 1.0.10 | ✅ | ❌ | ❌ |
+| `pushover/userkey` | user key | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/maxmind_key` | pfBlockerNG licence | 1.1.0 | ✅ | ✅ | ❌ |
+| `item/accountkey` | ACME account key | 1.1.0 | ✅ | ❌ | ❌ |
+| `a_dnsprovider/dns_cf_token` | Cloudflare token | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/ha_certificates` | HAProxy certs (see above) | 1.2.0 | ✅ | ❌ | ✅ |
+| `config/ssloffloadcert` | HAProxy cert (see above) | 1.2.0 | ✅ | ❌ | ✅ |
+| `config/influx_token` | InfluxDB token | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/token` | bare token | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/bearer_token` | bearer token | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/access_key` | S3 access key | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/secret_access_key` | S3 secret | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/tlspskvalue` | Zabbix PSK | 1.1.0 | ✅ | ❌ | ❌ |
+| `config/upsd_users` | NUT password | 1.1.0 | ✅ | ✅ | ❌ |
+| `config/userparams` | Zabbix script path | 1.1.0 | ✅ | ✅ | ❌ |
+| `config/webhook_url` | Slack path token | 1.1.1 | ✅ | ❌ | ❌ |
+| `config_note[@secret]` | attribute | 1.0.10 | ✅ | ❌ | ❌ |
+| `config_note[@note]` | attribute free text | 1.1.2 | ❌ | ❌ | ❌ |
+| **Total** | | | **44 / 46** | **17 / 46** | **11 / 46** |
+
+`config_note[@note]` is marked ❌ because the headline run is `--aggressive`
+alone. 1.1.2 catches it with `--redact-descriptions`, which is the 45 / 46 in
+the results table.
 
 </details>
+
+## Supplementary corpus
+
+`tests/corpus/canary-corpus-supplementary.xml` holds markers added after the
+benchmark above was published, so that the frozen corpus keeps the denominator
+the other two tools were measured against. It has no known survivors.
+
+| Marker | Location | Added | Why |
+| --- | --- | --- | --- |
+| `CANARY_ATTR_BLOB` | `telemetry[@endpoint_id]` | 1.2.0 | Key material in an attribute whose name says nothing. `SENSITIVE_ATTR_PATTERN` matches attribute names only, so this was invisible to it and to `--fail-on-warn` alike. Now entropy-checked: reported by default, redacted under `--aggressive`. |
+
+```bash
+pfsense-redactor tests/corpus/canary-corpus-supplementary.xml --stdout --aggressive \
+  | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
+```
+
+Expect no output.

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,6 +22,46 @@ pfSense and its packages actually emit: `rocommunity`, `radiussecret`,
 `passwordagain`. A deny-list handles the false positives that creates
 (`keylen`, `certref`, `password_type`).
 
+### Certificate references are resolved, not guessed
+
+Elements named for a certificate are a special case, because they hold two quite
+different things. `<crt>` holds the material. `<ssl_ca_cert>` and HAProxy's
+`<ha_certificates>` usually hold a `refid` pointing at a certificate defined
+elsewhere in the same file, and those references are worth keeping: they are not
+secret, and they let whoever reads the config follow its structure.
+
+Telling them apart by length is the obvious approach and the wrong one. Anything
+short enough passes, whatever it actually is.
+
+Since 1.2.0 the file is scanned for every `<refid>` it declares before redaction
+starts, and a short value in a certificate-named element is kept only if it
+resolves against that list. Values that resolve to nothing are redacted. Where a
+value carries several references, as HAProxy's can, all of them have to resolve;
+a partial match means the value is not purely a reference list.
+
+A config with no `<refid>` anywhere therefore loses its short certificate
+values. That is deliberate. Absent evidence that a value is a reference, the
+threat model says treat it as a secret.
+
+### Attribute values
+
+pfSense itself does not use XML attributes, but third-party packages may, and
+the tool accepts whatever XML it is given. Attributes are handled two ways:
+
+- **By name.** An attribute named for a secret is redacted, as an element would
+  be. `--redact-descriptions` extends this to free-prose names such as `note`
+  and `descr`.
+- **By value.** Since 1.2.0, an attribute whose name says nothing but whose
+  *value* looks like key material is reported among the retained high-entropy
+  values, and redacted under `--aggressive`.
+
+The second exists because name matching cannot see a blob in an innocuously
+named attribute, so before 1.2.0 such a value was invisible to `--fail-on-warn`
+as well: a CI gate passed on a file whose own output had never mentioned it. It
+reports rather than redacts by default because no pfSense config examined in
+testing uses attributes at all, and rewriting values on that evidence would
+over-redact for everyone.
+
 Credentials embedded in URLs are handled separately:
 
 | Location | Default | `--aggressive` |

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -21,6 +21,13 @@ These are values that look like key material in elements the tool does not
 recognise, typically third-party package fields. It reports the element path
 rather than the value, so the warning is safe to paste into a ticket.
 
+Since 1.2.0 attribute values are checked the same way, and appear with the
+attribute named in brackets:
+
+```
+    - pfsense/installedpackages/mycustompkg/config/telemetry[@endpoint_id]
+```
+
 This warning is the direct answer to "what did you leave behind". Do not ignore
 it, and re-run with `--aggressive` if any path looks like it holds a secret.
 

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -194,6 +194,14 @@ SECRET_TAG_PATTERN = re.compile(
 # are useful for understanding config structure) survive intact.
 CERT_TAG_PATTERN = re.compile(r'cert(?:ificate)?s?$|ssloffload', re.IGNORECASE)
 
+# The placeholders this module writes. Recognised on the way back in so that
+# redacting an already-redacted file is a no-op: without this, the short value
+# '[REDACTED_CERT_OR_KEY]' fails to resolve as a certificate reference on a
+# second pass and degrades to the less informative '[REDACTED]'.
+REDACTION_PLACEHOLDERS: frozenset[str] = frozenset({
+    '[REDACTED]', '[REDACTED_CERT_OR_KEY]',
+})
+
 # Tags that match SECRET_TAG_PATTERN but are not secrets.
 #
 # IMPORTANT: this deny-list gates SECRET_TAG_PATTERN/CERT_TAG_PATTERN only. It
@@ -736,6 +744,14 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # can be surfaced in the summary for manual review
         self.high_entropy_paths: list[str] = []
         self._path_stack: list[str] = []
+
+        # Every <refid> defined in the config being processed, so a short value
+        # in a certificate-named element can be resolved rather than guessed at.
+        # Populated by _collect_refids before the traversal starts; empty here
+        # so redact_element stays callable on a bare element, which is how most
+        # of the unit tests drive it. An empty set resolves nothing, so those
+        # values are treated as secrets - the safe direction.
+        self.known_refids: frozenset[str] = frozenset()
 
         # Get logger instance
         self.logger = logging.getLogger('pfsense_redactor')
@@ -2245,16 +2261,81 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return True
 
-    def _looks_like_cert_material(self, text: str | None) -> bool:
-        """Whether an element's text is a certificate or key rather than a reference
+    @staticmethod
+    def _collect_refids(root: ET.Element) -> frozenset[str]:
+        """Every refid defined anywhere in the config
 
-        Short values in cert-named elements are references (a certref, a key
-        id), not the material itself, so length is what separates them absent a
-        PEM header.
+        Collected from the whole tree rather than from <cert>/<ca>/<crl> alone:
+        package certificate stores do not reliably sit where the base system
+        puts them, and a superset only ever preserves more references.
+
+        Safe to build before redaction and use after it, because <refid> is
+        matched by neither SECRET_TAG_PATTERN nor CERT_TAG_PATTERN and its
+        13-character values are under BLOB_MIN_SCAN_LENGTH. The ids survive, so
+        the references this keeps still resolve in the output.
+        """
+        return frozenset(
+            el.text.strip() for el in root.iter('refid') if el.text and el.text.strip()
+        )
+
+    def _looks_like_cert_material(self, text: str | None) -> bool:
+        """Whether an element's text is certificate or key material
+
+        Length is the test only once a PEM header has been ruled out: anything
+        longer than a reference id, in an element named for a certificate, is
+        the material itself.
         """
         if not text:
             return False
         return bool(self.PEM_MARKER.search(text)) or len(text.strip()) > self.CERT_MIN_LENGTH
+
+    def _is_known_cert_reference(self, text: str) -> bool:
+        """Whether a short value in a cert-named element is a reference we can resolve
+
+        The config states which references exist, so resolve against it rather
+        than inferring from length. HAProxy's ha_certificates can carry several,
+        so every token has to resolve: a partial match means the value is not
+        purely a reference list, and the whole of it is then suspect.
+        """
+        tokens = [t for t in re.split(r'[,\s]+', text.strip()) if t]
+        if not tokens:
+            return False
+        return all(token in self.known_refids for token in tokens)
+
+    def _names_a_cert_store(self, tag: str, tag_base: str) -> bool:
+        """Whether the tag names a certificate reference or store
+
+        CERT_KEY_ELEMENTS (<crt>, <cert>, <public-key>) carry the material
+        itself, so a short value in one of those is a truncated key or one of
+        our own placeholders - never a refid, and not something to resolve.
+        """
+        if tag in self.cert_key_elements:
+            return False
+        if tag_base in self.cert_key_elements:
+            return False
+        return bool(CERT_TAG_PATTERN.search(tag) or CERT_TAG_PATTERN.search(tag_base))
+
+    def _holds_unresolvable_cert_reference(
+        self, tag: str, tag_base: str, element: ET.Element
+    ) -> bool:
+        """Whether a cert-named element holds a short value the config cannot account for"""
+        if not self._names_a_cert_store(tag, tag_base):
+            return False
+
+        # Containers such as <ha_certificates><item>... have only the newline
+        # before their first child as text; treating that as a value would
+        # redact the wrapper and swallow the children's indentation.
+        if len(element) > 0:
+            return False
+
+        text = (element.text or '').strip()
+        if not text:
+            return False
+
+        if text in REDACTION_PLACEHOLDERS:
+            return False
+
+        return not self._is_known_cert_reference(text)
 
     def _redact_cert_key_element(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Redact certificate/key elements. Returns True if this is a cert/key element."""
@@ -2263,6 +2344,14 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         if self._looks_like_cert_material(element.text):
             self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+            return True
+
+        # Short, no PEM header: either a reference the config defines, or a
+        # secret sitting in a cert-named element. Redacted as a secret rather
+        # than as cert material, because by this point it demonstrably is not
+        # cert material.
+        if self._holds_unresolvable_cert_reference(tag, tag_base, element):
+            self._redact_text_and_track(element, 'Secret')
 
         return True
 
@@ -2289,14 +2378,55 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return False
         return attr.lower() in DESCRIPTION_ATTRIBUTES
 
-    def _redact_sensitive_attributes(self, element: ET.Element) -> None:
-        """Redact attributes whose name says the value should not be shared"""
+    def _replace_attribute(self, element: ET.Element, attr: str, category: str = 'Secret',
+                           placeholder: str = '[REDACTED]') -> None:
+        """Swap an attribute's value for a placeholder and count it"""
+        original = element.attrib[attr]
+        element.attrib[attr] = placeholder
+
+        if category == 'Cert/Key':
+            self.stats['certs_redacted'] += 1
+        else:
+            self.stats['secrets_redacted'] += 1
+
+        self._add_sample(category, original, placeholder)
+
+    def _account_for_attribute_blob(self, element: ET.Element, tag: str, attr: str) -> None:
+        """Redact or report key material in an attribute whose name says nothing
+
+        Reported rather than redacted by default. No pfSense config examined in
+        testing uses XML attributes at all, so this guards against third-party
+        packages rather than an observed leak, and rewriting values on that
+        basis would over-redact for everyone. Reporting costs nothing and is
+        what the element path has always done.
+        """
+        if not self._is_high_entropy_value(element.attrib[attr]):
+            return
+
+        if self.aggressive:
+            self._replace_attribute(element, attr, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+            return
+
+        self.stats['high_entropy_retained'] += 1
+        path = f"{'/'.join([*self._path_stack, tag])}[@{attr}]"
+        if path not in self.high_entropy_paths:
+            self.high_entropy_paths.append(path)
+
+    def _redact_sensitive_attributes(self, element: ET.Element, tag: str) -> None:
+        """Handle attribute values: redact by name, and account for blobs in the rest
+
+        SENSITIVE_ATTR_PATTERN only ever sees an attribute's *name*. A value
+        that is plainly key material, sitting in an attribute named something
+        unremarkable, used to be invisible to the redactor and to --fail-on-warn
+        alike - so a CI gate passed on a file whose own output never mentioned
+        it. Elements have been handled this way since _redact_unknown_blob_element;
+        this gives attributes the same treatment.
+        """
         for attr in list(element.attrib.keys()):
             if self._should_redact_attribute(attr):
-                original = element.attrib[attr]
-                element.attrib[attr] = '[REDACTED]'
-                self.stats['secrets_redacted'] += 1
-                self._add_sample('Secret', original, '[REDACTED]')
+                self._replace_attribute(element, attr)
+                continue
+            self._account_for_attribute_blob(element, tag, attr)
 
     def _redact_text_aggressive(
         self, element: ET.Element, text_already_processed: bool, redact_ips: bool, redact_domains: bool
@@ -2390,8 +2520,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             tag, tag_base, element, redact_ips, redact_domains
         )
 
-        # Redact attributes with sensitive names
-        self._redact_sensitive_attributes(element)
+        # Redact attributes with sensitive names, and account for high-entropy
+        # values in the rest. Runs before the aggressive text pass below, which
+        # would otherwise rewrite the values this needs to see.
+        self._redact_sensitive_attributes(element, tag)
 
         # Recursively process child elements
         self._path_stack.append(tag)
@@ -2499,6 +2631,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             if not dry_run and not stdout_mode:
                 self.logger.info("[+] Parsing XML configuration from: %s", input_file)
                 self.logger.info("[+] Redacting sensitive information...")
+
+            # Before the traversal, so certificate references can be resolved
+            # against what the config actually defines
+            self.known_refids = self._collect_refids(root)
 
             self.redact_element(root, redact_ips, redact_domains)
 

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -2275,7 +2275,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         the references this keeps still resolve in the output.
         """
         return frozenset(
-            el.text.strip() for el in root.iter('refid') if el.text and el.text.strip()
+            refid for el in root.iter('refid') if (refid := (el.text or '').strip())
         )
 
     def _looks_like_cert_material(self, text: str | None) -> bool:
@@ -2296,8 +2296,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         than inferring from length. HAProxy's ha_certificates can carry several,
         so every token has to resolve: a partial match means the value is not
         purely a reference list, and the whole of it is then suspect.
+
+        Expects text already stripped by the caller.
         """
-        tokens = [t for t in re.split(r'[,\s]+', text.strip()) if t]
+        tokens = [t for t in re.split(r'[,\s]+', text) if t]
         if not tokens:
             return False
         return all(token in self.known_refids for token in tokens)
@@ -2315,9 +2317,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return False
         return bool(CERT_TAG_PATTERN.search(tag) or CERT_TAG_PATTERN.search(tag_base))
 
-    def _holds_unresolvable_cert_reference(
-        self, tag: str, tag_base: str, element: ET.Element
-    ) -> bool:
+    def _holds_unresolvable_cert_reference(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Whether a cert-named element holds a short value the config cannot account for"""
         if not self._names_a_cert_store(tag, tag_base):
             return False
@@ -2325,6 +2325,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # Containers such as <ha_certificates><item>... have only the newline
         # before their first child as text; treating that as a value would
         # redact the wrapper and swallow the children's indentation.
+        #
+        # len() rather than a truthiness test on purpose: ElementTree elements
+        # with no children are falsy, so 'if element' asks a different question
+        # and gets the wrong answer.
         if len(element) > 0:
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.1.2"
+version = "1.2.0"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/corpus/canary-corpus-supplementary.xml
+++ b/tests/corpus/canary-corpus-supplementary.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+  Supplementary canary corpus: markers added after the benchmark was published.
+
+  tests/corpus/canary-corpus.xml is frozen at 46 markers. It is the file
+  ForesightCyber and netgate-xlsx were scored against, and that comparison is
+  only valid for as long as it does not move, so new markers go here instead.
+  This file is scored on its own and never folded into the published table.
+
+  Same rules as the frozen corpus: every value is synthetic, domains use the
+  reserved .example TLD (RFC 2606), addresses are RFC 1918 or RFC 5737
+  documentation ranges. Nothing here is or ever was real.
+
+  Contributions are welcome here, particularly ones this project would not have
+  thought of. Of the frozen 46, none came from outside, and docs/benchmark.md
+  says so plainly because it is the honest limit of the benchmark. A marker that
+  survives is worth more to this project than one that does not.
+
+  Marker origins are recorded in docs/benchmark.md.
+
+  Note for editors: XML forbids a double hyphen inside a comment, so flag names
+  are written without their leading dashes here.
+-->
+<pfsense>
+  <version>23.09</version>
+
+  <!--
+    CANARY_ATTR_BLOB: key material in an attribute whose name says nothing.
+
+    SENSITIVE_ATTR_PATTERN matches attribute names, so this is invisible to it.
+    Since 1.2.0 the value is entropy-checked instead: reported for review by
+    default, and redacted under 'aggressive'.
+
+    The marker is padded out to be base64-shaped, 32+ characters and free of
+    spaces, because that is what the heuristic requires. Prose in an attribute
+    is a different problem, covered by the 'redact-descriptions' flag, and the
+    frozen corpus already carries a marker for it.
+  -->
+  <installedpackages>
+    <mycustompkg><config>
+      <telemetry endpoint_id="CANARY_ATTR_BLOBaG7kQ2xZpR9vN4tY8wL3mB6dF1sJ0c">enabled</telemetry>
+    </config></mycustompkg>
+  </installedpackages>
+</pfsense>

--- a/tests/integration/test_canary_corpus.py
+++ b/tests/integration/test_canary_corpus.py
@@ -5,11 +5,16 @@ tests/corpus/canary-corpus.xml carries 46 planted secrets, each a unique
 CANARY_* marker. A marker surviving redaction is a leak, so the survivors are
 the score, and docs/benchmark.md publishes it.
 
+That file is frozen. It is what ForesightCyber and netgate-xlsx were scored
+against, and the published comparison holds only while the denominator does not
+move, so markers added later live in canary-corpus-supplementary.xml and are
+scored separately.
+
 A published number that nothing enforces drifts. These tests fail in both
 directions on purpose:
 
-- a fifth marker surviving is a redaction regression
-- one of the four disappearing means the benchmark doc is now stale
+- a third marker surviving is a redaction regression
+- one of the two disappearing means the benchmark doc is now stale
 
 Either way the failure names which marker moved, so the fix is obvious.
 """
@@ -22,43 +27,47 @@ import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 CORPUS = PROJECT_ROOT / 'tests' / 'corpus' / 'canary-corpus.xml'
+SUPPLEMENTARY = PROJECT_ROOT / 'tests' / 'corpus' / 'canary-corpus-supplementary.xml'
 CANARY_RE = re.compile(r'CANARY_[A-Z0-9_]+')
 
 TOTAL_CANARIES = 46
 
-# The four survivors, and why each is not simply a bug. Kept here rather than
-# as a bare set so a failure explains itself without opening the benchmark doc.
+# The two survivors, and why neither is simply a bug. Kept here rather than as
+# a bare set so a failure explains itself without opening the benchmark doc.
 EXPECTED_SURVIVORS = {
-    'CANARY_HAPROXYCERTS': (
-        'corpus artefact - the marker is a short literal, and short values in '
-        'cert-named elements are preserved as references. Real PEM redacts.'
-    ),
-    'CANARY_SSLOFFLOAD': (
-        'corpus artefact - same as CANARY_HAPROXYCERTS.'
-    ),
     'CANARY_WGPUB': (
         'deliberate - a WireGuard *public* key is not a secret, and is in '
         'SECRET_TAG_DENYLIST.'
     ),
     'CANARY_ATTR_PLAIN': (
-        'known limitation - free text in an attribute whose name is not '
-        'sensitive, so SENSITIVE_ATTR_PATTERN does not match it.'
+        'known limitation in this mode - free text in an attribute whose name '
+        'is not sensitive. Closed by --redact-descriptions.'
     ),
 }
 
+# Closed in 1.2.0 by resolving certificate references against the <refid>
+# elements the config declares, rather than assuming any short value in a
+# cert-named element is a reference. Listed so a regression names itself.
+CLOSED_IN_1_2_0 = ('CANARY_HAPROXYCERTS', 'CANARY_SSLOFFLOAD')
 
-def redact_corpus(*flags):
-    """Redact the corpus to stdout, returning the whole CompletedProcess
+
+def redact_file(path, *flags):
+    """Redact a corpus file to stdout, returning the whole CompletedProcess
 
     The full result rather than just stdout, because the retained-value warning
     these tests also check is written to stderr.
     """
     result = subprocess.run(
-        [sys.executable, '-m', 'pfsense_redactor', str(CORPUS), '--stdout', *flags],
+        [sys.executable, '-m', 'pfsense_redactor', str(path), '--stdout', *flags],
         capture_output=True, text=True, cwd=str(PROJECT_ROOT), check=False
     )
     assert result.returncode == 0, f'redaction failed: {result.stderr}'
     return result
+
+
+def redact_corpus(*flags):
+    """Redact the frozen corpus"""
+    return redact_file(CORPUS, *flags)
 
 
 def survivors(result):
@@ -88,7 +97,12 @@ class TestCorpusIntegrity:
         assert CORPUS.exists(), f'{CORPUS} is missing'
 
     def test_planted_secret_count(self):
-        """The denominator in the published score"""
+        """The denominator in the published score
+
+        Frozen. The other two tools in docs/benchmark.md were scored against
+        this exact file, and that table stops meaning anything the moment the
+        denominator moves. New markers belong in the supplementary corpus.
+        """
         planted = set(CANARY_RE.findall(CORPUS.read_text(encoding='utf-8')))
 
         assert len(planted) == TOTAL_CANARIES
@@ -105,7 +119,7 @@ class TestCorpusIntegrity:
 
 
 class TestAggressiveScore:
-    """The published headline: 42 of 46 under --aggressive"""
+    """The published headline: 44 of 46 under --aggressive"""
 
     def test_exactly_the_known_survivors(self, aggressive_run):
         """Fails in both directions - regression, or a stale benchmark doc"""
@@ -123,31 +137,39 @@ class TestAggressiveScore:
             'docs/benchmark.md and EXPECTED_SURVIVORS: ' + ', '.join(sorted(fixed))
         )
 
-    def test_published_score_is_42_of_46(self, aggressive_run):
+    def test_published_score_is_44_of_46(self, aggressive_run):
         """The count of secrets caught, which docs/benchmark.md publishes"""
         caught = TOTAL_CANARIES - len(survivors(aggressive_run))
 
-        assert caught == 42
+        assert caught == 44
 
     @pytest.mark.parametrize('marker', sorted(EXPECTED_SURVIVORS))
     def test_each_survivor_is_accounted_for(self, marker):
         """Every survivor has a recorded reason, so none is an unexplained miss"""
         assert EXPECTED_SURVIVORS[marker].strip()
 
+    @pytest.mark.parametrize('marker', CLOSED_IN_1_2_0)
+    def test_certificate_references_stay_closed(self, aggressive_run, marker):
+        """These two were survivors until reference resolution landed
+
+        Named individually so a regression in _is_known_cert_reference points
+        at itself rather than at a count that moved.
+        """
+        assert marker not in survivors(aggressive_run)
+
 
 class TestDescriptionsRaiseTheScore:
     """--redact-descriptions closes the one survivor that is a real gap
 
-    The other three are a deliberate choice and two corpus artefacts, so this
-    is as far as the corpus can be taken without redacting things that are not
-    secrets.
+    The other is a deliberate choice, so this is as far as the corpus can be
+    taken without redacting things that are not secrets.
     """
 
-    def test_score_is_43_of_46(self):
+    def test_score_is_45_of_46(self):
         """The number docs/benchmark.md publishes for this mode"""
         left = survivors(redact_corpus('--aggressive', '--redact-descriptions'))
 
-        assert TOTAL_CANARIES - len(left) == 43
+        assert TOTAL_CANARIES - len(left) == 45
 
     def test_it_is_the_attribute_marker_that_moves(self):
         """Specifically the free-text attribute, not something else"""
@@ -179,6 +201,45 @@ class TestDefaultModeIsNotWorse:
         caught = TOTAL_CANARIES - len(survivors(default_run))
 
         assert caught >= 35, f'default mode caught only {caught}/{TOTAL_CANARIES}'
+
+
+class TestSupplementaryCorpus:
+    """Markers added after the benchmark froze, scored on their own
+
+    Kept out of canary-corpus.xml so the published three-tool comparison keeps
+    its denominator. Nothing here has been run against the other two tools, so
+    nothing here belongs in that table.
+    """
+
+    def test_it_exists_and_is_shipped(self):
+        """MANIFEST.in ships tests/**.xml, so this reaches the sdist"""
+        assert SUPPLEMENTARY.exists(), f'{SUPPLEMENTARY} is missing'
+
+    def test_markers_do_not_overlap_the_frozen_set(self):
+        """A duplicated marker would be scored twice and mean neither thing"""
+        frozen = set(CANARY_RE.findall(CORPUS.read_text(encoding='utf-8')))
+        extra = set(CANARY_RE.findall(SUPPLEMENTARY.read_text(encoding='utf-8')))
+
+        assert not (frozen & extra), (
+            'these appear in both corpora: ' + ', '.join(sorted(frozen & extra))
+        )
+
+    def test_attribute_blob_is_reported_by_default(self):
+        """The 1.2.0 addition: key material in an ordinarily-named attribute
+
+        Retained by default and named in the warning, which is what
+        --fail-on-warn gates on. Reporting rather than redacting is deliberate;
+        see tests/unit/test_attribute_entropy.py.
+        """
+        result = redact_file(SUPPLEMENTARY)
+
+        assert 'telemetry[@endpoint_id]' in result.stderr
+
+    def test_aggressive_catches_everything_here(self):
+        """No known survivors in this corpus, so any survivor is a regression"""
+        left = survivors(redact_file(SUPPLEMENTARY, '--aggressive'))
+
+        assert not left, 'survived --aggressive: ' + ', '.join(sorted(left))
 
 
 class TestRetainedValuesAreReported:

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.1.2 -->
+  <!-- Redacted using pfsense-redactor v1.2.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_attribute_entropy.py
+++ b/tests/unit/test_attribute_entropy.py
@@ -79,6 +79,7 @@ class TestAggressiveRedacts:
     """The documented remedy works for attributes as it does for elements"""
 
     def test_value_is_replaced(self):
+        """The blob does not survive the mode that exists to remove it"""
         _, out = redact(aggressive=True)
 
         assert BLOB not in out
@@ -96,6 +97,7 @@ class TestAggressiveRedacts:
         assert redactor.stats['high_entropy_retained'] == 0
 
     def test_it_is_counted_as_a_redaction(self):
+        """A redaction missing from the summary is invisible to whoever reads it"""
         redactor, _ = redact(aggressive=True)
 
         assert redactor.stats['certs_redacted'] >= 1

--- a/tests/unit/test_attribute_entropy.py
+++ b/tests/unit/test_attribute_entropy.py
@@ -1,0 +1,158 @@
+"""
+Tests for high-entropy values in attributes reaching the retained-value report.
+
+SENSITIVE_ATTR_PATTERN matches on an attribute's *name*. Key material sitting in
+an attribute named something unremarkable therefore used to be invisible twice
+over: not redacted, and not counted among the retained high-entropy values that
+--fail-on-warn gates on. A CI check passed on a file whose own output had never
+mentioned it.
+
+Reported rather than redacted by default, deliberately. No pfSense config
+examined in testing uses XML attributes at all, so this covers third-party
+packages rather than an observed leak, and rewriting values by default on that
+evidence would over-redact for everyone. --aggressive still redacts.
+
+This does not close CANARY_ATTR_PLAIN, and is not meant to. That marker is prose
+in a note attribute; the entropy heuristic requires 32+ characters with no
+spaces, so it cannot match. --redact-descriptions is what covers it.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor
+
+# 62 base64-shaped characters in an attribute whose name says nothing
+BLOB = 'MIIDXTCCAkWgAwIBAgIJAKL0UG6mRkSPMA0GCSqGSIb3DQEBCwUAMEUxCzAJBg'
+DOC = f'<pfsense><installedpackages><p><thing marker="{BLOB}">x</thing></p></installedpackages></pfsense>'
+
+
+def redact(xml=DOC, **kwargs):
+    """Redact a document and return (redactor, serialised output)"""
+    redactor = PfSenseRedactor(**kwargs)
+    root = ET.fromstring(xml)
+    redactor.redact_element(root)
+    return redactor, ET.tostring(root, encoding='unicode')
+
+
+class TestDefaultModeReports:
+    """The gap this closes: accounted for, not silently kept"""
+
+    def test_value_is_retained(self):
+        """Default mode does not rewrite it"""
+        _, out = redact()
+
+        assert BLOB in out
+
+    def test_it_is_counted(self):
+        """Which is what --fail-on-warn gates on"""
+        redactor, _ = redact()
+
+        assert redactor.stats['high_entropy_retained'] == 1
+
+    def test_the_path_names_the_attribute(self):
+        """'element[@attr]' - the notation docs/benchmark.md already uses"""
+        redactor, _ = redact()
+
+        assert redactor.high_entropy_paths == ['pfsense/installedpackages/p/thing[@marker]']
+
+    def test_ordinary_values_are_not_reported(self):
+        """A short or prose-shaped value is not key material"""
+        redactor, _ = redact(
+            '<pfsense><a><thing note="WAN uplink, second floor" id="7">x</thing></a></pfsense>'
+        )
+
+        assert redactor.stats['high_entropy_retained'] == 0
+
+    def test_prose_long_enough_to_qualify_on_length_is_still_ignored(self):
+        """Spaces disqualify a value, so notes do not become false positives
+
+        This is also why the heuristic cannot close CANARY_ATTR_PLAIN.
+        """
+        prose = 'ISP support line pin is on the card in the rack cabinet'
+        redactor, _ = redact(f'<pfsense><a><thing note="{prose}">x</thing></a></pfsense>')
+
+        assert redactor.stats['high_entropy_retained'] == 0
+
+
+class TestAggressiveRedacts:
+    """The documented remedy works for attributes as it does for elements"""
+
+    def test_value_is_replaced(self):
+        _, out = redact(aggressive=True)
+
+        assert BLOB not in out
+
+    def test_placeholder_matches_the_element_path(self):
+        """_redact_unknown_blob_element uses the same one for the same reason"""
+        _, out = redact(aggressive=True)
+
+        assert '[REDACTED_CERT_OR_KEY]' in out
+
+    def test_nothing_is_left_to_report(self):
+        """Redacted values are not also counted as retained"""
+        redactor, _ = redact(aggressive=True)
+
+        assert redactor.stats['high_entropy_retained'] == 0
+
+    def test_it_is_counted_as_a_redaction(self):
+        redactor, _ = redact(aggressive=True)
+
+        assert redactor.stats['certs_redacted'] >= 1
+
+
+class TestNameMatchingStillWins:
+    """The pre-existing behaviour must not be disturbed"""
+
+    def test_secret_named_attribute_is_still_redacted_by_name(self):
+        """Short enough that entropy would never have caught it"""
+        _, out = redact('<pfsense><a><thing password="hunter2">x</thing></a></pfsense>')
+
+        assert 'hunter2' not in out
+        assert '[REDACTED]' in out
+
+    def test_a_name_match_is_not_also_reported_as_retained(self):
+        """It was redacted, so there is nothing left to review"""
+        redactor, _ = redact(f'<pfsense><a><thing api_key="{BLOB}">x</thing></a></pfsense>')
+
+        assert redactor.stats['high_entropy_retained'] == 0
+        assert redactor.stats['secrets_redacted'] >= 1
+
+    @pytest.mark.parametrize('attr', ['descr', 'note', 'comment'])
+    def test_description_attributes_under_the_flag(self, attr):
+        """--redact-descriptions still covers free prose by name"""
+        _, out = redact(
+            f'<pfsense><a><thing {attr}="ISP pin 4471">x</thing></a></pfsense>',
+            redact_descriptions=True
+        )
+
+        assert 'ISP pin 4471' not in out
+
+
+class TestThroughTheCli:
+    """A count that never reaches the shell is not a gate"""
+
+    def test_fail_on_warn_stops_on_an_attribute_blob(self, cli_runner, tmp_path):
+        """The whole point: CI can now see this"""
+        source = tmp_path / 'config.xml'
+        source.write_text(f'<?xml version="1.0"?>{DOC}', encoding='utf-8')
+
+        exit_code, _, stderr = cli_runner.run(
+            str(source), flags=['--stdout', '--fail-on-warn'], expect_success=False
+        )
+
+        assert exit_code != 0
+        assert 'thing[@marker]' in stderr
+
+    def test_aggressive_reopens_the_gate(self, cli_runner, tmp_path):
+        """The remedy the warning names actually works"""
+        source = tmp_path / 'config.xml'
+        source.write_text(f'<?xml version="1.0"?>{DOC}', encoding='utf-8')
+
+        exit_code, stdout, _ = cli_runner.run(
+            str(source), flags=['--stdout', '--aggressive', '--fail-on-warn'],
+            expect_success=False
+        )
+
+        assert exit_code == 0
+        assert BLOB not in stdout

--- a/tests/unit/test_cert_reference_resolution.py
+++ b/tests/unit/test_cert_reference_resolution.py
@@ -177,6 +177,44 @@ class TestWhatMustNotChange:
         assert REFID in out
         assert '[REDACTED]' not in out
 
+    def test_a_cert_store_that_is_itself_a_container(self):
+        """The case the container guard actually exists for
+
+        <cert> exits earlier because it holds material, so it never reaches the
+        guard. HAProxy's <ha_certificates> wrapping <item> children does, and
+        its text is only the newline before the first child.
+        """
+        out = redact(
+            '<pfsense><a><ha_certificates>\n  <item>first</item>\n'
+            '</ha_certificates></a></pfsense>'
+        )
+
+        assert '<item>first</item>' in out
+        assert '[REDACTED]' not in out
+
+    @pytest.mark.parametrize('text', ['', '   ', '\n  '])
+    def test_empty_cert_elements_are_left_alone(self, text):
+        """Nothing to resolve and nothing to leak"""
+        out = redact(f'<pfsense><a><ha_certificates>{text}</ha_certificates></a></pfsense>')
+
+        assert '[REDACTED]' not in out
+
+    def test_separators_with_no_tokens_are_redacted(self):
+        """A value that is punctuation only resolves to nothing
+
+        It cannot be a reference list, so it takes the unresolved path rather
+        than being waved through as empty.
+        """
+        out = redact('<pfsense><a><ha_certificates>,,</ha_certificates></a></pfsense>')
+
+        assert '[REDACTED]' in out
+
+    def test_numbered_material_elements_are_excluded_too(self):
+        """Exclusion is by tag base, so <crt2> is still a material element"""
+        out = redact('<pfsense><a><crt2>short</crt2></a></pfsense>')
+
+        assert 'short' in out
+
     @pytest.mark.parametrize('placeholder', ['[REDACTED]', '[REDACTED_CERT_OR_KEY]'])
     def test_our_own_placeholders_are_left_alone(self, placeholder):
         """Redacting an already-redacted file must be a no-op

--- a/tests/unit/test_cert_reference_resolution.py
+++ b/tests/unit/test_cert_reference_resolution.py
@@ -1,0 +1,232 @@
+"""
+Tests for resolving certificate references instead of inferring them from length.
+
+A cert-named element holding a short value used to be kept on the strength of
+its length alone: under CERT_MIN_LENGTH and without a PEM header, it was assumed
+to be a refid and left readable. That is a proxy for meaning, and it is what let
+CANARY_HAPROXYCERTS and CANARY_SSLOFFLOAD through the canary corpus.
+
+The config already declares which references exist, so the value is resolved
+against the <refid> elements in the same file. Resolves: keep, because a
+reference helps a reader understand the structure and is not key material.
+Does not resolve: redact, because nothing accounts for it.
+
+The direction of the unresolved case is deliberate. Absent proof that a value is
+a reference, it is treated as a secret - a config carrying no <refid> at all
+therefore loses its short cert values, which is over-redaction in the safe
+direction.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor
+
+REFID = '5a04208c70f14'
+OTHER_REFID = '5a04208c7c65a'
+
+PEM = (
+    '-----BEGIN CERTIFICATE-----\n'
+    'MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKKzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\n'
+    '-----END CERTIFICATE-----'
+)
+
+
+def redact(xml, refids=(), **kwargs):
+    """Drive redact_element directly with a known refid set"""
+    redactor = PfSenseRedactor(**kwargs)
+    redactor.known_refids = frozenset(refids)
+    root = ET.fromstring(xml)
+    redactor.redact_element(root)
+    return ET.tostring(root, encoding='unicode')
+
+
+class TestCollectingRefids:
+    """The pre-pass that builds the lookup table"""
+
+    def test_finds_refids_anywhere_in_the_tree(self):
+        """Package cert stores do not reliably sit where the base system puts them"""
+        root = ET.fromstring(
+            f'<pfsense><cert><refid>{REFID}</refid></cert>'
+            f'<installedpackages><p><refid>{OTHER_REFID}</refid></p></installedpackages>'
+            '</pfsense>'
+        )
+
+        assert PfSenseRedactor._collect_refids(root) == {REFID, OTHER_REFID}
+
+    def test_blank_and_missing_refids_are_skipped(self):
+        """An empty <refid/> declares nothing and must not admit the empty string"""
+        root = ET.fromstring('<pfsense><cert><refid/></cert><ca><refid>   </refid></ca></pfsense>')
+
+        assert PfSenseRedactor._collect_refids(root) == frozenset()
+
+    def test_no_refids_gives_an_empty_set(self):
+        """Which resolves nothing, so short cert values are treated as secrets"""
+        root = ET.fromstring('<pfsense><a>x</a></pfsense>')
+
+        assert PfSenseRedactor._collect_refids(root) == frozenset()
+
+
+class TestResolvableReferencesSurvive:
+    """The reason short values were ever kept"""
+
+    @pytest.mark.parametrize('tag', ['ssl_ca_cert', 'ssl_server_cert', 'ha_certificates'])
+    def test_declared_reference_is_preserved(self, tag):
+        """Real configs point at certificates this way throughout"""
+        out = redact(f'<pfsense><a><{tag}>{REFID}</{tag}></a></pfsense>', refids=[REFID])
+
+        assert REFID in out
+
+    def test_several_references_all_declared(self):
+        """HAProxy's ha_certificates can carry more than one"""
+        out = redact(
+            f'<pfsense><a><ha_certificates>{REFID},{OTHER_REFID}</ha_certificates></a></pfsense>',
+            refids=[REFID, OTHER_REFID]
+        )
+
+        assert REFID in out
+        assert OTHER_REFID in out
+
+    def test_whitespace_separated_references(self):
+        """The separator is not consistent across packages"""
+        out = redact(
+            f'<pfsense><a><ha_certificates>{REFID} {OTHER_REFID}</ha_certificates></a></pfsense>',
+            refids=[REFID, OTHER_REFID]
+        )
+
+        assert OTHER_REFID in out
+
+
+class TestUnresolvableValuesAreRedacted:
+    """The gap this closes"""
+
+    def test_undeclared_value_goes(self):
+        """Nothing in the config accounts for it, so it is not a reference"""
+        out = redact('<pfsense><a><ssloffloadcert>hunter2secret</ssloffloadcert></a></pfsense>')
+
+        assert 'hunter2secret' not in out
+
+    def test_partial_match_redacts_the_whole_value(self):
+        """One token resolving does not make the rest of the value a reference
+
+        Requiring every token to resolve is the safe direction: a mixed value is
+        not purely a reference list, so all of it is suspect.
+        """
+        out = redact(
+            f'<pfsense><a><ha_certificates>{REFID},hunter2secret</ha_certificates></a></pfsense>',
+            refids=[REFID]
+        )
+
+        assert 'hunter2secret' not in out
+
+    def test_a_config_with_no_refids_loses_its_short_cert_values(self):
+        """Over-redaction in the safe direction, and the documented behaviour
+
+        A fragment shared without its <cert> section cannot prove any of its
+        references are references, so they are treated as secrets.
+        """
+        out = redact('<pfsense><a><ssl_ca_cert>abc123def456</ssl_ca_cert></a></pfsense>')
+
+        assert 'abc123def456' not in out
+
+    def test_it_is_redacted_as_a_secret_not_as_cert_material(self):
+        """A short value with no PEM header demonstrably is not cert material"""
+        out = redact('<pfsense><a><ssloffloadcert>hunter2secret</ssloffloadcert></a></pfsense>')
+
+        assert '[REDACTED]' in out
+        assert '[REDACTED_CERT_OR_KEY]' not in out
+
+
+class TestWhatMustNotChange:
+    """The surrounding behaviour this refines rather than replaces"""
+
+    def test_pem_material_is_still_cert_redacted(self):
+        """Resolution refines the short-value branch only"""
+        out = redact(f'<pfsense><a><ha_certificates>{PEM}</ha_certificates></a></pfsense>')
+
+        assert '[REDACTED_CERT_OR_KEY]' in out
+
+    def test_long_values_are_still_cert_redacted(self):
+        """Anything past CERT_MIN_LENGTH is material, whatever the refid table says"""
+        blob = 'A1b2C3d4' * 8
+
+        out = redact(f'<pfsense><a><ssl_ca_cert>{blob}</ssl_ca_cert></a></pfsense>')
+
+        assert blob not in out
+        assert '[REDACTED_CERT_OR_KEY]' in out
+
+    @pytest.mark.parametrize('tag', ['crt', 'cert', 'public-key'])
+    def test_material_holding_elements_are_untouched_by_resolution(self, tag):
+        """CERT_KEY_ELEMENTS carry the material itself
+
+        A short value in one is a truncated key or one of our own placeholders,
+        never a refid, so resolving it would be answering the wrong question.
+        """
+        out = redact(f'<pfsense><a><{tag}>short</{tag}></a></pfsense>')
+
+        assert 'short' in out
+
+    def test_container_elements_are_not_mangled(self):
+        """<cert> wraps <refid>/<crt>; its own text is the newline before them"""
+        out = redact(
+            f'<pfsense><cert>\n  <refid>{REFID}</refid>\n  <descr>Web</descr>\n</cert></pfsense>',
+            refids=[REFID]
+        )
+
+        assert '<cert>' in out
+        assert REFID in out
+        assert '[REDACTED]' not in out
+
+    @pytest.mark.parametrize('placeholder', ['[REDACTED]', '[REDACTED_CERT_OR_KEY]'])
+    def test_our_own_placeholders_are_left_alone(self, placeholder):
+        """Redacting an already-redacted file must be a no-op
+
+        Without this, '[REDACTED_CERT_OR_KEY]' fails to resolve on a second pass
+        and degrades to the less informative '[REDACTED]'.
+        """
+        out = redact(
+            f'<pfsense><a><ha_certificates>{placeholder}</ha_certificates></a></pfsense>'
+        )
+
+        assert placeholder in out
+
+
+class TestThroughRedactConfig:
+    """The refid table is built by redact_config, not by the caller"""
+
+    def test_references_resolve_end_to_end(self, tmp_path):
+        """A whole config, with the pre-pass running as it does in production"""
+        source = tmp_path / 'config.xml'
+        source.write_text(
+            f'<?xml version="1.0"?><pfsense><cert><refid>{REFID}</refid></cert>'
+            f'<installedpackages><h><config><ssloffloadcert>{REFID}</ssloffloadcert>'
+            '<ha_certificates>undeclared99</ha_certificates>'
+            '</config></h></installedpackages></pfsense>',
+            encoding='utf-8'
+        )
+        out_file = tmp_path / 'out.xml'
+
+        assert PfSenseRedactor().redact_config(str(source), str(out_file)) is True
+
+        out = out_file.read_text(encoding='utf-8')
+        assert REFID in out, 'a declared reference should survive'
+        assert 'undeclared99' not in out, 'an undeclared value should not'
+
+    def test_refids_declared_after_their_use_still_resolve(self, tmp_path):
+        """The pre-pass runs over the whole tree before any redaction
+
+        Element order in config.xml is not guaranteed, so a package section that
+        precedes the <cert> block must still resolve against it.
+        """
+        source = tmp_path / 'config.xml'
+        source.write_text(
+            f'<?xml version="1.0"?><pfsense>'
+            f'<installedpackages><h><config><ssloffloadcert>{REFID}</ssloffloadcert>'
+            '</config></h></installedpackages>'
+            f'<cert><refid>{REFID}</refid></cert></pfsense>',
+            encoding='utf-8'
+        )
+        out_file = tmp_path / 'out.xml'
+        PfSenseRedactor().redact_config(str(source), str(out_file))
+
+        assert REFID in out_file.read_text(encoding='utf-8')

--- a/tests/unit/test_secret_detection.py
+++ b/tests/unit/test_secret_detection.py
@@ -84,11 +84,28 @@ class TestSecretElementPatternMatching:
         assert '>C<' not in output
 
     def test_short_cert_reference_is_preserved(self, basic_redactor):
-        """Cert-ish tags holding short reference IDs stay readable"""
+        """Cert-ish tags holding a reference the config defines stay readable
+
+        The reference has to resolve. known_refids is what redact_config builds
+        from the <refid> elements in the file before the traversal starts; set
+        here directly because this drives redact_element on its own.
+        """
+        basic_redactor.known_refids = frozenset({'5f3a1c9b'})
         root = ET.fromstring('<pfsense><a><ssl_ca_cert>5f3a1c9b</ssl_ca_cert></a></pfsense>')
         basic_redactor.redact_element(root)
 
         assert '5f3a1c9b' in ET.tostring(root, encoding='unicode')
+
+    def test_short_cert_value_that_resolves_to_nothing_is_redacted(self, basic_redactor):
+        """A short value is only kept because it is a reference, so it must be one
+
+        Nothing declares '5f3a1c9b' here, so it is a secret sitting in a
+        cert-named element rather than a pointer to a certificate.
+        """
+        root = ET.fromstring('<pfsense><a><ssl_ca_cert>5f3a1c9b</ssl_ca_cert></a></pfsense>')
+        basic_redactor.redact_element(root)
+
+        assert '5f3a1c9b' not in ET.tostring(root, encoding='unicode')
 
     def test_cert_element_with_pem_is_redacted(self, basic_redactor):
         """The same tag holding actual PEM material is redacted"""


### PR DESCRIPTION
## Description

Three changes to how coverage is decided and measured. Two close gaps the canary corpus had been reporting since it was published; the third replaces the benchmark's written admission of bias with a measurement of it.

The corpus score goes from **42/46 to 44/46** under `--aggressive` (45/46 with `--redact-descriptions`). The corpus file itself is unchanged, so the published comparison against ForesightCyber and netgate-xlsx keeps its denominator and stays valid.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update
- [x] 🔒 Security fix

## Changes Made

### 1. Resolve certificate references instead of measuring their length

A short value in a cert-named element was kept on the strength of being under 50 characters with no PEM header, on the assumption it was a `refid` reference. References are worth keeping, but length is a proxy for meaning, so anything short enough was kept whatever it was. `CANARY_HAPROXYCERTS` and `CANARY_SSLOFFLOAD` were the two markers this let through.

Every `<refid>` in the file is now collected before redaction starts, and short values in cert-named elements are resolved against it. Values resolving to nothing are redacted. Where a value carries several references, as HAProxy's can, all must resolve: a partial match means the value is not purely a reference list.

A config declaring no `<refid>` at all therefore loses its short certificate values. Deliberate, and follows the threat model: absent evidence that a value is a reference, treat it as a secret.

Two things fell out of testing and are worth flagging for review:

- `<cert>` and `<ca>` are **containers** whose `.text` is only the newline before `<refid>`. Guarded on child count.
- `<crt>`, `<cert>` and `<public-key>` reach the same branch via `CERT_KEY_ELEMENTS` but hold key *material*, where resolution asks the wrong question. `test_redaction_is_idempotent` caught this: a second pass was degrading `[REDACTED_CERT_OR_KEY]` to the less informative `[REDACTED]`. Resolution is now scoped to `CERT_TAG_PATTERN`, and the placeholders this tool writes are recognised on the way back in.

### 2. Report high-entropy attribute values

`SENSITIVE_ATTR_PATTERN` matches attribute *names*, so key material in an attribute named something unremarkable was neither redacted nor counted among the retained values `--fail-on-warn` reads. A CI check passed on a file whose own output had never mentioned it.

Values are now entropy-checked and reported with the attribute named in the path (`telemetry[@endpoint_id]`), and redacted under `--aggressive`.

Reported rather than redacted by default because no pfSense config examined in testing uses XML attributes at all (both reference configs parse to zero). This covers third-party packages rather than an observed leak, and rewriting values on that evidence would over-redact for everyone.

This does **not** close the `config_note[@note]` canary and is not meant to. That marker is prose, and the heuristic requires 32+ characters with no spaces. `--redact-descriptions` covers it, as it has since 1.1.2.

### 3. Measure where the corpus came from

Rather than inferring provenance from the changelog, every released version was installed from PyPI and re-run against the corpus. Survivor counts reproduced the published record exactly (1.0.10: 31, 1.1.0: 5, 1.1.1: 4, 1.1.2: 4).

| Origin | Markers |
| --- | --: |
| Already caught by 1.0.10 | 15 |
| First caught in 1.1.0 | 26 |
| First caught in 1.1.1 | 1 |
| First caught in 1.1.2 | 1 |
| First caught in 1.2.0 | 2 |
| Still surviving (deliberate) | 1 |
| **Contributed from outside** | **0** |

So 31 of 46 markers, 67%, were planted against ground the tool did not yet hold. And none came from outside the project, which is the honest limit of the benchmark and is now stated as a number rather than a disclaimer.

`canary-corpus.xml` is frozen at 46 markers, enforced by test, because it is what the other two tools were scored against. Markers added since live in `canary-corpus-supplementary.xml` and are scored separately.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] Added new tests for new functionality
- [x] Tested with sample pfSense configs

735 passed, 1 skipped (up from 693). New: `tests/unit/test_cert_reference_resolution.py` (22), `tests/unit/test_attribute_entropy.py` (16), plus supplementary-corpus coverage in `test_canary_corpus.py`.

```bash
pytest -q
python tools/check_structure.py pfsense_redactor/ tests/
flake8 pfsense_redactor/ tests/ tools/ --select=C901 --max-complexity=8
python -m build && twine check dist/*

# reproduces the published number
pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
  | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
```

## Impact Assessment

**Backwards compatibility**:

- [x] ⚠️ Minor compatibility changes (document below)

Output changes in two cases, both toward redacting more:

1. A short value in a cert-named element that does not resolve to a declared `<refid>` is now redacted. Configs shared without their `<cert>` section lose those values.
2. A high-entropy attribute value is now redacted under `--aggressive`, and counted under `--fail-on-warn` in every mode. A pipeline using `--fail-on-warn` on a config with such an attribute will start failing, which is the point.

Minor version bump to 1.2.0.

**Security implications**:

- [x] Improves security

**Reference snapshots**: 21 files change by exactly one line each, the version string in the redaction comment. Content is otherwise byte-identical, which is the evidence that reference resolution leaves real configs alone. `test-config1` exercises the path directly: `<ssl_ca_cert>` and `<ssl_server_cert>` both resolve and are preserved.

## Documentation

- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Added/updated docstrings
- [x] Added/updated comments for complex logic

`docs/benchmark.md` gains the origin column and provenance counts, plus a contribution path for adversarial markers. `docs/security.md` covers reference resolution and attribute handling; `docs/verifying-output.md` covers the new path notation.