### PR TITLE
Test on Python 3.14

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Security",
     "Topic :: System :: Networking",


### PR DESCRIPTION
## Description

3.14 has been the current stable release since October 2025, and the suite passes on it, but nothing declared or checked that. A version that is not in the matrix is a version that breaks quietly.

## Type of Change

- [x] 🧪 Test improvements

## Changes Made

- `3.14` added to the test matrix in `tests.yml` (all three OSes)
- `3.14` added to the pylint matrix in `pylint.yml`
- `Programming Language :: Python :: 3.14` classifier, so the published metadata says what CI verifies

**No source change was needed.** `redactor.py` imports `from __future__ import annotations`, so the PEP 604 unions and PEP 585 generics it uses are never evaluated at runtime. `requires-python = ">=3.9"` is unchanged and 3.9 stays in the matrix.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] Tested with different Python versions

Verified locally on **3.14.6**: 741 passed, 1 skipped (the Windows-only path test). `python -m build` and `twine check` both pass, and the new classifier appears in the built `PKG-INFO`.

## Impact Assessment

**Backwards compatibility**:

- [x] ✅ Fully backwards compatible

Additive. The existing pytest pin already covers it (`pytest==9.1.1; python_version >= "3.10"`).

**Security implications**:

- [x] No security impact

## Notes

3.15 is in pre-release until October 2026. It could be added with `allow-prereleases: true` as an early-warning signal, but that trades CI stability for it, so I have left it out. Happy to add it if you would rather know early.