### PR TITLE
Redact bracketed IPv6 addresses that carry a zone identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ Against the 46-secret canary corpus, `--aggressive` now catches 44 where 1.1.2
 caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
 
 ### Security
+- **FIX**: A bracketed IPv6 address carrying a zone identifier was not redacted
+  at all. `%` was a token separator, so `[2001:db8::1%igb0]:51820` split into
+  `[2001:db8::1` and `igb0]:51820`; the first half carried an unbalanced
+  bracket, failed to parse as an address, and was returned untouched.
+
+  The bare form `fe80::1%igb0` appeared to work, but only by accident: its two
+  halves were masked and copied through separately. Every bracketed form leaked,
+  with or without a port, and **routable addresses leaked as readily as
+  link-local ones**. `[address%zone]:port` is the shape pfSense writes for a
+  WireGuard peer endpoint, so real configs carry it.
+
+  `%` is now a token character. The masking code already handled the shape
+  correctly once given the whole token; only tokenising was wrong.
+
+  Two existing tests covered this exact input and passed throughout, because
+  they asserted only that the zone identifier and the port survived. Returning
+  the input untouched satisfies both. They now assert the address is gone as
+  well, which is the property that actually mattered.
+
 - **FIX**: A short value in a certificate-named element was kept on the strength
   of its length alone. Under 50 characters and without a PEM header, it was
   assumed to be a `refid` reference rather than key material.

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -808,8 +808,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.FQDN_RE = re.compile(r'\b(?:[A-Za-z0-9-]+\.){1,10}(?:[A-Za-z]{2,}|xn--[A-Za-z0-9-]{2,})\b')
 
         # IP pattern for token matching and splitting
+        #
+        # '%' is a token character, not a separator. IP_PATTERN already expects
+        # a zone identifier to arrive attached to its address, and splitting on
+        # '%' severed it: 'fe80::1%igb0' happened to survive because the two
+        # halves were masked and copied through separately, but
+        # '[fe80::1%igb0]:51820' split into '[fe80::1' and 'igb0]:51820', so the
+        # address carried an unbalanced bracket, failed to parse, and was
+        # returned untouched. Any bracketed address with a zone leaked, routable
+        # ones included.
         self.IP_PATTERN = re.compile(r'^[\[\]]?[0-9A-Fa-f:.]+(?:%[A-Za-z0-9_.:+-]+)?[\[\]]?(?::\d+)?$')
-        self._ip_token_splitter = re.compile(r'([^0-9A-Za-z\.\:\[\]_+-])')
+        self._ip_token_splitter = re.compile(r'([^0-9A-Za-z\.\:\[\]_+%-])')
 
         # PEM marker detection
         self.PEM_MARKER = re.compile(

--- a/tests/unit/test_ipv6_zone_identifiers.py
+++ b/tests/unit/test_ipv6_zone_identifiers.py
@@ -102,6 +102,11 @@ class TestIPv6ZoneIdentifiers:
             # Zone should be preserved in bracketed form
             assert any(z in result for z in ('%eth0.100]', '%wlan0-1]', '%eth0:1]')), \
                 f"Zone identifier lost in bracketed form for {input_text}, got: {result}"
+            # ...but not by leaving the whole token alone. Asserting only that
+            # the zone survived passed happily while the address leaked, which
+            # is how the bracketed-zone gap went unnoticed.
+            assert 'fe80::1' not in result, \
+                f"Address should be redacted for {input_text}, got: {result}"
 
     def test_bracketed_ipv6_with_zone_and_port(self):
         """Test bracketed IPv6 with zone identifier and port"""
@@ -120,6 +125,11 @@ class TestIPv6ZoneIdentifiers:
                 f"Zone identifier or port lost for {input_text}, got: {result}"
             assert any(p in result for p in (':51820', ':8080', ':443')), \
                 f"Port lost for {input_text}, got: {result}"
+            # The assertion this test was missing. Both checks above are
+            # satisfied by returning the input untouched, which is exactly what
+            # used to happen to this shape.
+            assert 'fe80::1' not in result, \
+                f"Address should be redacted for {input_text}, got: {result}"
 
     def test_zone_parsing_in_parse_ip_token(self):
         """Test _parse_ip_token correctly extracts zone identifiers"""
@@ -255,6 +265,80 @@ class TestIPv6ZoneAndPortHandling:
         assert "2001:db8::1" not in result
         assert ":443" in result
         assert "[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:443" in result
+
+
+class TestBracketedAddressWithZone:
+    """A bracketed IPv6 carrying a zone identifier, which used to leak whole
+
+    '%' was a token separator, so '[fe80::1%igb0]:51820' was split into
+    '[fe80::1' and 'igb0]:51820'. The first half carried an unbalanced bracket,
+    failed to parse as an address, and was returned untouched, so nothing was
+    redacted. The bare form 'fe80::1%igb0' happened to survive only because its
+    two halves were masked and reassembled separately.
+
+    Routable addresses leaked the same way, so this was not limited to
+    link-local. '[addr%zone]:port' is the shape pfSense writes for a WireGuard
+    peer endpoint.
+    """
+
+    @pytest.mark.parametrize('text,address', [
+        ('[2001:db8::1%igb0]:51820', '2001:db8::1'),
+        ('[2001:db8::1%igb0]', '2001:db8::1'),
+        ('[fe80::1%igb0]:51820', 'fe80::1'),
+        ('Endpoint = [2001:db8:abcd::5%vtnet0]:51820', '2001:db8:abcd::5'),
+    ])
+    def test_the_address_is_redacted(self, text, address):
+        """The leak itself: the address must not survive"""
+        assert address not in PfSenseRedactor()._mask_ip_like_tokens(text)
+
+    def test_zone_brackets_and_port_all_survive(self):
+        """Redacting the address must not destroy the structure around it"""
+        result = PfSenseRedactor()._mask_ip_like_tokens('[fe80::1%igb0]:51820')
+
+        assert result == '[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX%igb0]:51820'
+
+    @pytest.mark.parametrize('zone', ['eth0.100', 'eth0:1', 'br-lan', 'bond0.50'])
+    def test_awkward_interface_names_inside_brackets(self, zone):
+        """The zone spellings the unbracketed tests already cover"""
+        result = PfSenseRedactor()._mask_ip_like_tokens(f'[fe80::1%{zone}]:500')
+
+        assert 'fe80::1' not in result
+        assert f'%{zone}' in result
+
+    def test_it_survives_a_whole_config(self, create_xml_file, cli_runner):
+        """End to end, since the gap was in tokenising text rather than masking"""
+        source = create_xml_file(
+            '<?xml version="1.0"?><pfsense><installedpackages><wireguard><tunnels>'
+            '<item><endpoint>[2001:db8::99%vtnet0]:51820</endpoint></item>'
+            '</tunnels></wireguard></installedpackages></pfsense>',
+            'wg.xml'
+        )
+
+        _, stdout, _ = cli_runner.run(str(source), flags=['--stdout'])
+
+        assert '2001:db8::99' not in stdout
+        assert '%vtnet0' in stdout
+
+
+class TestPercentIsNotOverRedacted:
+    """Making '%' a token character must not start rewriting ordinary text
+
+    The masker only rewrites a token once ipaddress has parsed it, so prose and
+    percent-encoding are unaffected. Worth pinning: this is the cost side of
+    the fix above.
+    """
+
+    @pytest.mark.parametrize('text', [
+        'CPU at 50% load',
+        'disk 85% full',
+        '/var/log%2Ffile',
+        'user%40host',
+        'abc%20def',
+        'dead%20beef',
+    ])
+    def test_left_alone(self, text):
+        """Percent signs in prose and percent-encoding are not addresses"""
+        assert PfSenseRedactor()._mask_ip_like_tokens(text) == text
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

A bracketed IPv6 address carrying a zone identifier was **not redacted at all**. Found while adding coverage for unrelated refactoring; it predates that work and is on `main` today.

```
[2001:db8::1%igb0]:51820   ->  [2001:db8::1%igb0]:51820    LEAK
[2001:db8::1%igb0]         ->  [2001:db8::1%igb0]          LEAK
2001:db8::1%igb0           ->  XXXX:...:XXXX%igb0          ok
[2001:db8::1]:51820        ->  [XXXX:...:XXXX]:51820       ok
```

**Routable addresses leaked as readily as link-local ones.** `[address%zone]:port` is the shape pfSense writes for a WireGuard peer endpoint, so real configs carry it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security fix

## Changes Made

### Root cause

`%` was a token *separator* in `_ip_token_splitter`, so the zone was severed from its address:

| Input | Tokens produced | Outcome |
| --- | --- | --- |
| `fe80::1%igb0` | `fe80::1` / `%` / `igb0` | address masked, zone copied through — **works by accident** |
| `[fe80::1%igb0]:51820` | `[fe80::1` / `%` / `igb0]:51820` | first token has an unbalanced bracket, fails to parse, **returned untouched** |

`IP_PATTERN` already expected a zone identifier to arrive attached to its address, and `_mask_one_ip_token` handled the whole shape correctly when called with it directly. Only tokenising was wrong.

The fix is to make `%` a token character.

### The tests were the reason this survived

Two existing tests covered this exact input and passed throughout:

```python
assert any(z in result for z in ('%eth0.100]:', '%wlan0-1]:', ...))   # zone survived
assert any(p in result for p in (':51820', ':8080', ':443'))          # port survived
```

Both assertions are satisfied by returning the input completely unredacted, which is precisely what was happening. They now also assert the address is gone.

That failure mode generalises: **a test that checks only what should be preserved cannot detect a redactor that preserves everything.** Worth keeping in mind for the rest of the suite.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] Added new tests for new functionality

757 passed, 1 skipped. New coverage for bracketed addresses with a zone (with and without a port, and with awkward interface names such as `eth0.100`, `eth0:1`, `br-lan`), plus an end-to-end run through a WireGuard config.

**Verified the tests actually catch it**: reverting only the splitter character class, with the new tests in place, fails 12 tests including the two that previously passed.

Also pinned the cost side, that ordinary text containing `%` is still left alone:

```
'CPU at 50% load'  'disk 85% full'  '/var/log%2Ffile'  'user%40host'  'abc%20def'  'dead%20beef'
```

## Impact Assessment

**Backwards compatibility**:

- [x] ✅ Fully backwards compatible

More is redacted than before, which is the point. `tests/reference/**` is **byte-identical to main**, so no other tokenising moved.

**Security implications**:

- [x] Improves security

Closes an under-redaction path. Under-redaction is this project's threat model: output exists to be shared outside the firewall, so anything missed is disclosed to whoever receives it.

## Documentation

- [x] Updated CHANGELOG.md

Folded into the unreleased 1.2.0 entry rather than taking a new version, since PyPI is still on 1.1.2.

## Notes

Deliberately narrow: three files, one of them the changelog. A canary for this shape is coming separately in #62, which is where the supplementary corpus work lives.