### PR TITLE
Secret detection hardening: private-key PEM, encoded key material, JWTs and opaque values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0][] - 2026-07-28
+
+Secret detection hardening. Five classes of credential that previously survived
+redaction while the run reported success are now removed or reported.
+
+### Security
+
+- **Private-key PEM material is now redacted in every mode, whatever holds it.**
+  A private key stored in an element or attribute whose name the tool did not
+  recognise was previously *reported* as a retained high-entropy value and left
+  in the output, and the run exited 0. A PEM private-key header is unambiguous
+  evidence of key material and carries no over-redaction risk, so the
+  report-only policy no longer applies to it. Recognised headers: `PRIVATE KEY`,
+  `RSA`/`EC`/`DSA`/`ED25519 PRIVATE KEY`, `ENCRYPTED PRIVATE KEY`, `OPENSSH
+  PRIVATE KEY`, `SSH2 ENCRYPTED PRIVATE KEY`, `PGP PRIVATE KEY BLOCK` and
+  OpenVPN's `STATIC KEY`. Public keys and certificates are unaffected.
+  (FINDING-01, FINDING-02)
+
+- **Base64 and Base64URL values are inspected for key material.** Packages that
+  store credentials encoded — ACME account keys, several backup agents — hid the
+  PEM header from every check the tool made. Values are now decoded to a bounded
+  depth of 3 and re-examined, so single- and double-wrapped key material is
+  found. Decoding is bounded in source length, decoded size, depth and total
+  operations per value, and decoded content is never logged, sampled or placed
+  in an error message. (FINDING-03)
+
+- **JWTs are detected and redacted in every mode.** A compact token's `.`
+  separators defeated the shape test, so a JWT was neither redacted nor
+  reported. Recognised by the `eyJ` prefix or by the first segment decoding to a
+  JOSE header; ordinary dotted strings — hostnames, versions, IPv4 addresses,
+  filenames, reversed package names — are not affected. (FINDING-05)
+
+- **Long single-character-class values are no longer invisible.** The opaque
+  value test required two of {digit, upper, lower}, so an all-lowercase token,
+  an all-uppercase token and a digest spelled only in `a-f` were neither
+  redacted nor **reported** — `--fail-on-warn` could not see them and the
+  summary never mentioned them. Hex values of 32 characters or more, and
+  Base64-shaped values of 36 or more, are now judged on length and Shannon
+  entropy instead. UUIDs, all-zero fields and padding are excluded by shape.
+  (FINDING-04)
+
+- **Element names and attribute names are classified by one shared predicate.**
+  The two patterns disagreed: `bearer`, `cookie` and `signature` were secrets
+  only as attributes; `credentials`, `privkey`, `licensekey`, `psk`,
+  `passphrase` and `community` only as elements. The deny-list now applies to
+  attribute names as it always has to element names. (FINDING-10)
+
+- **13 further credential-bearing element names are recognised**: `pwd`,
+  `bearer`, `salt`, `seed`, `otpseed`, `digest`, `hash`, `nonce`, `keydata`,
+  `keystore`, `authorization`, `sessionid` and `totp`. (FINDING-09)
+
+### Changed
+
+- Values in these positions may now be redacted where they were previously kept
+  and listed among the retained high-entropy paths. Nothing that was redacted
+  before is kept now. If you relied on reading a retained value out of the
+  output, it will be `[REDACTED_CERT_OR_KEY]` or `[REDACTED]` instead.
+
+- `<digest>` and `<hash>` are decided by their value rather than their name, so
+  `<digest>SHA384</digest>` — IPsec selecting an algorithm — is preserved while
+  anything outside a closed list of algorithm names in those elements is
+  redacted. Algorithm-selector names (`hash-algorithm`, `hashalgo`,
+  `digestalgo`, `saltlen` and similar) and the OpenVPN `auth-retry*` directives
+  are on the deny-list.
+
+- The retained-value warning is correspondingly shorter, and the count that
+  `--fail-on-warn` reads no longer includes private keys or JWTs, because those
+  are no longer retained.
+
+No action is required. No CLI option, default or exit code changes in this
+release, and output remains valid pfSense XML.
+
 ## [1.2.0][] - 2026-07-28
 
 Three changes to how coverage is decided and measured. Two close gaps the canary
@@ -600,6 +672,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.3.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.3.0
 [1.2.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.0
 [1.1.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.2
 [1.1.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1][] - 2026-07-28
+## [1.2.1][] - 2026-08-02
 
 Secret detection hardening. Five classes of credential that previously survived
 redaction while the run reported success are now removed or reported.
@@ -14,12 +14,12 @@ redaction while the run reported success are now removed or reported.
 
 - **Private-key PEM material is now redacted in every mode, whatever holds it.**
   A private key stored in an element or attribute whose name the tool did not
-  recognise was previously *reported* as a retained high-entropy value and left
+  recognise was previously _reported_ as a retained high-entropy value and left
   in the output, and the run exited 0. A PEM private-key header is unambiguous
   evidence of key material and carries no over-redaction risk, so the
   report-only policy no longer applies to it. Recognised headers: `PRIVATE KEY`,
   `RSA`/`EC`/`DSA`/`ED25519 PRIVATE KEY`, `ENCRYPTED PRIVATE KEY`, `OPENSSH
-  PRIVATE KEY`, `SSH2 ENCRYPTED PRIVATE KEY`, `PGP PRIVATE KEY BLOCK` and
+PRIVATE KEY`, `SSH2 ENCRYPTED PRIVATE KEY`, `PGP PRIVATE KEY BLOCK` and
   OpenVPN's `STATIC KEY`. Public keys and certificates are unaffected.
   (FINDING-01, FINDING-02)
 
@@ -93,6 +93,7 @@ Against the 46-secret canary corpus, `--aggressive` now catches 44 where 1.1.2
 caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
 
 ### Security
+
 - **FIX**: A bracketed IPv6 address carrying a zone identifier was not redacted
   at all. `%` was a token separator, so `[2001:db8::1%igb0]:51820` split into
   `[2001:db8::1` and `igb0]:51820`; the first half carried an unbalanced
@@ -138,7 +139,7 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
   question.
 
 - **FIX**: `--fail-on-warn` could not see key material in an XML attribute.
-  `SENSITIVE_ATTR_PATTERN` matches an attribute's *name*, so a blob sitting in
+  `SENSITIVE_ATTR_PATTERN` matches an attribute's _name_, so a blob sitting in
   an attribute named something unremarkable was neither redacted nor counted
   among the retained high-entropy values the gate reads. A CI check passed on a
   file whose own output had never mentioned it.
@@ -158,12 +159,14 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
   1.1.2.
 
 ### Changed
+
 - Redacting an already-redacted file is now a no-op for certificate elements.
   Without the placeholder check added here, `[REDACTED_CERT_OR_KEY]` failed to
   resolve as a reference on a second pass and degraded to the less informative
   `[REDACTED]`.
 
 ### Documentation
+
 - `docs/benchmark.md` now reports where the corpus came from as a measurement
   rather than a caveat. Every released version was re-run against it to find
   which release first caught each marker: 15 were already caught by 1.0.10, 26
@@ -181,9 +184,10 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
 ## [1.1.2][] - 2026-07-28
 
 ### Security
+
 - **FIX**: Webhook tokens survived in default mode unless the element happened
   to be named for a secret. 1.1.0 fixed `<webhook_url>` by matching the element
-  *name*, so a Slack URL in `<slack_url>`, `<notifyurl>` or a plain `<url>` kept
+  _name_, so a Slack URL in `<slack_url>`, `<notifyurl>` or a plain `<url>` kept
   its token. The token is the whole authorisation, since anyone holding the
   URL can post as that integration.
 
@@ -202,6 +206,7 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
   Found by scanning redacted output with gitleaks: of six realistic secrets in a
   test config it flagged exactly one, and this was it. Running an independent
   scanner over the output catches what a name-driven redactor cannot.
+
 - **FIX**: `--fail-on-warn` covered the root-tag check and nothing else, so a
   config carrying a value the tool declined to redact printed "Review before
   sharing" and still exited 0. An automated check passed on a file its own
@@ -214,6 +219,7 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
   and points at `--aggressive`. Redacted output is still written when the gate
   fails, since the retained values were reported rather than leaked and the
   operator needs the file to review them.
+
 - **ADD**: Microsoft Teams webhook endpoints are recognised, so their path
   tokens are redacted in every mode alongside Slack, Discord and Telegram.
   Teams puts the tenant in a subdomain, so `*.webhook.office.com` is matched as
@@ -228,6 +234,7 @@ caught 42, and 45 with `--redact-descriptions` where 1.1.2 caught 43.
   ordinary paths on unrelated servers. Those still need `--aggressive`.
 
 ### Added
+
 - `--redact-descriptions` now covers free-text **attributes** as well as
   elements: `note`, `comment`, `label`, `title` and similar. Attributes named
   for a secret were already redacted; these are the ones whose name says
@@ -248,6 +255,7 @@ confirming them. The second is two long-standing defects surfaced while
 reviewing that work, both older than 1.1.0.
 
 ### Security
+
 - **FIX**: Three credential formats bypassed URL path-segment detection:
   - **AWS access key IDs** (`AKIA...`) are exactly 20 characters, and the
     length test was `<= 20`, so the entire format was excluded by an
@@ -265,10 +273,10 @@ reviewing that work, both older than 1.1.0.
   emits one, so its presence means the file did not come from pfSense
   untouched.
 
-  This is deliberately *not* described as an XXE fix. `xml.etree.ElementTree`
+  This is deliberately _not_ described as an XXE fix. `xml.etree.ElementTree`
   does not resolve external entities. A `SYSTEM` entity raises `ParseError`,
   so there is no file disclosure and no SSRF. What it does do is expand
-  *internal* entities, where a few hundred bytes of nested definitions expand
+  _internal_ entities, where a few hundred bytes of nested definitions expand
   to gigabytes. Severity is low: the input is a file the user supplies, and the
   failure is loud rather than a silent under-redaction.
 
@@ -277,6 +285,7 @@ reviewing that work, both older than 1.1.0.
   the guard reporting success while doing nothing.
 
 ### Fixed
+
 - **FIX**: FQDN substitution rewrote filenames as domains, corrupting output
   rather than redacting it. `list.txt`, `emerging-block.rules`,
   `pfblockerng.php` and `haproxy.sh` all became `example.com`.
@@ -290,6 +299,7 @@ reviewing that work, both older than 1.1.0.
   context. Context is required because extension alone cannot decide it: `.sh`,
   `.pl`, `.io` and `.zip` are all real TLDs, so `haproxy.sh` is preserved
   inside a path but still redacted in prose.
+
 - **FIX** (predates 1.1.0): IPv6 anonymisation produced invalid addresses once
   the RFC 3849 pool was exhausted. The RFC 4193 overflow mapping used
   `((overflow - 1) % 0x10000) + 1`, which ranges `1..0x10000`, one past what a
@@ -301,8 +311,9 @@ reviewing that work, both older than 1.1.0.
   Two existing tests asserted the malformed value, complete with comments
   working through the arithmetic that produced it, which is why the defect
   survived. Both are corrected.
+
 - **FIX** (predates 1.1.0): The sensitive-directory check used a plain string
-  prefix, so paths that merely *begin* with a protected directory's name were
+  prefix, so paths that merely _begin_ with a protected directory's name were
   rejected: `/rootkit`, `/roots`, `/var/logs-archive`, `/bootstrap`,
   `/usr/binaries`, `/libraries` and `/runner` were all refused as output
   locations. Matching is now component-aware, and no longer depends on whether
@@ -320,6 +331,7 @@ reviewing that work, both older than 1.1.0.
   No effect off Windows, where none of these variables are set.
 
 ### Known limitations
+
 - A path segment of 21-23 characters containing no digit is not detected.
   `Open_VM_Tools_package` (a route name that must be preserved) and a
   hypothetical 21-character alphabetic token are the same length and shape, so
@@ -329,6 +341,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.1.0][] - 2026-07-27
 
 ### Security
+
 - **FIX**: Secret detection matched element names exactly, so the concatenated spellings pfSense
   and its packages actually emit were never redacted. `REDACT_ELEMENTS` contained `community`,
   but pfSense writes `<rocommunity>`/`<rwcommunity>`; the entry that existed was the one that
@@ -344,6 +357,7 @@ reviewing that work, both older than 1.1.0.
 
   This also affected this project's own sample configs, where `passwordagain`, `crypto_password`,
   `redis_password`, `auth_pass` and `rocommunity` values were all being emitted in the clear.
+
 - **FIX**: `_get_tag_base()` stripped trailing digits but was only applied to IP-bearing elements,
   so `password` was redacted while `password2` and `passwordagain` were not. It is now applied to
   secret and certificate matching as well.
@@ -364,7 +378,7 @@ reviewing that work, both older than 1.1.0.
   as sanitised when it is not.
   Userinfo redaction now follows the same policy on every URL path, and a URL carrying credentials
   is rewritten even when nothing else in it changes.
-- **FIX**: Free-text blob elements received *less* URL scanning than unrecognised elements, because
+- **FIX**: Free-text blob elements received _less_ URL scanning than unrecognised elements, because
   they reported their text as handled. They are now scanned for URL secrets as well as inline
   `key=value` credentials, and the key=value scanner no longer mistakes a URL scheme for a key.
 - **FIX**: `--dry-run-verbose` printed URL credentials to the console. The sample display masked the
@@ -375,27 +389,30 @@ reviewing that work, both older than 1.1.0.
   before sharing, so it now redacts path and query secrets too.
 
 ### Added
+
 - **NEW**: `--redact-descriptions` flag to redact free-text descriptions and identifiers
   (`descr`, `detail`, `hostname`, `ssid`). DHCP static-map descriptions are a reliable source of
   personal names. Off by default, as these fields aid troubleshooting.
 - Unrecognised high-entropy values are now reported in the summary with their element path, so
-  retained secrets can be reviewed manually. Previously the summary only counted what *was*
+  retained secrets can be reviewed manually. Previously the summary only counted what _was_
   redacted, making retained values impossible to audit. `--aggressive` redacts them outright.
 
 ### Changed
+
 - **BREAKING (output)**: Secret element matching is now pattern-based rather than exact-match, so
   more fields are redacted by default. A deny-list keeps known non-secrets readable
   (`snortcommunityrules`, `pass_order`, `password_type`, `source_hash_key`, `certref`, `keylen`).
   Validated at zero false positives across all 875 unique element names in the sample configs.
-- `--aggressive` now broadens *secret* detection, not just IP/domain rewriting. Previously it
+- `--aggressive` now broadens _secret_ detection, not just IP/domain rewriting. Previously it
   changed none of the 31 leaked canaries, despite users reasonably reading it as "redact more
   secrets".
 - Certificate-shaped elements are redacted only when their content looks like PEM or a long blob,
-  so short certificate *references* stay readable.
+  so short certificate _references_ stay readable.
 
 ## [1.0.10][] - 2025-12-15
 
 ### Changed
+
 - Improved PyPI metadata with additional classifiers
 - Added code quality tool configurations (Black, isort, mypy)
 - Enhanced project URLs (Bug Tracker, Changelog, Source Code)
@@ -404,6 +421,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.0.9][] - 2025-11-08
 
 ### Added
+
 - **NEW**: Version checking functionality with `--version` and `--check-version` flags
   - `--version`: Display current version and exit (instant, no network call)
   - `--check-version`: Check PyPI for latest version with context-aware upgrade instructions
@@ -412,6 +430,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.0.8][] - 2025-11-05
 
 ### Security
+
 - **FIX**: Added symlink security check for `--inplace` mode
   - Prevents following symlinks when using `--inplace` to avoid overwriting sensitive system files
   - Symlink check now occurs before file size validation to handle directory symlinks on Windows
@@ -443,6 +462,7 @@ reviewing that work, both older than 1.1.0.
   - Added 27 tests in `tests/unit/test_port_validation.py`
 
 ### Fixed
+
 - **FIX**: Prevent re-redaction of RFC documentation IPs in anonymisation mode
   - RFC 5737 IPv4 ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24) now recognised as masked values
   - RFC 3849 IPv6 range (2001:db8::/32) now recognised as masked values
@@ -461,6 +481,7 @@ reviewing that work, both older than 1.1.0.
   - Verified no duplicate mappings occur across RFC and overflow ranges
 
 ### Security
+
 - **FIX**: Added file path validation to prevent arbitrary file read/write operations
   - Blocks directory traversal attempts (`../../../etc/passwd`)
   - Blocks paths with null bytes (path traversal attack vector)
@@ -471,6 +492,7 @@ reviewing that work, both older than 1.1.0.
   - By default, only allows relative paths and absolute paths to safe locations (home, CWD, temp directories)
 
 ### Added
+
 - New `--allow-absolute-paths` flag to explicitly enable absolute path usage
   - Required for absolute paths outside safe locations (home, CWD, temp)
   - Still enforces protection against sensitive system directories
@@ -484,6 +506,7 @@ reviewing that work, both older than 1.1.0.
   - Tests cover directory traversal, null bytes, sensitive directories, symbolic links, and edge cases
 
 ### Changed
+
 - Path validation now occurs before file existence checks
 - In-place mode (`--inplace`) now validates paths with stricter output-level checks
 - Dry-run mode now validates output paths for security (even though no write occurs)
@@ -492,6 +515,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.0.7][] - 2025-11-03
 
 ### Fixed
+
 - **CRITICAL FIX**: Fixed whitespace corruption in URL/email/FQDN redaction
   - `_redact_urls_safe`, `_redact_emails_safe`, and `_redact_fqdns_safe` were using `text.split()` and `' '.join()`
   - This collapsed all whitespace (including newlines) into single spaces, corrupting XML text content
@@ -519,6 +543,7 @@ reviewing that work, both older than 1.1.0.
   - Ensures consistent handling of previously redacted configurations
 
 ### Added
+
 - New `--quiet` / `-q` flag: Suppress progress messages (show only warnings and errors)
 - New `--verbose` / `-v` flag: Show detailed debug information
 - Flags are mutually exclusive and validated at runtime
@@ -531,6 +556,7 @@ reviewing that work, both older than 1.1.0.
   - Added 7 tests in `TestURLUsernameRedaction`
 
 ### Changed
+
 - **BREAKING**: Replaced `print()` statements with Python's `logging` module for better integration
   - All output now uses proper log levels (ERROR, WARNING, INFO, DEBUG)
   - Logs route to stdout by default, stderr when using `--stdout` mode
@@ -546,11 +572,13 @@ reviewing that work, both older than 1.1.0.
   - More predictable and maintainable than previous two-hextet approach
 
 ### Removed
+
 - `--stats-stderr` flag (replaced by automatic log routing in `--stdout` mode)
 
 ## [1.0.6][] - 2025-11-02
 
 ### Security
+
 - **CRITICAL FIX**: Extended URL regex to handle non-HTTP protocols (FTP, FTPS, SFTP, SSH, Telnet, File, SMB, NFS)
   - Previously only HTTP/HTTPS URLs were matched, allowing credentials in `ftp://user:pass@host` URLs to bypass redaction
   - Credentials in non-HTTP URLs would have leaked through the bare FQDN redaction path
@@ -560,11 +588,12 @@ reviewing that work, both older than 1.1.0.
   - This changed URL semantics from local filesystem to network file share
   - Added early return in `_mask_url()` when `hostname` is `None` or empty
 - **ENHANCEMENT**: Expanded email regex to support RFC 5322 special characters
-  - Now matches emails with `!#$&'*/=?^`{|}~` in local part (e.g., `user!test@example.com`)
+  - Now matches emails with `!#$&'*/=?^`{|}~`in local part (e.g.,`user!test@example.com`)
   - Maintains ReDoS protection with limited repetitions
   - Previous regex only matched `[A-Za-z0-9._%+-]`, missing many legal email addresses
 
 ### Added
+
 - Module-level exports control via `__all__` (PfSenseRedactor, main, parse_allowlist_file)
 - Python 3.9+ version check at module import time with clear error message
 - Cached IDNA encoding using `@functools.lru_cache(maxsize=256)` for improved performance
@@ -575,13 +604,14 @@ reviewing that work, both older than 1.1.0.
   - 6 tests for hostnameless URL preservation
 
 ### Changed
+
 - Updated version to 1.0.6 in both `__init__.py` and `pyproject.toml`
 - Updated all test reference files to include redaction comment
-
 
 ## [1.0.5][] - 2025-11-02
 
 ### Changed
+
 - Updated installation documentation in README to address `externally-managed-environment` error
 - Added installation alternatives for macOS and modern Linux distributions:
   - pipx installation (recommended for CLI tools)
@@ -592,6 +622,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.0.4][] - 2025-11-02
 
 ### Changed
+
 - Upgraded minimum Python version from 3.8 to 3.9
 - Modernised type hints using `from __future__ import annotations` and PEP 604 union syntax (`X | Y`)
 - Replaced all `typing` module imports with built-in types (`list`, `dict`, `tuple`, etc.)
@@ -599,12 +630,14 @@ reviewing that work, both older than 1.1.0.
 - Removed `ET.indent()` try/except block (now available in Python 3.9+)
 
 ### Added
+
 - Linter configurations:
   - `.pylintrc` for production code (strict)
   - `.pylintrc-tests` for test code (relaxed)
   - `.bandit` for security linting
 
 ### Fixed
+
 - Consistent XML indentation across Python versions
 - All pylint, Prospector, and Bandit warnings resolved
 - CI/CD workflows updated to test Python 3.9-3.13
@@ -612,6 +645,7 @@ reviewing that work, both older than 1.1.0.
 ## [1.0.3][] - 2025-11-02
 
 ### Added
+
 - Initial PyPI release
 - Python package structure with proper packaging configuration
 - Command-line tool `pfsense-redactor` installable via pip
@@ -652,6 +686,7 @@ reviewing that work, both older than 1.1.0.
   - MIT licence
 
 ### Technical Details
+
 - Python 3.8+ support
 - Zero external dependencies (uses only standard library)
 - Format-preserving redaction where possible
@@ -659,11 +694,13 @@ reviewing that work, both older than 1.1.0.
 - Security-first design with comprehensive pattern matching
 
 ### Installation
+
 ```bash
 pip install pfsense-redactor
 ```
 
 ### Usage
+
 ```bash
 # Basic usage
 pfsense-redactor config.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0][] - 2026-07-28
+## [1.2.1][] - 2026-07-28
 
 Secret detection hardening. Five classes of credential that previously survived
 redaction while the run reported success are now removed or reported.
@@ -678,7 +678,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
-[1.3.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.3.0
+[1.2.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.1
 [1.2.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.0
 [1.1.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.2
 [1.1.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ redaction while the run reported success are now removed or reported.
   `bearer`, `salt`, `seed`, `otpseed`, `digest`, `hash`, `nonce`, `keydata`,
   `keystore`, `authorization`, `sessionid` and `totp`. (FINDING-09)
 
+- **Element text and attribute values are classified by one shared function.**
+  `unambiguous_secret_kind` decides what counts as private-key material or a
+  JWT, and both paths dispatch on its answer, so the two cannot come to
+  different conclusions about the same value. This is the parity the name
+  patterns already have (FINDING-10), applied to values.
+
 ### Changed
 
 - Values in these positions may now be redacted where they were previously kept

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ scanner that fails differently, see
 | [Benchmark](https://github.com/grounzero/pfsense-redactor/blob/main/docs/benchmark.md) | Canary corpus results and known gaps |
 | [Examples](https://github.com/grounzero/pfsense-redactor/blob/main/docs/examples.md) | Before/after output, statistics, testing |
 | [FAQ](https://github.com/grounzero/pfsense-redactor/blob/main/docs/faq.md) | Common questions |
+| [Security remediation tracker](https://github.com/grounzero/pfsense-redactor/blob/main/docs/security-remediation-tracker.md) | Status of the July 2026 review findings |
 | [Changelog](https://github.com/grounzero/pfsense-redactor/blob/main/CHANGELOG.md) | Release history |
 
 ## Contributing

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -31,6 +31,21 @@ python -m pytest tests/ -q
 825 passed, 1 skipped, 57 xfailed
 ```
 
+After the adversarial suite and this page were committed (both add tests of
+their own), the same command reports:
+
+```text
+829 passed, 1 skipped, 57 xfailed
+```
+
+That is the number each pull request below is compared against.
+
+## Progress
+
+| PR | Full suite | Xfails removed | Xfails remaining |
+| --- | --- | --- | --- |
+| 1 | 1063 passed, 1 skipped, 26 xfailed | 31 | 26 |
+
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.
 

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -1,0 +1,83 @@
+# Security remediation tracker
+
+[← Documentation index](../README.md#documentation)
+
+Working record for the remediation of the July 2026 security review of
+`pfsense-redactor` 1.2.0. One row per scoped finding: where it is fixed, what
+proves it, and what changes for users.
+
+The review report itself is not part of this repository. This page carries the
+remediation state; finding identifiers are referenced by id only.
+
+## Delivery sequence
+
+Five stacked pull requests, each independently reviewable and each leaving the
+repository in a working state.
+
+| PR | Branch | Objective |
+| --- | --- | --- |
+| 1 | `security/secret-detection-hardening` | See key material the transformer previously walked past |
+| 2 | `security/independent-output-verifier` | Re-read the serialised output with rules the transformer does not share |
+| 3 | `security/verified-atomic-output` | Verify before anything becomes externally visible; write atomically at `0600` |
+| 4 | `security/strict-public-sharing-mode` | `--strict`: fail closed, no implicit configuration, machine-readable verdict |
+| 5 | `security/supply-chain-hardening` | Pin write-capable actions; keep OIDC the only release path |
+
+## Baseline
+
+Measured on `main` at `5e15f4c` before any production change:
+
+```text
+python -m pytest tests/ -q
+825 passed, 1 skipped, 57 xfailed
+```
+
+Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
+so closing one turns its test into a failure until the marker is removed.
+
+## Finding status
+
+Status values: `fixed`, `partial`, `deferred`, `not planned`.
+
+| Finding | Target PR | Existing test | New tests | Behaviour change | Compatibility impact | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| 01 PEM in unknown element retained | 1 | `test_redaction_gaps.py::TestKeyMaterialSurvival::test_pem_in_unknown_element_is_redacted` | private-key header matrix, log/preview leak checks | Private-key PEM is redacted in every mode, whatever element holds it | Values previously retained are now `[REDACTED_CERT_OR_KEY]` | fixed |
+| 02 PEM in attribute retained | 1 | `…::test_pem_in_attribute_is_redacted` | attribute PEM, multiline, whitespace | Same, for attribute values | As above | fixed |
+| 03 Encoded key material never decoded | 1 | `…::test_base64_wrapped_pem_is_redacted`, `…::test_double_base64_wrapped_pem_is_redacted` | bounded-decode unit suite | Bounded Base64/Base64URL inspection, depth 3 | Encoded key blobs are now redacted | fixed |
+| 04 Single-character-class blobs invisible | 1 | `test_redaction_gaps.py::TestEntropyDetectorBlindSpots` (3 cases) | hex/uppercase/lowercase/negative corpus | Long uniform values are detected by length and entropy | More values reported as retained; more redacted under `--aggressive` | fixed |
+| 05 JWTs invisible | 1 | `…::test_jwt_is_noticed` | JWT positive and negative corpus | JWT-like values are secrets in every mode | JWTs are redacted rather than retained | fixed |
+| 09 Credential-bearing element names missed | 1 | `TestNameCoverage::test_unmatched_secret_tags_are_matched` (13 cases) | deny-list regression | 13 further element names classified as secret-bearing | Elements previously kept are now redacted | fixed |
+| 10 Element and attribute patterns disagree | 1 | `TestNameCoverage::test_element_and_attribute_patterns_agree` (9 cases) | parity law | One shared predicate for both | Attribute and element handling now agree | fixed |
+| 21 No independent verification | 2 | `test_assurance_signals.py::TestFailClosed::test_retained_key_material_fails_the_run` | defect-injection suite | Separate verifier re-reads serialised output | New module; advisory in PR 2, enforcing in PR 3 | fixed |
+| 15 Input can be overwritten by output | 3 | `test_filesystem_safety.py::TestInputPreservation` (2 cases) | device/inode identity cases | Same-file output refused | `in.xml in.xml --force` now fails | fixed |
+| 16 Output symlink followed | 3 | `…::test_output_symlink_pointing_at_input_is_refused` | symlink destination cases | Symlink output refused | Writing through a symlink now fails | fixed |
+| 17 `--inplace` without `--force` | 3 | `…::test_inplace_requires_explicit_consent` | help/enforcement parity | `--inplace` requires `--force` | Scripts using bare `--inplace` must add `--force` | fixed |
+| 18 Output is world-readable | 3 | `TestWriteSafety::test_output_is_not_world_readable` | mode assertions | Output created `0600` | Downstream readers may need explicit permissions | fixed |
+| 19 Writes are not atomic | 3 | `TestWriteSafety` (2 cases) | fsync/replace failure injection | Temp file, `fsync`, `os.replace` | Hard-linked destinations are replaced, not written through | fixed |
+| 22 `--fail-on-warn` writes before failing | 3 | `test_assurance_signals.py::TestFailClosed::test_fail_on_warn_writes_no_output` | verdict-before-write cases | Verify, then write | A failing gate no longer leaves an artefact | fixed |
+| 13 Unbounded recursion on nesting | 4 | `test_parser_limits.py::TestRecursionBounds` (2 cases) | depth-limit cases | Depth bound, refusal instead of `RecursionError` | Very deep documents are refused | fixed |
+| 14 Oversized text silently truncated | 4 | `TestTextSizeBounds::test_oversized_text_is_not_silently_truncated` | oversized-value cases | Oversized text replaced, not truncated; refused under `--strict` | Oversized elements change representation | fixed |
+| 23 Only exit codes 0 and 1 | 4 | `TestFailClosed::test_exit_codes_distinguish_failure_kinds` | exit-code matrix | Distinct codes 0–6 | Non-zero remains non-zero; specific values are new | fixed |
+| 24 Config `<version>` never inspected | 4 | `TestUnsupportedInput::test_unsupported_config_version_is_reported` | version-report cases | Version reported; refused under `--strict` | Unknown versions are named on stderr | fixed |
+| 25 Implicit allow-lists | 4 | `TestImplicitConfiguration` (2 cases) | strict-mode discovery cases | Always announced; disabled under `--strict` | Extra stderr line in scripted modes | fixed |
+| 26 No machine-readable report | 4 | `TestMachineReadableAssurance::test_a_structured_report_is_available` | schema and permission cases | `--report-json` | New optional flag | fixed |
+| 27 Corpus score cannot see encoded survivors | 4 | `test_encoded_canary_scoring.py::TestCorpusScoringIsIncomplete` | benchmark documentation | Benchmark states the mode it measures | Documentation only | partial |
+| SC-01 Action pinned to a moving branch | 5 | — (workflow) | workflow assertions | SHA-pinned, gated push | Snapshot workflow gains pre-push checks | fixed |
+| SC-02 Dormant PyPI token | 5 | — (repository setting) | — | OIDC remains the only path | Requires a manual revocation | partial |
+| SC-03 Ruleset requires no checks | 5 | — (repository setting) | — | Documented required checks | Requires administrator action | deferred |
+| 29 Documentation drift | 5 | `tests/unit/test_docs_links.py` | documentation assertions | Corrected `/tmp`, bandit, version, reporting channel | Documentation only | fixed |
+
+## Findings not scoped for this sequence
+
+These remain open with their `xfail(strict=True)` markers intact. They are
+recorded here so the remaining risk is visible rather than implied.
+
+| Finding | Why it is not in this sequence |
+| --- | --- |
+| 06 Embedded JSON never parsed | Depends on the name predicate unified in PR 1; a JSON walker is a separate design decision |
+| 07 CDATA free text | A restatement of 11 rather than a separate mechanism |
+| 08 Element tails only under `--aggressive` | Defence in depth against XML pfSense does not emit |
+| 11 Identifier redaction gated on a tag list | Changing the default is a product decision with a real compatibility cost |
+| 12 Preview leaks the network and registrable domain | Privacy rather than credential exposure; needs a preview format decision |
+| 20 Input accepted on `st_size` alone | Diagnosis quality; both cases are already refused |
+| 28 Vacuous PEM invariant | Superseded in practice by `test_encoded_canary_scoring.py::TestPemInvariantIsNotVacuous`, which asserts the same invariant non-vacuously |
+| 30 Stray directory from an isolated test | Test hygiene, no product impact |

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -44,7 +44,7 @@ That is the number each pull request below is compared against.
 
 | PR | Full suite | Xfails removed | Xfails remaining |
 | --- | --- | --- | --- |
-| 1 | 1063 passed, 1 skipped, 26 xfailed | 31 | 26 |
+| 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,7 +85,7 @@ all-zero field, a run of padding and `abababab…` are not reported. UUIDs are
 excluded by shape: they are 36 characters of hex and hyphens, pfSense uses them
 as object identifiers, and none of them is a secret.
 
-Before 1.3.0 all three bands required two of {digit, upper, lower}, so an
+Before 1.2.1 all three bands required two of {digit, upper, lower}, so an
 all-lowercase token, an all-uppercase token and a digest spelled only in `a-f`
 were neither redacted **nor reported** — invisible to `--fail-on-warn` and to the
 summary as well as to the output.
@@ -121,7 +121,7 @@ the tool accepts whatever XML it is given. Attributes are handled two ways:
   and `descr`.
 - **By value.** Since 1.2.0, an attribute whose name says nothing but whose
   *value* looks like key material is reported among the retained high-entropy
-  values, and redacted under `--aggressive`. Since 1.3.0 the two unambiguous
+  values, and redacted under `--aggressive`. Since 1.2.1 the two unambiguous
   cases — private-key PEM and JWTs — are redacted here in every mode, on the
   same reasoning as for elements.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,12 +15,80 @@ Verify before sharing: see [verifying output](verifying-output.md), and see
 
 ## What gets redacted
 
-Secrets are found by **element name**, not by value shape, because a real SNMP
-community (`public`) or WPA passphrase looks like ordinary text. Matching is
+Secrets are found mostly by **element name**, not by value shape, because a real
+SNMP community (`public`) or WPA passphrase looks like ordinary text. Matching is
 substring-based, since the spellings that leak are the concatenated ones
 pfSense and its packages actually emit: `rocommunity`, `radiussecret`,
 `passwordagain`. A deny-list handles the false positives that creates
 (`keylen`, `certref`, `password_type`).
+
+Element names and attribute names are classified by **one** pattern. They were
+two, and they disagreed: `bearer`, `cookie` and `signature` were secrets only as
+attribute names, `credentials`, `privkey`, `psk`, `passphrase`, `licensekey` and
+`community` only as element names. A name means the same thing wherever it
+appears, so there is now a single predicate with the deny-list applied
+consistently to both.
+
+Short names that are common substrings of innocent ones — `auth`, `bearer`,
+`cookie`, `signature` — are matched on word boundaries. `author`, `authserver`,
+`enable_cookie` and `signature_algorithm` are not credentials and are left
+alone.
+
+`<digest>` and `<hash>` are decided by their value rather than their name.
+pfSense writes `<digest>SHA384</digest>` to select an IPsec algorithm and the
+reader needs it; the same element name can also hold a digest. A closed list of
+algorithm names is preserved and everything else in those elements is treated as
+a secret.
+
+### Key material is not a judgement call
+
+Three things are redacted on the strength of the **value alone**, in every mode,
+whatever element or attribute holds them and whether or not the name means
+anything to the tool:
+
+- **Private-key PEM material.** `PRIVATE KEY`, `RSA`/`EC`/`DSA`/`ED25519 PRIVATE
+  KEY`, `ENCRYPTED PRIVATE KEY`, `OPENSSH PRIVATE KEY`, `SSH2 ENCRYPTED PRIVATE
+  KEY`, `PGP PRIVATE KEY BLOCK` and OpenVPN's `STATIC KEY`. A public key or a
+  certificate is not one of these and is unaffected.
+- **The same material through an encoding.** Base64 and Base64URL values are
+  decoded to a bounded depth of 3 and re-examined. An encoding is not a
+  protection, and a package that stores its key base64-encoded is not thereby
+  storing something else.
+- **Compact JWTs.** `header.payload.signature`, recognised either by the `eyJ`
+  prefix or by the first segment decoding to a JOSE header.
+
+These carry no over-redaction risk to weigh, which is why they are removed
+rather than reported. Everything else the tool cannot name keeps the report-only
+default described under [opaque values](#opaque-values), where the
+false-positive argument genuinely applies.
+
+Decoding is bounded in every dimension — source length, decoded size, depth, and
+the total number of decode operations per value — because decoding
+attacker-influenced text without limits is its own vulnerability. Decoded
+content is inspected in memory and discarded: it is never logged, never sampled
+and never placed in an error message.
+
+### Opaque values
+
+A value the tool cannot name is judged on shape, and this is the only heuristic
+of the three. It must be at least 32 characters, free of whitespace, and
+Base64- or hex-shaped:
+
+| Shape | Rule |
+| --- | --- |
+| Hex, 32 characters or more | Treated as opaque. 32 hex characters is a 128-bit key or digest whatever subset of the alphabet it uses |
+| Base64, 36 characters or more | Treated as opaque regardless of character classes |
+| Base64, 32 to 36 characters | Must mix character classes — the band where an ordinary word collides with an encoded one |
+
+Every band also requires Shannon entropy above 2 bits per character, so an
+all-zero field, a run of padding and `abababab…` are not reported. UUIDs are
+excluded by shape: they are 36 characters of hex and hyphens, pfSense uses them
+as object identifiers, and none of them is a secret.
+
+Before 1.3.0 all three bands required two of {digit, upper, lower}, so an
+all-lowercase token, an all-uppercase token and a digest spelled only in `a-f`
+were neither redacted **nor reported** — invisible to `--fail-on-warn` and to the
+summary as well as to the output.
 
 ### Certificate references are resolved, not guessed
 
@@ -53,7 +121,9 @@ the tool accepts whatever XML it is given. Attributes are handled two ways:
   and `descr`.
 - **By value.** Since 1.2.0, an attribute whose name says nothing but whose
   *value* looks like key material is reported among the retained high-entropy
-  values, and redacted under `--aggressive`.
+  values, and redacted under `--aggressive`. Since 1.3.0 the two unambiguous
+  cases — private-key PEM and JWTs — are redacted here in every mode, on the
+  same reasoning as for elements.
 
 The second exists because name matching cannot see a blob in an innocuously
 named attribute, so before 1.2.0 such a value was invisible to `--fail-on-warn`

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.3.0"
+__version__ = "1.2.1"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -583,6 +583,42 @@ def contains_jwt(text: str) -> bool:
     return any(_segment_is_jose_header(match.group(1)) for match in candidates)
 
 
+# What an unambiguous secret is, and which placeholder replaces it. Ordered:
+# a value is classified by the first entry that matches.
+UNAMBIGUOUS_SECRET_KINDS: tuple[tuple[str, str, str], ...] = (
+    ('private-key', 'Cert/Key', '[REDACTED_CERT_OR_KEY]'),
+    ('jwt', 'Secret', '[REDACTED]'),
+)
+
+
+def unambiguous_secret_kind(text: str) -> str | None:
+    """Classify a value that is a credential whatever contains it
+
+    Returns 'private-key', 'jwt', or None. Both are structural facts about the
+    value rather than inferences from its name or its shape, so neither carries
+    the over-redaction risk that keeps the opaque-value heuristic in
+    report-only mode by default.
+
+    One function rather than a pair of checks at each call site, because there
+    are two call sites - element text and attribute values - and they must not
+    drift. The same reasoning produced one shared predicate for element and
+    attribute *names*; this is that principle applied to values.
+    """
+    if contains_private_key_material(text):
+        return 'private-key'
+    if contains_jwt(text):
+        return 'jwt'
+    return None
+
+
+def _redaction_for(kind: str) -> tuple[str, str]:
+    """The (statistics category, placeholder) pair for a secret kind"""
+    for name, category, placeholder in UNAMBIGUOUS_SECRET_KINDS:
+        if name == kind:
+            return category, placeholder
+    raise ValueError(f'unknown secret kind: {kind}')  # pragma: no cover - unreachable
+
+
 def shannon_entropy_bits(value: str) -> float:
     """Shannon entropy of `value`, in bits per character
 
@@ -2635,17 +2671,56 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self._redact_text_and_track(element, 'Secret')
         return True
 
+    def _redact_unambiguous_secret_element(self, element: ET.Element, text: str) -> bool:
+        """Remove private-key material or a JWT from element text, in every mode
+
+        These do not depend on the element being recognised, and they are not
+        subject to the report-only policy below: a PEM private-key header and a
+        compact JWT are unambiguous evidence, so there is no over-redaction risk
+        to trade against.
+        """
+        kind = unambiguous_secret_kind(text)
+        if kind is None:
+            return False
+
+        category, placeholder = _redaction_for(kind)
+        self._redact_text_and_track(element, category, placeholder)
+        return True
+
+    def _account_for_opaque_element(self, tag: str, element: ET.Element, text: str) -> bool:
+        """Redact or report an opaque value, which is the heuristic half
+
+        Default: record the value's location so users can audit it manually,
+        because the false-positive argument genuinely applies to a shapeless
+        blob. --aggressive: redact it.
+        """
+        if not self._is_high_entropy_value(text):
+            return False
+
+        if self.aggressive:
+            self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+            return True
+
+        # _path_stack holds ancestors only; this element's own tag completes it
+        self._record_retained_path('/'.join([*self._path_stack, tag]))
+        return False
+
+    def _record_retained_path(self, path: str) -> None:
+        """Count a retained high-entropy value and remember where it is"""
+        self.stats['high_entropy_retained'] += 1
+        if path not in self.high_entropy_paths:
+            self.high_entropy_paths.append(path)
+
     def _redact_unknown_blob_element(self, tag: str, element: ET.Element) -> bool:
         """Handle high-entropy values in elements we do not otherwise recognise
 
-        Private-key material: redacted, in every mode, whatever the element is
-        called. A PEM private-key header is unambiguous evidence, so there is no
-        over-redaction risk to trade against - the argument for report-only does
-        not apply to it.
+        Two policies, in order, split into a method each because they are
+        decided on different grounds:
 
-        Everything else keeps the previous policy, where that argument does
-        apply. Default: record the value's location so users can audit it
-        manually. --aggressive: redact it.
+        1. _redact_unambiguous_secret_element - private-key material and JWTs,
+           removed in every mode because the value itself settles the question
+        2. _account_for_opaque_element - everything else, where the shape is
+           only evidence and report-only remains the default
 
         The <key> handler already covers its own tag; everything else previously
         sailed through regardless of how much it looked like key material.
@@ -2656,30 +2731,9 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return False
 
         text = element.text.strip()
-
-        # Neither of these may survive because its XML tag is unrecognised.
-        if contains_private_key_material(text):
-            self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+        if self._redact_unambiguous_secret_element(element, text):
             return True
-
-        if contains_jwt(text):
-            self._redact_text_and_track(element, 'Secret')
-            return True
-
-        if not self._is_high_entropy_value(text):
-            return False
-
-        # _path_stack holds ancestors only; this element's own tag completes it
-        path = '/'.join([*self._path_stack, tag])
-
-        if self.aggressive:
-            self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
-            return True
-
-        self.stats['high_entropy_retained'] += 1
-        if path not in self.high_entropy_paths:
-            self.high_entropy_paths.append(path)
-        return False
+        return self._account_for_opaque_element(tag, element, text)
 
     def _redact_key_element_if_needed(self, tag: str, element: ET.Element) -> bool:
         """Redact <key> element if needed - can be short secret or PEM blob. Returns True if handled."""
@@ -2858,18 +2912,13 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         Private-key material and JWTs are the exceptions, on the same reasoning
         as _redact_unknown_blob_element: they are removed here rather than
-        reported, in every mode.
+        reported, in every mode. Both paths classify through
+        unambiguous_secret_kind, so the two cannot decide the same value
+        differently.
         """
         value = element.attrib[attr]
 
-        # Neither of these may survive because its attribute name is
-        # unrecognised.
-        if contains_private_key_material(value):
-            self._replace_attribute(element, attr, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
-            return
-
-        if contains_jwt(value):
-            self._replace_attribute(element, attr)
+        if self._redact_unambiguous_secret_attribute(element, attr, value):
             return
 
         if not self._is_high_entropy_value(value):
@@ -2879,10 +2928,23 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             self._replace_attribute(element, attr, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
             return
 
-        self.stats['high_entropy_retained'] += 1
-        path = f"{'/'.join([*self._path_stack, tag])}[@{attr}]"
-        if path not in self.high_entropy_paths:
-            self.high_entropy_paths.append(path)
+        self._record_retained_path(f"{'/'.join([*self._path_stack, tag])}[@{attr}]")
+
+    def _redact_unambiguous_secret_attribute(
+        self, element: ET.Element, attr: str, value: str
+    ) -> bool:
+        """The attribute counterpart of _redact_unambiguous_secret_element
+
+        Same classification, same ordering, same placeholders - only the
+        mechanism for replacing the value differs.
+        """
+        kind = unambiguous_secret_kind(value)
+        if kind is None:
+            return False
+
+        category, placeholder = _redaction_for(kind)
+        self._replace_attribute(element, attr, category, placeholder)
+        return True
 
     def _redact_sensitive_attributes(self, element: ET.Element, tag: str) -> None:
         """Handle attribute values: redact by name, and account for blobs in the rest

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -34,14 +34,18 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 import argparse
+import base64
+import binascii
+import math
 import re
 import sys
 import ipaddress
 import functools
 import logging
 from pathlib import Path
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Callable
+from itertools import islice
 from typing import NoReturn, Union
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode, SplitResult
 import os
@@ -180,14 +184,38 @@ CERT_KEY_ELEMENTS: frozenset[str] = frozenset({
 # concatenated forms are precisely what leaks. False positives are handled by
 # SECRET_TAG_DENYLIST below rather than by narrowing the pattern - consistent
 # with this tool's general stance that over-redaction beats under-redaction.
-SECRET_TAG_PATTERN = re.compile(
-    r'passw(?:or)?d|passphrase|(?:^|[_-])pass(?:$|[_-])'
+#
+# One pattern serves both elements and attributes. They previously disagreed -
+# 'bearer', 'cookie' and 'signature' were secrets as attribute names but not as
+# element names, and 'credentials', 'privkey', 'psk' and 'community' were the
+# reverse - which no threat model justifies. SENSITIVE_ATTR_PATTERN below is an
+# alias of this, so the two cannot drift apart again.
+#
+# Two anchoring styles, deliberately mixed:
+#
+#   substring     for names that only ever mean one thing, however they are
+#                 concatenated ('radiussecret', 'ipsecpsk', 'passwordagain')
+#   \b-anchored   for short names that are common substrings of innocent ones.
+#                 'auth' is a credential; 'author' is not. 'signature' is;
+#                 'signature_algorithm' is not.
+SECRET_NAME_PATTERN = re.compile(
+    r'passw(?:or)?d|passphrase|(?:^|[_-])pass(?:$|[_-])|pwd'
     r'|psk|pre-?shared-?key|shared-?key'
     r'|secret|token|community|credential|bindpw|licen[cs]e|webhook'
     r'|api[_-]?key|account-?key|authorized-?keys'
-    r'|priv(?:ate)?[_-]?key|key(?:s)?$|[_-]key\d*$',
+    r'|priv(?:ate)?[_-]?key|key(?:s)?$|[_-]key\d*$'
+    # Credential-bearing names measured as missed against real package configs
+    r'|key(?:data|store|material|blob)'
+    r'|otpseed|totp|nonce|salt|seed|digest|hash'
+    r'|session[_-]?id|authorization'
+    # Word-anchored: secrets in their own right, substrings of innocent names
+    r'|\b(?:auth(?:[_-]key|[_-]token|entication)?|bearer|cookie|signature)\b',
     re.IGNORECASE
 )
+
+# Retained under its historical name: imported by tests and by anything reading
+# the module as documentation. There is one pattern now, not two.
+SECRET_TAG_PATTERN = SECRET_NAME_PATTERN
 
 # Certificate-ish tags are redacted only when the content actually looks like
 # PEM/blob material, so short certificate *references* (refid-style IDs, which
@@ -219,6 +247,35 @@ SECRET_TAG_DENYLIST: frozenset[str] = frozenset({
     'snortcommunityrules',   # Boolean "use community ruleset" toggle
     'sendcommunity',         # Boolean toggle
     'source_hash_key',       # HAProxy load-balancing algorithm selector
+    # Algorithm selectors admitted by the widened name pattern. Each names a
+    # choice of algorithm; none can hold that algorithm's output.
+    'hash-algorithm', 'hash-algorithm-option', 'hashalgo', 'hashalgorithm',
+    'hash_algorithm', 'hashtype', 'hash_type', 'hashsize',
+    'digestalgo', 'digest_algorithm', 'digest-algorithm', 'digesttype',
+    'saltlen', 'saltlength', 'seedlen',
+    # OpenVPN directives whose names begin with the word 'auth'
+    'auth-retry', 'auth-retry-none', 'auth-nocache',
+})
+
+# Element names whose meaning depends on the value rather than the name.
+# <digest>SHA384</digest> selects an algorithm; <digest>9f86d081…</digest> is
+# one's output. pfSense uses the same spelling for both in IPsec and OpenVPN,
+# so the name alone cannot decide and the value is consulted.
+ALGORITHM_NAMED_ELEMENTS: frozenset[str] = frozenset({
+    'digest', 'hash',
+})
+
+# The complete set of values that keep an ALGORITHM_NAMED_ELEMENTS element. A
+# closed list rather than a shape test: anything outside it in one of those
+# elements is treated as a secret, which is the safe direction.
+ALGORITHM_VALUE_NAMES: frozenset[str] = frozenset({
+    'md5', 'sha1', 'sha-1', 'sha224', 'sha-224', 'sha256', 'sha-256',
+    'sha384', 'sha-384', 'sha512', 'sha-512',
+    'sha3-224', 'sha3-256', 'sha3-384', 'sha3-512',
+    'hmac-md5', 'hmac-sha1', 'hmac-sha256', 'hmac-sha384', 'hmac-sha512',
+    'aesxcbc', 'aes-xcbc', 'aescmac', 'aes-cmac',
+    'bcrypt', 'scrypt', 'argon2', 'argon2i', 'argon2id', 'pbkdf2',
+    'none', 'null', 'auto', 'default',
 })
 
 
@@ -289,6 +346,279 @@ BLOB_SECRET_DIRECTIVES: frozenset[str] = frozenset({
 BLOB_MIN_SCAN_LENGTH: int = 32
 BASE64ISH_RE = re.compile(r'^[A-Za-z0-9+/=_\-]+$')
 HEXISH_RE = re.compile(r'^[0-9A-Fa-f]+$')
+
+# A UUID is 36 characters of hex and hyphens, which satisfies every shape test
+# below. pfSense uses them as interface and object identifiers, and they carry
+# no secret, so they are excluded by shape rather than by tuning a threshold
+# until they happen to fall outside it.
+UUID_RE = re.compile(
+    r'\A[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
+    r'[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\Z'
+)
+
+# Opaque-value thresholds.
+#
+# 32 stays the floor at which a value is considered at all.
+#
+# From 32 to OPAQUE_UNIFORM_MIN_LENGTH, a Base64-shaped value must still mix
+# character classes: this is the band where an ordinary word collides with an
+# encoded one, and 'administratorsonlyplease' is not a key.
+#
+# At OPAQUE_UNIFORM_MIN_LENGTH and above, uniformity stops meaning anything. An
+# all-lowercase token, an all-uppercase token and a digest spelled only in a-f
+# are all plausible secrets at that length and none of them mixes classes. 36
+# rather than the 48 the review suggested, because the shortest single-class
+# secrets measured in package configs sit just above 36, and the one structural
+# value at that length - the UUID - is excluded above by shape.
+#
+# Hex-shaped values skip the band entirely: 32 hex characters is a 128-bit key
+# or digest whatever subset of the alphabet it uses, and requiring a digit made
+# a digest spelled only in a-f invisible.
+OPAQUE_UNIFORM_MIN_LENGTH: int = 36
+
+# Shannon entropy floor, in bits per character. Rejects values that satisfy a
+# shape but carry nothing: all-zero fields, repeated fill, and padding. A
+# base64 secret scores around 5; 'deadbeef' repeated scores 2.3; 40 zeroes
+# score 0.
+MIN_OPAQUE_ENTROPY_BITS: float = 2.0
+
+# ==========================================================================
+# Bounded inspection of encoded values
+# ==========================================================================
+# A value that decodes to key material is key material; an encoding is not a
+# protection. Decoding attacker-influenced text is also where a scanner turns
+# into a denial of service, so every dimension is bounded and named here rather
+# than being implicit in the loop.
+MAX_DECODE_DEPTH: int = 3            # single, double and triple wrapping
+MAX_DECODE_SOURCE_CHARS: int = 262144   # encoded text considered per value
+MAX_DECODED_BYTES: int = 65536       # produced per decode; a PEM key is ~3 KiB
+MAX_DECODE_OPERATIONS: int = 32      # total decodes per value, across all depths
+MIN_DECODE_CANDIDATE_CHARS: int = 24  # shorter runs cannot hide a key header
+
+# A run long enough that its decoding could not exceed MAX_DECODED_BYTES.
+MAX_ENCODED_RUN_CHARS: int = (MAX_DECODED_BYTES * 4) // 3 + 4
+
+# Base64 and Base64URL share an alphabet apart from two characters, so one
+# scanner finds both and the decoder tries each mapping.
+ENCODED_RUN_RE = re.compile(
+    r'[A-Za-z0-9+/=_-]{%d,}' % MIN_DECODE_CANDIDATE_CHARS
+)
+_URLSAFE_TO_STANDARD = str.maketrans('-_', '+/')
+
+# PEM headers that denote private key material.
+#
+# Unlike a certificate, there is no configuration in which sharing one of these
+# is intended, so a match is removed in every mode and in every element or
+# attribute. That makes this the one classification in the module with no
+# over-redaction trade-off to weigh.
+#
+# The algorithm qualifier is a bounded repetition rather than '.*' so the
+# pattern cannot backtrack pathologically over attacker-supplied text. It
+# covers PRIVATE KEY, RSA/EC/DSA/ED25519 PRIVATE KEY, ENCRYPTED PRIVATE KEY,
+# OPENSSH PRIVATE KEY, SSH2 ENCRYPTED PRIVATE KEY and PGP PRIVATE KEY BLOCK,
+# plus OpenVPN's static key, which pfSense writes for tls-auth and tls-crypt.
+PRIVATE_KEY_PEM_RE = re.compile(
+    r'-----BEGIN (?:[A-Z0-9]+ ){0,4}PRIVATE KEY(?: BLOCK)?-----'
+    r'|-----BEGIN OPENVPN STATIC KEY(?: V\d)?-----'
+)
+
+# Compact JWT. Anchored on 'eyJ', the Base64 of '{"' with which every compact
+# JOSE header begins, so an ordinary dotted string - a hostname, a version, an
+# IPv4 address, a filename - cannot reach it. Segment lengths are bounded to
+# keep matching linear.
+JWT_PREFIXED_RE = re.compile(
+    r'eyJ[A-Za-z0-9_-]{5,8192}\.[A-Za-z0-9_-]{4,8192}\.[A-Za-z0-9_-]{0,8192}'
+)
+
+# The general three-segment compact-token shape. Matching this alone would flag
+# any sufficiently long dotted string, so a match only counts when the first
+# segment actually decodes to a JOSE header (see _segment_is_jose_header). That
+# catches header encodings the 'eyJ' prefix misses without inventing findings.
+COMPACT_TOKEN_RE = re.compile(
+    r'(?<![A-Za-z0-9_.-])'
+    r'([A-Za-z0-9_-]{12,8192})\.([A-Za-z0-9_-]{8,8192})\.([A-Za-z0-9_-]{0,8192})'
+)
+MAX_TOKEN_CANDIDATES: int = 32
+
+
+def _b64_decode_bounded(candidate: str) -> bytes | None:
+    """Strictly decode one Base64 run, or None if it is not decodable
+
+    Strict validation matters: without it, base64 silently discards characters
+    outside the alphabet and manufactures a decoding for text that was never
+    encoded. Padding is added rather than required, because values stored in
+    attributes and JSON commonly arrive with it stripped.
+    """
+    body = ''.join(candidate.split()).rstrip('=')
+    if not body:
+        return None
+
+    padded = body + '=' * (-len(body) % 4)
+    for alphabet in (padded, padded.translate(_URLSAFE_TO_STANDARD)):
+        decoded = _b64_decode_strict(alphabet)
+        if decoded is not None:
+            return decoded
+    return None
+
+
+def _b64_decode_strict(padded: str) -> bytes | None:
+    """One strict decode attempt, refusing anything over MAX_DECODED_BYTES"""
+    try:
+        decoded = base64.b64decode(padded, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    if len(decoded) > MAX_DECODED_BYTES:
+        return None
+    return decoded or None
+
+
+def _decode_encoded_runs(layer: str, budget: int) -> tuple[list[str], int]:
+    """Decode the encoded runs in one layer, spending a shared operation budget
+
+    The budget is shared across the whole traversal rather than per layer, so
+    the total work for a value is bounded no matter how the runs are
+    distributed between depths.
+    """
+    produced: list[str] = []
+    for run in ENCODED_RUN_RE.findall(layer):
+        if budget <= 0:
+            break
+        if len(run) > MAX_ENCODED_RUN_CHARS:
+            continue
+        budget -= 1
+        decoded = _b64_decode_bounded(run)
+        if decoded is not None:
+            produced.append(decoded.decode('utf-8', errors='replace'))
+    return produced, budget
+
+
+def _next_decode_layer(
+    frontier: list[str], seen: set[str], budget: int
+) -> tuple[list[str], int]:
+    """Decode every layer in the frontier once, dropping what is not new
+
+    A decoding that reproduces something already seen is a dead end - it means
+    the value is not really layered - so it is dropped rather than expanded
+    again.
+    """
+    produced: list[str] = []
+    for layer in frontier:
+        decoded, budget = _decode_encoded_runs(layer, budget)
+        produced.extend(item for item in decoded if item not in seen)
+        seen.update(decoded)
+    return produced, budget
+
+
+def decoded_layers(text: str, max_depth: int = MAX_DECODE_DEPTH) -> list[str]:
+    """Successive decodings of the encoded runs in `text`, bounded throughout
+
+    Stops on decode failure, on a layer that reproduces something already seen,
+    at `max_depth`, at MAX_DECODE_OPERATIONS, and at the size limits. Returns
+    the decoded layers only - never the input - so a caller cannot accidentally
+    re-scan the original and double-count it.
+
+    Decoded content is inspected in memory and discarded. It is never logged,
+    never sampled and never placed in an exception message: it is by definition
+    the plaintext of something someone chose to encode.
+    """
+    if len(text) < MIN_DECODE_CANDIDATE_CHARS:
+        return []
+
+    source = text[:MAX_DECODE_SOURCE_CHARS]
+    layers: list[str] = []
+    frontier = [source]
+    seen = {source}
+    budget = MAX_DECODE_OPERATIONS
+
+    for _ in range(max_depth):
+        frontier, budget = _next_decode_layer(frontier, seen, budget)
+        layers.extend(frontier)
+        if not frontier or budget <= 0:
+            break
+
+    return layers
+
+
+def contains_private_key_material(text: str) -> bool:
+    """Whether `text` holds private-key PEM, directly or through an encoding
+
+    Checked before every heuristic in the module, and acted on in every mode.
+    """
+    if not text:
+        return False
+    if PRIVATE_KEY_PEM_RE.search(text):
+        return True
+    return any(PRIVATE_KEY_PEM_RE.search(layer) for layer in decoded_layers(text))
+
+
+def _segment_is_jose_header(segment: str) -> bool:
+    """Whether a compact-token segment decodes to a JOSE header object
+
+    A JWT header is a JSON object naming an algorithm. Requiring both facts is
+    what keeps the general three-segment shape from matching a long hostname.
+    """
+    decoded = _b64_decode_bounded(segment)
+    if decoded is None:
+        return False
+    return decoded.lstrip()[:1] == b'{' and b'"alg"' in decoded[:512]
+
+
+def contains_jwt(text: str) -> bool:
+    """Whether `text` contains a compact JWT-style token
+
+    Treated as a secret in every mode. The token's own segments are never
+    logged or sampled: a JWT header names the issuer and the payload usually
+    names the subject, so even a prefix is identifying.
+    """
+    if not text or '.' not in text:
+        return False
+    if JWT_PREFIXED_RE.search(text):
+        return True
+
+    candidates = islice(
+        COMPACT_TOKEN_RE.finditer(text[:MAX_DECODE_SOURCE_CHARS]),
+        MAX_TOKEN_CANDIDATES
+    )
+    return any(_segment_is_jose_header(match.group(1)) for match in candidates)
+
+
+def shannon_entropy_bits(value: str) -> float:
+    """Shannon entropy of `value`, in bits per character
+
+    One bounded pass over a string the caller has already length-capped.
+    """
+    if not value:
+        return 0.0
+
+    total = len(value)
+    return -sum(
+        (count / total) * math.log2(count / total)
+        for count in Counter(value).values()
+    )
+
+
+def _is_opaque_secret_shape(compact: str) -> bool:
+    """Whether a whitespace-free value is shaped like an opaque secret
+
+    See OPAQUE_UNIFORM_MIN_LENGTH for why the bands are where they are. Every
+    band additionally requires entropy above MIN_OPAQUE_ENTROPY_BITS, so a
+    value that satisfies a shape while carrying nothing is not reported.
+    """
+    if UUID_RE.match(compact):
+        return False
+
+    hex_shaped = bool(HEXISH_RE.match(compact))
+    if not (hex_shaped or BASE64ISH_RE.match(compact)):
+        return False
+
+    if shannon_entropy_bits(compact) < MIN_OPAQUE_ENTROPY_BITS:
+        return False
+
+    if hex_shaped or len(compact) >= OPAQUE_UNIFORM_MIN_LENGTH:
+        return True
+
+    return _has_mixed_character_classes(compact, hex_only=False)
 
 # Final labels that are file extensions rather than TLDs. FQDN_RE is
 # deliberately broad, so without this 'list.txt' and 'backup-2026.tar.gz' are
@@ -469,14 +799,14 @@ IP_CONTAINING_ELEMENTS: frozenset[str] = frozenset({
     'mac',  # MAC addresses in <mac> tags
 })
 
-# Compile regex for sensitive attribute matching (anchored patterns to avoid false positives)
-# Use word boundaries (\b) to match whole words or common separators (-, _)
-SENSITIVE_ATTR_PATTERN = re.compile(
-    r'\b(?:password|passwd|pass|key|secret|token|bearer|cookie|'
-    r'client[_-]?secret|client[_-]?key|api[_-]?key|apikey|'
-    r'auth(?:_key|_token|entication)?|signature)\b',
-    re.IGNORECASE
-)
+# Attribute names are classified by the same pattern as element names.
+#
+# These were two separate patterns, and they disagreed: 'bearer', 'cookie' and
+# 'signature' were secrets only as attributes, 'credentials', 'privkey', 'psk',
+# 'passphrase', 'licensekey' and 'community' only as elements. A name means the
+# same thing wherever it appears, so there is one pattern and this is an alias
+# of it. Kept as a name because tests and readers refer to it.
+SENSITIVE_ATTR_PATTERN = SECRET_NAME_PATTERN
 
 
 # ==========================================================================
@@ -2115,9 +2445,29 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return bool(CERT_TAG_PATTERN.search(tag) or CERT_TAG_PATTERN.search(tag_base))
 
+    @staticmethod
+    def _names_an_algorithm_choice(tag: str, tag_base: str, element: ET.Element) -> bool:
+        """Whether a digest/hash element selects an algorithm rather than holding one's output
+
+        <digest>SHA384</digest> is IPsec choosing an algorithm; the reader needs
+        it and it is not a secret. <digest>CANARY_ADV19_DIGEST</digest> in the
+        same element name is. Only the closed ALGORITHM_VALUE_NAMES list is
+        preserved, so anything unrecognised is still treated as a secret.
+        """
+        if tag not in ALGORITHM_NAMED_ELEMENTS and tag_base not in ALGORITHM_NAMED_ELEMENTS:
+            return False
+        if len(element) > 0:
+            return False
+
+        value = (element.text or '').strip().lower()
+        return not value or value in ALGORITHM_VALUE_NAMES
+
     def _should_redact_completely(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Check if element should be completely redacted and handle it. Returns True if handled."""
         if not self._is_secret_tag(tag, tag_base):
+            return False
+
+        if self._names_an_algorithm_choice(tag, tag_base, element):
             return False
 
         if element.text:
@@ -2155,9 +2505,26 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     def _is_high_entropy_value(self, text: str) -> bool:
         """Check whether a leaf value looks like an encoded secret
 
-        Stricter than _looks_like_secret_blob: requires the whole value to be
-        base64/hex-shaped, so ordinary long prose is not flagged.
+        Three classes, in descending order of certainty:
+
+        1. private-key material, including through a bounded decode
+        2. a compact JWT
+        3. an opaque shape - the only heuristic of the three
+
+        The first two are structural facts about the value rather than
+        judgements about it, so they are checked before the length floor: a
+        value can be shorter than BLOB_MIN_SCAN_LENGTH and still be a key
+        header or a token.
+
+        Stricter than _looks_like_secret_blob for case 3: the whole value must
+        be base64/hex-shaped, so ordinary long prose is not flagged.
         """
+        if contains_private_key_material(text):
+            return True
+
+        if contains_jwt(text):
+            return True
+
         if len(text) < BLOB_MIN_SCAN_LENGTH:
             return False
 
@@ -2171,10 +2538,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if _disqualified_as_blob(compact):
             return False
 
-        if not (BASE64ISH_RE.match(compact) or HEXISH_RE.match(compact)):
-            return False
-
-        return _has_mixed_character_classes(compact, hex_only=bool(HEXISH_RE.match(compact)))
+        return _is_opaque_secret_shape(compact)
 
     def _redact_blob_text_element(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Scan opaque free-text containers for inline credentials
@@ -2274,8 +2638,14 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     def _redact_unknown_blob_element(self, tag: str, element: ET.Element) -> bool:
         """Handle high-entropy values in elements we do not otherwise recognise
 
-        Default: record the value's location so users can audit it manually.
-        --aggressive: redact it.
+        Private-key material: redacted, in every mode, whatever the element is
+        called. A PEM private-key header is unambiguous evidence, so there is no
+        over-redaction risk to trade against - the argument for report-only does
+        not apply to it.
+
+        Everything else keeps the previous policy, where that argument does
+        apply. Default: record the value's location so users can audit it
+        manually. --aggressive: redact it.
 
         The <key> handler already covers its own tag; everything else previously
         sailed through regardless of how much it looked like key material.
@@ -2286,6 +2656,16 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return False
 
         text = element.text.strip()
+
+        # Neither of these may survive because its XML tag is unrecognised.
+        if contains_private_key_material(text):
+            self._redact_text_and_track(element, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+            return True
+
+        if contains_jwt(text):
+            self._redact_text_and_track(element, 'Secret')
+            return True
+
         if not self._is_high_entropy_value(text):
             return False
 
@@ -2425,14 +2805,30 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 return True
         return False
 
+    @staticmethod
+    def _is_secret_name(name: str) -> bool:
+        """Whether a name denotes a secret, deny-list applied
+
+        The single classification used for element names, attribute names and
+        key names inside blob text, so the same word cannot mean different
+        things in the three places it can appear.
+        """
+        lowered = name.lower()
+        if lowered in SECRET_TAG_DENYLIST:
+            return False
+        return bool(SECRET_NAME_PATTERN.search(lowered))
+
     def _should_redact_attribute(self, attr: str) -> bool:
         """Whether an attribute's value should be removed on the strength of its name
 
         Two reasons: the name denotes a secret, or the name denotes free prose
         and --redact-descriptions was asked for. The second is opt-in because
         notes and labels are often the most useful part of a config to a reader.
+
+        The deny-list applies here as it does to element names. 'keylen' and
+        'certref' name a length and a reference wherever they appear.
         """
-        if SENSITIVE_ATTR_PATTERN.search(attr):
+        if self._is_secret_name(attr):
             return True
         if not self.redact_descriptions:
             return False
@@ -2459,8 +2855,24 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         packages rather than an observed leak, and rewriting values on that
         basis would over-redact for everyone. Reporting costs nothing and is
         what the element path has always done.
+
+        Private-key material and JWTs are the exceptions, on the same reasoning
+        as _redact_unknown_blob_element: they are removed here rather than
+        reported, in every mode.
         """
-        if not self._is_high_entropy_value(element.attrib[attr]):
+        value = element.attrib[attr]
+
+        # Neither of these may survive because its attribute name is
+        # unrecognised.
+        if contains_private_key_material(value):
+            self._replace_attribute(element, attr, 'Cert/Key', '[REDACTED_CERT_OR_KEY]')
+            return
+
+        if contains_jwt(value):
+            self._replace_attribute(element, attr)
+            return
+
+        if not self._is_high_entropy_value(value):
             return
 
         if self.aggressive:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -481,7 +481,11 @@ def _decode_encoded_runs(layer: str, budget: int) -> tuple[list[str], int]:
     distributed between depths.
     """
     produced: list[str] = []
-    for run in ENCODED_RUN_RE.findall(layer):
+    # finditer, not findall: the loop usually stops on the operation budget
+    # long before the runs are exhausted, so materialising them all first is
+    # work thrown away on exactly the large values that make it expensive.
+    for match in ENCODED_RUN_RE.finditer(layer):
+        run = match.group()
         if budget <= 0:
             break
         if len(run) > MAX_ENCODED_RUN_CHARS:
@@ -2552,15 +2556,21 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         value can be shorter than BLOB_MIN_SCAN_LENGTH and still be a key
         header or a token.
 
-        Stricter than _looks_like_secret_blob for case 3: the whole value must
-        be base64/hex-shaped, so ordinary long prose is not flagged.
+        The complete predicate, and the one to call when nothing is known about
+        the value. A caller that has *already* ruled out cases 1 and 2 should
+        call _is_opaque_value instead: repeating them here costs a second
+        bounded decode of the same text, which is the expensive half.
         """
-        if contains_private_key_material(text):
+        if unambiguous_secret_kind(text) is not None:
             return True
+        return self._is_opaque_value(text)
 
-        if contains_jwt(text):
-            return True
+    def _is_opaque_value(self, text: str) -> bool:
+        """Case 3 alone: whether the value is shaped like an opaque secret
 
+        Stricter than _looks_like_secret_blob: the whole value must be
+        base64/hex-shaped, so ordinary long prose is not flagged.
+        """
         if len(text) < BLOB_MIN_SCAN_LENGTH:
             return False
 
@@ -2694,7 +2704,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         because the false-positive argument genuinely applies to a shapeless
         blob. --aggressive: redact it.
         """
-        if not self._is_high_entropy_value(text):
+        # _is_opaque_value, not _is_high_entropy_value: the caller has already
+        # established the value is not private-key material and not a JWT, and
+        # re-checking would decode it a second time.
+        if not self._is_opaque_value(text):
             return False
 
         if self.aggressive:
@@ -2921,7 +2934,9 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if self._redact_unambiguous_secret_attribute(element, attr, value):
             return
 
-        if not self._is_high_entropy_value(value):
+        # As in _account_for_opaque_element: the unambiguous cases are already
+        # ruled out above, so the complete predicate would decode twice.
+        if not self._is_opaque_value(value):
             return
 
         if self.aggressive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.2.0"
+version = "1.3.0"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.3.0"
+version = "1.2.1"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/adversarial/__init__.py
+++ b/tests/adversarial/__init__.py
@@ -1,0 +1,14 @@
+"""Adversarial test suite - security review 2026-07
+
+These tests assert the security property that *should* hold, not the behaviour
+that currently does. Where a gap is real today the test carries
+``@pytest.mark.xfail(strict=True)``, so:
+
+- today it reports xfail and the suite stays green;
+- the day someone closes the gap it reports XPASS, which strict xfail turns
+  into a failure, forcing the marker to be removed.
+
+A gap therefore cannot be closed silently, and cannot be reopened silently
+either. Findings referenced as FINDING-nn map to
+docs/security-review-2026-07.md.
+"""

--- a/tests/adversarial/conftest.py
+++ b/tests/adversarial/conftest.py
@@ -24,12 +24,25 @@ def _subprocess_env() -> dict[str, str]:
     pytest from inside tests/, where that import is not guaranteed, so the
     fallback keeps these tests runnable from either working directory - they
     just go uninstrumented.
+
+    PROJECT_ROOT is put on PYTHONPATH either way. Several tests below run the
+    CLI with cwd set to a temporary directory, and `python -m pfsense_redactor`
+    finds the package from the current directory only when that directory is
+    the repository root. Without this, a job that runs pytest without
+    `pip install -e .` gets ModuleNotFoundError from every such run - which is
+    worse than a plain failure, because a test asserting "this was refused"
+    cannot tell a refusal from a subprocess that never started.
     """
     try:
         from tests.conftest import subprocess_env  # pylint: disable=import-outside-toplevel
+        env = subprocess_env()
     except ImportError:
-        return os.environ.copy()
-    return subprocess_env()
+        env = os.environ.copy()
+
+    existing = env.get("PYTHONPATH", "")
+    root = str(PROJECT_ROOT)
+    env["PYTHONPATH"] = f"{root}{os.pathsep}{existing}" if existing else root
+    return env
 
 
 @pytest.fixture
@@ -40,6 +53,14 @@ def adversarial_canary() -> Path:
     return ADVERSARIAL_CANARY
 
 
+# Startup failures that produce a non-zero exit and an empty stdout without
+# the tool having run at all.
+_NEVER_STARTED = (
+    "No module named pfsense_redactor",
+    "ModuleNotFoundError",
+)
+
+
 @pytest.fixture
 def run_redactor():
     """Run the CLI as a subprocess and return the CompletedProcess
@@ -47,9 +68,16 @@ def run_redactor():
     A thin wrapper rather than CLIRunner because these tests care about the
     exit code and the side effects on disk in cases where the run is *meant*
     to fail, which CLIRunner's expect_success default gets in the way of.
+
+    A subprocess that never started is turned into an immediate test failure
+    rather than being returned. Most tests here assert some combination of
+    "non-zero exit" and "the file was not modified", and an interpreter that
+    could not import the package satisfies both without executing a line of
+    the code under test. That is the difference between a security test
+    passing and a security test being *asked*, and it has to be loud.
     """
     def _run(*args, cwd: Path | None = None) -> subprocess.CompletedProcess:
-        return subprocess.run(
+        result = subprocess.run(
             [sys.executable, "-m", "pfsense_redactor", *[str(a) for a in args]],
             capture_output=True,
             text=True,
@@ -57,6 +85,13 @@ def run_redactor():
             env=_subprocess_env(),
             check=False,
         )
+
+        if any(marker in result.stderr for marker in _NEVER_STARTED):
+            pytest.fail(
+                "the redactor never started, so nothing below was actually "
+                f"tested:\n{result.stderr.strip()[:800]}"
+            )
+        return result
     return _run
 
 

--- a/tests/adversarial/conftest.py
+++ b/tests/adversarial/conftest.py
@@ -1,0 +1,68 @@
+"""Fixtures shared by the adversarial suite
+
+Builds on tests/conftest.py rather than replacing it: cli_runner, script_path
+and the tmp_path-based helpers all still apply here.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES = Path(__file__).parent / "fixtures"
+ADVERSARIAL_CANARY = FIXTURES / "adversarial-canary.xml"
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Child-process environment, with coverage enabled when it is available
+
+    Defers to tests/conftest.py's version when it can be imported. CI runs
+    pytest from inside tests/, where that import is not guaranteed, so the
+    fallback keeps these tests runnable from either working directory - they
+    just go uninstrumented.
+    """
+    try:
+        from tests.conftest import subprocess_env  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        return os.environ.copy()
+    return subprocess_env()
+
+
+@pytest.fixture
+def adversarial_canary() -> Path:
+    """The adversarial corpus, which is expected to defeat several passes"""
+    if not ADVERSARIAL_CANARY.exists():  # pragma: no cover - repo integrity
+        pytest.skip(f"missing fixture: {ADVERSARIAL_CANARY}")
+    return ADVERSARIAL_CANARY
+
+
+@pytest.fixture
+def run_redactor():
+    """Run the CLI as a subprocess and return the CompletedProcess
+
+    A thin wrapper rather than CLIRunner because these tests care about the
+    exit code and the side effects on disk in cases where the run is *meant*
+    to fail, which CLIRunner's expect_success default gets in the way of.
+    """
+    def _run(*args, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-m", "pfsense_redactor", *[str(a) for a in args]],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd or PROJECT_ROOT),
+            env=_subprocess_env(),
+            check=False,
+        )
+    return _run
+
+
+@pytest.fixture
+def canary_copy(adversarial_canary, tmp_path) -> Path:
+    """A writable copy of the adversarial corpus, for tests that mutate paths"""
+    target = tmp_path / "config.xml"
+    target.write_bytes(adversarial_canary.read_bytes())
+    return target

--- a/tests/adversarial/decode_scan.py
+++ b/tests/adversarial/decode_scan.py
@@ -1,0 +1,123 @@
+"""Decode-aware canary scanner
+
+The shipped corpus score in tests/integration/test_canary_corpus.py counts
+survivors with a literal ``CANARY_[A-Z0-9_]+`` regex over the output. Anything
+the config author encoded is therefore invisible to it: the base64 blob at
+tests/corpus/canary-corpus.xml:105 decodes to a CANARY marker, is provably
+retained in default mode, and still does not count against the 44/46 score.
+
+This module finds markers through base64 layers so a leak cannot hide behind an
+encoding. It is deliberately separate from the redactor: a verifier that shares
+the transformer's assumptions cannot catch the transformer's mistakes.
+
+Usable as a filter as well as an import::
+
+    pfsense-redactor config.xml --stdout | python tests/adversarial/decode_scan.py
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+import sys
+
+# Base64-ish runs long enough to carry something worth hiding. 24 rather than
+# 32: 'CANARY_ADV05' padded to a base64 quantum is shorter than a key blob, and
+# the cost of decoding a few extra runs is nothing.
+_B64_RUN = re.compile(r'[A-Za-z0-9+/=_\-]{24,}')
+
+# Matches the corpus convention (CANARY_FOO) and this suite's (CANARY_ADV01_X).
+MARKER_RE = re.compile(r'CANARY_[A-Z0-9_]+')
+
+# Three layers covers single, double and triple wrapping. Unbounded recursion
+# on attacker-supplied text is the mistake this file exists to look for
+# elsewhere, so it is not repeated here.
+MAX_DECODE_DEPTH = 3
+
+
+def _decode_candidates(text: str) -> list[str]:
+    """Every base64-ish run in `text`, decoded, dropping what does not decode"""
+    out = []
+    for run in _B64_RUN.findall(text):
+        # urlsafe first, then standard: the two differ only in - _ vs + /, and
+        # trying both means a URL-safe token is not missed.
+        for decoder in (base64.urlsafe_b64decode, base64.b64decode):
+            try:
+                padded = run + '=' * (-len(run) % 4)
+                decoded = decoder(padded.encode('ascii'))
+            except (binascii.Error, ValueError):
+                continue
+            try:
+                out.append(decoded.decode('utf-8', errors='replace'))
+            except UnicodeDecodeError:  # pragma: no cover - errors='replace'
+                pass
+            break
+    return out
+
+
+def find_markers(text: str, max_depth: int = MAX_DECODE_DEPTH) -> set[str]:
+    """Canary markers in `text`, literal or reachable by base64 decoding
+
+    Also searches the whitespace-stripped form, so a marker broken across lines
+    inside one element is found. That is how a real secret survives a
+    line-oriented scanner, and it is how this one is meant not to.
+    """
+    found: set[str] = set()
+    layers = [text]
+
+    for _ in range(max_depth + 1):
+        if not layers:
+            break
+        next_layers = []
+        for layer in layers:
+            found.update(MARKER_RE.findall(layer))
+            found.update(MARKER_RE.findall(re.sub(r'\s+', '', layer)))
+            next_layers.extend(_decode_candidates(layer))
+        layers = next_layers
+
+    return found
+
+
+def find_key_material(text: str) -> set[str]:
+    """PEM header labels in `text`, literal or reachable by base64 decoding
+
+    Separate from find_markers because key material is recognisable without a
+    planted marker, and is the thing whose survival matters most.
+    """
+    pem = re.compile(r'-----BEGIN ([A-Z0-9 ]+)-----')
+    found: set[str] = set()
+    layers = [text]
+
+    for _ in range(MAX_DECODE_DEPTH + 1):
+        if not layers:
+            break
+        next_layers = []
+        for layer in layers:
+            found.update(pem.findall(layer))
+            next_layers.extend(_decode_candidates(layer))
+        layers = next_layers
+
+    return found
+
+
+def main() -> int:
+    """Report markers and key material found on stdin"""
+    data = sys.stdin.read()
+    markers = sorted(find_markers(data))
+    keys = sorted(find_key_material(data))
+
+    for marker in markers:
+        print(f"MARKER   {marker}")
+    for label in keys:
+        print(f"KEY      BEGIN {label}")
+
+    if markers or keys:
+        print(f"\n{len(markers)} marker(s), {len(keys)} key type(s) survived.")
+        return 1
+
+    print("nothing found")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/adversarial/fixtures/adversarial-canary.xml
+++ b/tests/adversarial/fixtures/adversarial-canary.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+<!--
+  ADVERSARIAL CANARY CORPUS - security review 2026-07
+
+  EVERY VALUE IN THIS FILE IS SYNTHETIC. There are no real credentials, keys,
+  certificates, hostnames or addresses here. The "PEM" blocks are base64-legal
+  runs of the literal word CANARY; they are not keys and decode to nothing.
+  IP addresses are drawn from RFC 5737 / RFC 3849 / RFC 2544 documentation
+  ranges. Domains use .example and .invalid.
+
+  This file is the counterpart to tests/corpus/canary-corpus.xml. That corpus
+  measures what the tool catches; this one is built to probe where it does
+  not, so most markers here are EXPECTED to survive default-mode redaction
+  today. Each is paired with a test in tests/adversarial/ that either pins the
+  gap (xfail strict) or pins the correct behaviour (plain assertion).
+
+  Marker convention: CANARY_ADVnn_<WHAT>. Encoded markers (ADV04, ADV05, ADV06)
+  are not greppable as literals by design - that is the point they exist to
+  make, and tests/adversarial/decode_scan.py is what finds them.
+-->
+<pfsense>
+  <version>23.1</version>
+
+  <!-- ADV01: a credential in an element name no pattern anticipates.
+       Third-party packages invent field names freely. -->
+  <installedpackages>
+    <mqttbridge>
+      <config>
+        <mqtt_login_string>CANARY_ADV01_UNEXPECTED_TAG</mqtt_login_string>
+      </config>
+    </mqttbridge>
+
+    <!-- ADV02: private key material in an XML attribute whose name is not
+         matched by SENSITIVE_ATTR_PATTERN ('privkey' has no word boundary
+         before 'key'). -->
+    <vendoragent>
+      <config>
+        <endpoint privkey="-----BEGIN RSA PRIVATE KEY-----&#10;CANARYADV02PRIVATEKEYCANARYADV02PRIVATEKEYCANARYADV02PRIVATE0123&#10;-----END RSA PRIVATE KEY-----" host="collector.vendor.invalid"/>
+      </config>
+    </vendoragent>
+
+    <!-- ADV03: an entire PEM private key in an element the tool does not
+         recognise. Reported as high-entropy, retained, exit code 0. -->
+    <telemetryagent>
+      <config>
+        <vendorblob>-----BEGIN RSA PRIVATE KEY-----
+CANARYADV03PRIVATEKEYCANARYADV03PRIVATEKEYCANARYADV03PRIVATE0123
+CANARYADV03PRIVATEKEYCANARYADV03PRIVATEKEYCANARYADV03PRIVATE4567
+-----END RSA PRIVATE KEY-----</vendorblob>
+      </config>
+    </telemetryagent>
+
+    <!-- ADV04: the same private key, base64-encoded once. No decoding layer
+         exists, so the PEM marker is never seen. -->
+    <backupagent>
+      <config>
+        <payload>LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpDQU5BUllBRFYwM1BSSVZBVEVLRVlDQU5BUllBRFYwM1BSSVZBVEVLRVlDQU5BUllBRFYwM1BSSVZBVEUwMTIzCkNBTkFSWUFEVjAzUFJJVkFURUtFWUNBTkFSWUFEVjAzUFJJVkFURUtFWUNBTkFSWUFEVjAzUFJJVkFURTQ1NjcKLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K</payload>
+      </config>
+    </backupagent>
+
+    <!-- ADV05: the same private key, base64-encoded twice. -->
+    <syncagent>
+      <config>
+        <blob>TFMwdExTMUNSVWRKVGlCU1UwRWdVRkpKVmtGVVJTQkxSVmt0TFMwdExRcERRVTVCVWxsQlJGWXdNMUJTU1ZaQlZFVkxSVmxEUVU1QlVsbEJSRll3TTFCU1NWWkJWRVZMUlZsRFFVNUJVbGxCUkZZd00xQlNTVlpCVkVVd01USXpDa05CVGtGU1dVRkVWakF6VUZKSlZrRlVSVXRGV1VOQlRrRlNXVUZFVmpBelVGSkpWa0ZVUlV0RldVTkJUa0ZTV1VGRVZqQXpVRkpKVmtGVVJUUTFOamNLTFMwdExTMUZUa1FnVWxOQklGQlNTVlpCVkVVZ1MwVlpMUzB0TFMwSw==</blob>
+      </config>
+    </syncagent>
+
+    <!-- ADV06: one secret split across lines inside a single element. Each
+         fragment on its own is short; concatenated they are the credential. -->
+    <chunkedagent>
+      <config>
+        <parts>CANARY_ADV06_
+SPLIT_ACROSS_
+LINES_SECRET</parts>
+      </config>
+    </chunkedagent>
+
+    <!-- ADV07: credentials in a URL. This one SHOULD be caught in every mode -
+         it is a regression pin, not a gap. -->
+    <feedagent>
+      <config>
+        <updateurl>https://svcacct:CANARY_ADV07_URLPASS@feeds.vendor.invalid/list?token=CANARY_ADV07_QUERYTOKEN</updateurl>
+      </config>
+    </feedagent>
+
+    <!-- ADV08: a secret inside CDATA. ElementTree flattens CDATA to text, so
+         the value is reachable - but only by the same name-based rules. -->
+    <noteagent>
+      <config>
+        <freeform><![CDATA[deploy key is CANARY_ADV08_INSIDE_CDATA - do not share]]></freeform>
+      </config>
+    </noteagent>
+
+    <!-- ADV09: JSON embedded in element text. No JSON parsing exists, and
+         'cfg' matches nothing, so the whole object survives. -->
+    <jsonagent>
+      <config>
+        <cfg>{"endpoint": "https://api.vendor.invalid", "api_secret": "CANARY_ADV09_JSON_SECRET", "retries": 3}</cfg>
+      </config>
+    </jsonagent>
+
+    <!-- ADV10 / ADV11: mixed case and namespace prefixes. Both SHOULD be
+         caught - regression pins for _normalise_tag. -->
+    <caseagent>
+      <config>
+        <ApiKey>CANARY_ADV10_MIXEDCASE</ApiKey>
+        <PASSWORD>CANARY_ADV10_UPPERCASE</PASSWORD>
+      </config>
+    </caseagent>
+
+    <!-- ADV12: unfamiliar package field holding a bearer token. -->
+    <unknownpkg>
+      <config>
+        <authorization>Bearer CANARY_ADV12_AUTHZ_HEADER</authorization>
+        <sessionid>CANARY_ADV12_SESSIONID</sessionid>
+      </config>
+    </unknownpkg>
+
+    <!-- ADV13/14/15/16: high-entropy blobs of differing character classes.
+         Only the mixed-class ones are seen by _is_high_entropy_value. -->
+    <entropyagent>
+      <config>
+        <mixedblob>aGVsbG8gd29ybGQxMjM0NTY3ODkwQUJDREVGRw==</mixedblob>
+        <lowerblob>canaryadvfourteenlowercaseonlysecretvalue</lowerblob>
+        <upperblob>CANARYADVFIFTEENUPPERCASEONLYSECRETVALUE</upperblob>
+        <hexblob>deadbeefdeadbeefdeadbeefcafefeedcafefeed</hexblob>
+        <jwt>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJDQU5BUllfQURWMTZfSldUIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk</jwt>
+      </config>
+    </entropyagent>
+
+    <!-- ADV17/18/19: secret-bearing element names neither pattern matches. -->
+    <namingagent>
+      <config>
+        <pwd>CANARY_ADV17_PWD_TAG</pwd>
+        <bearer>CANARY_ADV18_BEARER_TAG</bearer>
+        <otpseed>CANARY_ADV19_OTPSEED</otpseed>
+        <salt>CANARY_ADV19_SALT</salt>
+        <digest>CANARY_ADV19_DIGEST</digest>
+        <keydata>CANARY_ADV19_KEYDATA</keydata>
+        <keystore>CANARY_ADV19_KEYSTORE</keystore>
+      </config>
+    </namingagent>
+
+    <!-- ADV20: a public routable address in an element outside
+         IP_CONTAINING_ELEMENTS. RFC 2544 benchmarking range, treated as
+         global by the ipaddress module. -->
+    <logagent>
+      <config>
+        <syslogtarget>198.18.51.77</syslogtarget>
+        <collector_fqdn_note>ships to collector.megacorp-holdings.example</collector_fqdn_note>
+      </config>
+    </logagent>
+
+    <!-- ADV22: a filename that looks like a hostname. Must NOT be rewritten
+         to example.com - corrupting a feed name is its own failure. -->
+    <feednames>
+      <config>
+        <path>/var/db/pfblockerng/deny.megacorp-holdings.example.txt</path>
+        <script>/usr/local/bin/haproxy.sh</script>
+      </config>
+    </feednames>
+
+    <!-- ADV23: values shaped exactly like this tool's own anonymised output,
+         present in the INPUT. A second pass must not renumber them into a
+         different identity. -->
+    <preanonymised>
+      <config>
+        <hostname>domain1.example</hostname>
+        <dnsserver>192.0.2.1</dnsserver>
+      </config>
+    </preanonymised>
+  </installedpackages>
+
+  <!-- ADV21: a secret in an element tail (mixed content). Only reached in
+       aggressive mode. -->
+  <notes><marker/>CANARY_ADV21_TAIL_SECRET</notes>
+
+  <!-- Baseline positives: these must always be caught, in every mode. -->
+  <system>
+    <hostname>fw-edge-01</hostname>
+    <domain>corp.megacorp-holdings.example</domain>
+    <user>
+      <name>admin</name>
+      <bcrypt-hash>$2y$10$CANARY_ADV_BCRYPT_BASELINE_HASH_VALUE</bcrypt-hash>
+      <authorizedkeys>CANARY_ADV_AUTHKEYS_BASELINE</authorizedkeys>
+    </user>
+  </system>
+  <snmpd>
+    <rocommunity>CANARY_ADV_ROCOMMUNITY_BASELINE</rocommunity>
+  </snmpd>
+</pfsense>

--- a/tests/adversarial/test_assurance_signals.py
+++ b/tests/adversarial/test_assurance_signals.py
@@ -1,0 +1,233 @@
+"""Phase 6: what the tool tells the operator, and whether it fails closed
+
+A redactor's exit code and summary are the only things most users read. If a
+run that left a private key in the output reports success, the tool has not
+just failed to redact - it has certified the failure.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from .decode_scan import find_key_material
+
+
+class TestFailClosed:
+    """Unsafe output must not be distributable"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-21: retained high-entropy values warn but do not fail, "
+               "so a run that left a private key in the output exits 0",
+    )
+    def test_retained_key_material_fails_the_run(self, adversarial_canary, run_redactor):
+        """Output holding a private key must not exit 0"""
+        result = run_redactor(adversarial_canary, "--stdout")
+
+        assert find_key_material(result.stdout), "fixture no longer leaks - update the test"
+        assert result.returncode != 0, (
+            "exit 0 on output containing a private key certifies the leak"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-22: --fail-on-warn reports failure only after the "
+               "output has already been written, so the gate does not prevent "
+               "the unsafe artefact from existing",
+    )
+    def test_fail_on_warn_writes_no_output(self, adversarial_canary, run_redactor, tmp_path):
+        """The gate must prevent the artefact, not just report on it"""
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(adversarial_canary, out, "--fail-on-warn")
+
+        assert result.returncode != 0, "fixture no longer trips the gate"
+        assert not out.exists(), (
+            f"the gate failed but still produced {out.stat().st_size} bytes "
+            f"of output for someone to share"
+        )
+
+    def test_fail_on_warn_does_fail(self, adversarial_canary, run_redactor):
+        """Regression pin: the gate itself works, whatever its timing"""
+        result = run_redactor(adversarial_canary, "--stdout", "--fail-on-warn")
+        assert result.returncode != 0
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-23: only 0 and 1 are used, so a caller cannot tell a "
+               "refused input from a retained secret from a write failure",
+    )
+    def test_exit_codes_distinguish_failure_kinds(self, tmp_path, run_redactor,
+                                                  adversarial_canary):
+        """A CI job needs to tell apart why a run failed"""
+        malformed = tmp_path / "bad.xml"
+        malformed.write_text("<pfsense><unclosed></pfsense>")
+
+        parse_failure = run_redactor(malformed, "--stdout").returncode
+        gate_failure = run_redactor(adversarial_canary, "--stdout", "--fail-on-warn").returncode
+
+        assert parse_failure != gate_failure, (
+            f"both failure kinds exit {parse_failure}; a CI job cannot tell "
+            f"'this file is not parseable' from 'this file still has secrets'"
+        )
+
+
+class TestUnsupportedInput:
+    """Structures the tool has no basis for understanding"""
+
+    def test_unknown_root_tag_warns(self, tmp_path, run_redactor):
+        """A non-pfSense root is surfaced to the operator"""
+        config = tmp_path / "other.xml"
+        config.write_text("<opnsense><system><password>CANARY_PW</password></system></opnsense>")
+
+        result = run_redactor(config, "--stdout")
+        assert "Warning" in result.stderr and "pfsense" in result.stderr
+
+    def test_unknown_root_tag_fails_under_fail_on_warn(self, tmp_path, run_redactor):
+        """And is fatal when the gate is asked for"""
+        config = tmp_path / "other.xml"
+        config.write_text("<opnsense><system><password>CANARY_PW</password></system></opnsense>")
+
+        result = run_redactor(config, "--stdout", "--fail-on-warn")
+        assert result.returncode != 0
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-24: the config's own <version> is never inspected, so "
+               "a schema the tool has never seen is accepted silently",
+    )
+    def test_unsupported_config_version_is_reported(self, tmp_path, run_redactor):
+        """An unrecognised schema version is named, not ignored"""
+        config = tmp_path / "future.xml"
+        config.write_text(
+            "<pfsense><version>99.9</version><system><password>CANARY_PW</password>"
+            "</system></pfsense>"
+        )
+
+        result = run_redactor(config, "--stdout")
+
+        # stderr only: stdout carries the XML declaration, whose own
+        # version="1.0" would satisfy any naive search for the word.
+        assert "99.9" in result.stderr, (
+            "nothing in the run tells the operator the schema is unrecognised"
+        )
+
+
+class TestImplicitConfiguration:
+    """Security behaviour must not change because of where you ran the tool"""
+
+    @pytest.fixture
+    def workdir_with_allowlist(self, canary_copy, tmp_path):
+        """A working directory containing an implicit .pfsense-allowlist"""
+        (tmp_path / ".pfsense-allowlist").write_text(
+            "# picked up silently from the current directory\n"
+            "megacorp-holdings.example\n"
+            "198.18.51.77\n"
+        )
+        return tmp_path
+
+    def test_implicit_allowlist_changes_the_output(self, workdir_with_allowlist, run_redactor):
+        """Establishes that the file really does take effect"""
+        with_list = run_redactor("config.xml", "--stdout", cwd=workdir_with_allowlist).stdout
+        (workdir_with_allowlist / ".pfsense-allowlist").unlink()
+        without = run_redactor("config.xml", "--stdout", cwd=workdir_with_allowlist).stdout
+
+        assert with_list != without, "the implicit allow-list had no effect"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-25: the 'Loaded default allow-list' notice is "
+               "suppressed under --stdout and --dry-run, the two modes most "
+               "likely to be scripted",
+    )
+    def test_implicit_allowlist_is_announced_in_stdout_mode(self, workdir_with_allowlist,
+                                                            run_redactor):
+        """Weakened redaction must never be silent"""
+        result = run_redactor("config.xml", "--stdout", cwd=workdir_with_allowlist)
+        assert "allow-list" in result.stderr.lower(), (
+            "redaction was weakened by a file in the working directory and "
+            "the run never said so"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-25: same suppression under --dry-run",
+    )
+    def test_implicit_allowlist_is_announced_in_dry_run(self, workdir_with_allowlist,
+                                                        run_redactor):
+        """Same requirement in the mode used to decide about sharing"""
+        result = run_redactor("config.xml", "--dry-run", cwd=workdir_with_allowlist)
+        combined = result.stdout + result.stderr
+        assert "allow-list" in combined.lower()
+
+    def test_no_default_allowlist_disables_it(self, workdir_with_allowlist, run_redactor):
+        """Regression pin for the opt-out"""
+        with_list = run_redactor("config.xml", "--stdout", cwd=workdir_with_allowlist).stdout
+        without = run_redactor(
+            "config.xml", "--stdout", "--no-default-allowlist", cwd=workdir_with_allowlist
+        ).stdout
+        assert with_list != without
+
+
+class TestMachineReadableAssurance:
+    """A sharing decision should be checkable by something other than a human"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-26: there is no machine-readable report; the retained "
+               "paths and counts exist only as prose on stderr",
+    )
+    def test_a_structured_report_is_available(self, adversarial_canary, run_redactor, tmp_path):
+        """A sharing gate needs something other than prose to read"""
+        import json  # pylint: disable=import-outside-toplevel
+
+        report = tmp_path / "report.json"
+        result = run_redactor(adversarial_canary, "--dry-run", "--report-json", report)
+
+        assert result.returncode == 0, f"flag not accepted: {result.stderr.strip()[:200]}"
+        assert report.exists(), "no report written"
+
+        data = json.loads(report.read_text())
+        assert "retained" in data or "high_entropy_retained" in data
+
+    def test_retained_paths_are_named_on_stderr(self, adversarial_canary, run_redactor):
+        """What exists today: prose, but at least specific prose"""
+        result = run_redactor(adversarial_canary, "--stdout")
+        assert "high-entropy value(s) retained" in result.stderr
+        assert "telemetryagent/config/vendorblob" in result.stderr
+        assert "endpoint[@privkey]" in result.stderr
+
+    def test_summary_does_not_claim_more_than_it_did(self, adversarial_canary, run_redactor):
+        """The summary must not read as a clean bill of health when it is not"""
+        result = run_redactor(adversarial_canary, "--stdout")
+        assert "Redaction summary" in result.stderr
+        assert "Review before sharing" in result.stderr, (
+            "the retained-value warning must sit alongside the success summary"
+        )
+
+
+class TestDryRunSafety:
+    """--dry-run is what people run before deciding to share"""
+
+    def test_dry_run_writes_no_file(self, canary_copy, run_redactor, tmp_path):
+        """Regression pin: --dry-run touches nothing"""
+        out = tmp_path / "out.xml"
+        run_redactor(canary_copy, out, "--dry-run")
+        assert not out.exists()
+
+    def test_dry_run_verbose_prints_no_raw_secret(self, adversarial_canary, run_redactor):
+        """The preview must not become the leak it exists to prevent"""
+        result = run_redactor(adversarial_canary, "--dry-run-verbose")
+        combined = result.stdout + result.stderr
+
+        for marker in ("CANARY_ADV07_URLPASS", "CANARY_ADV07_QUERYTOKEN",
+                       "CANARY_ADV_ROCOMMUNITY_BASELINE"):
+            assert marker not in combined, marker
+        assert "BEGIN RSA PRIVATE KEY" not in combined
+
+    def test_dry_run_verbose_output_is_not_xml(self, adversarial_canary, run_redactor):
+        """A preview that emitted the document would defeat --dry-run"""
+        result = run_redactor(adversarial_canary, "--dry-run-verbose")
+        with pytest.raises(ET.ParseError):
+            ET.fromstring(result.stdout or "<empty/>x")

--- a/tests/adversarial/test_assurance_signals.py
+++ b/tests/adversarial/test_assurance_signals.py
@@ -192,11 +192,35 @@ class TestMachineReadableAssurance:
         assert "retained" in data or "high_entropy_retained" in data
 
     def test_retained_paths_are_named_on_stderr(self, adversarial_canary, run_redactor):
-        """What exists today: prose, but at least specific prose"""
+        """What exists today: prose, but at least specific prose
+
+        The two paths this asserted on - telemetryagent/config/vendorblob and
+        endpoint[@privkey] - both held private-key material and are now
+        redacted rather than retained, so naming them as retained would be
+        false. The invariant is unchanged and is what is asserted here: a value
+        the tool decided to keep is located precisely enough to audit, not just
+        counted. The paths below are values the tool still deliberately keeps.
+        """
         result = run_redactor(adversarial_canary, "--stdout")
+
         assert "high-entropy value(s) retained" in result.stderr
-        assert "telemetryagent/config/vendorblob" in result.stderr
-        assert "endpoint[@privkey]" in result.stderr
+        assert "entropyagent/config/mixedblob" in result.stderr
+        assert "entropyagent/config/hexblob" in result.stderr
+
+    def test_redacted_key_material_is_not_reported_as_retained(
+        self, adversarial_canary, run_redactor
+    ):
+        """The counterpart: what was removed must not be listed as kept
+
+        A retained-value list that names something already redacted sends the
+        operator to audit a value that is no longer there, and inflates the
+        count --fail-on-warn reads.
+        """
+        result = run_redactor(adversarial_canary, "--stdout")
+
+        assert "telemetryagent/config/vendorblob" not in result.stderr
+        assert "endpoint[@privkey]" not in result.stderr
+        assert "entropyagent/config/jwt" not in result.stderr
 
     def test_summary_does_not_claim_more_than_it_did(self, adversarial_canary, run_redactor):
         """The summary must not read as a clean bill of health when it is not"""

--- a/tests/adversarial/test_encoded_canary_scoring.py
+++ b/tests/adversarial/test_encoded_canary_scoring.py
@@ -1,0 +1,156 @@
+"""Phase 7: whether the shipped corpus score measures what it claims
+
+tests/integration/test_canary_corpus.py counts survivors with a literal
+``CANARY_[A-Z0-9_]+`` regex over the output, and the README publishes the
+result as 44/46. Any marker the config author encoded is invisible to that
+count - so a genuine leak can sit in the corpus, be asserted as retained by
+another test in the same suite, and still not move the published number.
+
+These tests measure the measurement.
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from .decode_scan import find_key_material, find_markers
+
+CORPUS = Path(__file__).resolve().parent.parent / "corpus" / "canary-corpus.xml"
+
+
+@pytest.fixture
+def corpus() -> Path:
+    """The shipped canary corpus the published score is measured against"""
+    if not CORPUS.exists():  # pragma: no cover - repo integrity
+        pytest.skip(f"missing corpus: {CORPUS}")
+    return CORPUS
+
+
+class TestDecodeAwareScanner:
+    """The scanner itself, before it is trusted to judge anything"""
+
+    def test_finds_a_literal_marker(self):
+        """The plain case the corpus scorer already handles"""
+        assert "CANARY_PLAIN" in find_markers("value CANARY_PLAIN here")
+
+    def test_finds_a_single_base64_marker(self):
+        """One layer of encoding must not hide a marker"""
+        blob = base64.b64encode(b"CANARY_ONCE_WRAPPED").decode()
+        assert "CANARY_ONCE_WRAPPED" in find_markers(blob)
+
+    def test_finds_a_double_base64_marker(self):
+        """Nor two"""
+        once = base64.b64encode(b"CANARY_TWICE_WRAPPED").decode()
+        twice = base64.b64encode(once.encode()).decode()
+        assert "CANARY_TWICE_WRAPPED" in find_markers(twice)
+
+    def test_finds_a_marker_split_across_lines(self):
+        """Line wrapping must not hide a marker either"""
+        assert "CANARY_SPLIT_VALUE" in find_markers("CANARY_\nSPLIT_\nVALUE")
+
+    def test_finds_pem_through_base64(self):
+        """Key material is recognised without a planted marker"""
+        pem = b"-----BEGIN RSA PRIVATE KEY-----\nCANARY\n-----END RSA PRIVATE KEY-----"
+        assert "RSA PRIVATE KEY" in find_key_material(base64.b64encode(pem).decode())
+
+    def test_does_not_invent_markers(self):
+        """The scanner must not manufacture findings"""
+        assert not find_markers("ordinary configuration text with no markers")
+
+    def test_decoding_is_depth_bounded(self):
+        """The scanner must not become the unbounded-recursion bug it looks for"""
+        payload = b"CANARY_DEEP"
+        for _ in range(8):
+            payload = base64.b64encode(payload)
+        assert "CANARY_DEEP" not in find_markers(payload.decode(), max_depth=2)
+
+
+class TestCorpusScoringIsIncomplete:
+    """The published 44/46 does not account for encoded markers"""
+
+    def test_corpus_contains_an_encoded_marker(self, corpus):
+        """Establishes the premise: the corpus really does hold one"""
+        text = corpus.read_text()
+        literal = find_markers(text, max_depth=0)
+        decoded = find_markers(text)
+
+        assert decoded - literal, (
+            "no encoded marker in the corpus - if one was removed, this "
+            "finding is closed and the test should be deleted"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-27: the corpus score counts literal markers only, so "
+               "the base64 canary that survives default mode is not in the "
+               "denominator and cannot move the published 44/46",
+    )
+    def test_no_encoded_marker_survives_default_mode(self, corpus, run_redactor):
+        """Encoded markers count against the score like any other"""
+        result = run_redactor(corpus, "--stdout")
+
+        literal = find_markers(result.stdout, max_depth=0)
+        decoded = find_markers(result.stdout)
+
+        assert not (decoded - literal), (
+            f"markers recoverable only by decoding: {sorted(decoded - literal)}"
+        )
+
+    def test_aggressive_mode_clears_the_encoded_marker(self, corpus, run_redactor):
+        """Pins the escape hatch, and scopes the finding to default mode"""
+        result = run_redactor(corpus, "--stdout", "--aggressive")
+
+        literal = find_markers(result.stdout, max_depth=0)
+        decoded = find_markers(result.stdout)
+        assert decoded == literal
+
+    def test_no_key_material_survives_the_shipped_corpus(self, corpus, run_redactor):
+        """The corpus's own key material must not survive any mode"""
+        for flags in ([], ["--aggressive"], ["--anonymise"]):
+            result = run_redactor(corpus, "--stdout", *flags)
+            assert not find_key_material(result.stdout), flags
+
+
+class TestPemInvariantIsNotVacuous:
+    """A non-vacuous counterpart to tests/properties/test_invariants.py:89-124
+
+    That test guards its assertion with `if has_pem_in_input:`, and no file in
+    test-configs/ contains a PEM marker - so the loop body has never executed.
+    The original is left alone; this asserts the same invariant against input
+    that actually contains what the invariant is about.
+    """
+
+    PEM = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+
+    @pytest.fixture
+    def config_with_pem(self, tmp_path) -> Path:
+        """A config that actually contains the PEM the invariant is about"""
+        config = tmp_path / "pem.xml"
+        config.write_text(
+            "<pfsense><system><user><name>admin</name></user></system>"
+            f"<cert><refid>abc123</refid><crt>{self.PEM}</crt>"
+            f"<prv>{self.PEM}</prv></cert></pfsense>"
+        )
+        return config
+
+    def test_premise_holds(self, config_with_pem):
+        """The guard the original test never got past"""
+        assert "BEGIN RSA PRIVATE KEY" in config_with_pem.read_text()
+
+    @pytest.mark.parametrize(
+        "flags",
+        [[], ["--aggressive"], ["--anonymise"], ["--keep-private-ips"],
+         ["--redact-descriptions"]],
+        ids=["default", "aggressive", "anonymise", "keep-private", "descriptions"],
+    )
+    def test_no_pem_marker_survives_any_mode(self, config_with_pem, run_redactor, flags):
+        """The invariant tests/properties never got to assert"""
+        result = run_redactor(config_with_pem, "--stdout", *flags)
+        assert "BEGIN RSA PRIVATE KEY" not in result.stdout
+        assert "CANARYPRIVATEKEY" not in result.stdout

--- a/tests/adversarial/test_filesystem_safety.py
+++ b/tests/adversarial/test_filesystem_safety.py
@@ -1,0 +1,228 @@
+"""Phase 5: file-system safety
+
+Path traversal, sensitive directories and --inplace-on-a-symlink are already
+covered by tests/unit/test_path_validation.py, tests/unit/test_symlink_security.py
+and tests/integration/test_path_security.py. This file covers what those do
+not: whether the *write* is safe once the path has been accepted.
+
+The threat is not an attacker on the box. It is an operator with one copy of a
+firewall configuration, a tool they have been told is safe to point at it, and
+a laptop that can run out of battery mid-write.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor
+
+
+class TestInputPreservation:
+    """The input is the only copy of the secrets. It must survive."""
+
+    def test_input_untouched_in_every_non_inplace_mode(self, canary_copy, run_redactor, tmp_path):
+        """Only --inplace may ever alter the input"""
+        before = canary_copy.read_bytes()
+        for flags in (["--stdout"], ["--dry-run"], ["--dry-run-verbose"],
+                      [str(tmp_path / "o1.xml")], ["--aggressive", "--stdout"]):
+            run_redactor(canary_copy, *flags)
+            assert canary_copy.read_bytes() == before, flags
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-15: input and output paths are never compared, so "
+               "naming the input as the output destroys it",
+    )
+    def test_same_input_and_output_path_is_refused(self, canary_copy, run_redactor):
+        """Naming the input as the output must not destroy it"""
+        before = canary_copy.read_bytes()
+        result = run_redactor(canary_copy, canary_copy, "--force")
+
+        assert result.returncode != 0
+        assert canary_copy.read_bytes() == before
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-15: the comparison is textual at best, so ./name and "
+               "name reach the same file undetected",
+    )
+    def test_same_file_via_relative_indirection_is_refused(self, canary_copy, run_redactor):
+        """Spelling the path differently must not defeat the check"""
+        before = canary_copy.read_bytes()
+        result = run_redactor("config.xml", "./config.xml", "--force", cwd=canary_copy.parent)
+
+        assert result.returncode != 0
+        assert canary_copy.read_bytes() == before
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-16: an output path that is a symlink is followed, so a "
+               "link pointing back at the input overwrites the input",
+    )
+    def test_output_symlink_pointing_at_input_is_refused(self, canary_copy, run_redactor, tmp_path):
+        """Nor must reaching the input through a link"""
+        link = tmp_path / "out-link.xml"
+        link.symlink_to(canary_copy)
+        before = canary_copy.read_bytes()
+
+        result = run_redactor(canary_copy, link, "--force")
+
+        assert result.returncode != 0 or canary_copy.read_bytes() == before
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-17: --inplace rewrites the original without requiring "
+               "--force; only args.output is covered by the overwrite guard",
+    )
+    def test_inplace_requires_explicit_consent(self, canary_copy, run_redactor):
+        """Destroying the original is not a default-worthy action"""
+        before = canary_copy.read_bytes()
+        result = run_redactor(canary_copy, "--inplace")
+
+        assert result.returncode != 0 or canary_copy.read_bytes() == before, (
+            "--inplace destroyed the original with no --force and no prompt"
+        )
+
+    def test_inplace_with_force_does_rewrite(self, canary_copy, run_redactor):
+        """The documented behaviour, pinned so a fix for the above is scoped"""
+        before = canary_copy.read_bytes()
+        run_redactor(canary_copy, "--inplace", "--force")
+        assert canary_copy.read_bytes() != before
+        ET.fromstring(canary_copy.read_text())
+
+
+class TestWriteSafety:
+    """How the output is written, not where"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-18: tree.write() creates the file with the process "
+               "umask, so redacted output is typically world-readable 0644",
+    )
+    def test_output_is_not_world_readable(self, canary_copy, run_redactor, tmp_path):
+        """Redacted output can still hold retained values"""
+        out = tmp_path / "out.xml"
+        run_redactor(canary_copy, out)
+
+        mode = stat.S_IMODE(out.stat().st_mode)
+        assert not mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IWGRP | stat.S_IWOTH), (
+            f"mode {mode:04o}; redacted output can still hold retained "
+            f"high-entropy values and identifying material"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-19: the write is not atomic - tree.write() truncates "
+               "the target first, so a failure mid-write destroys it",
+    )
+    def test_interrupted_inplace_write_preserves_the_original(self, canary_copy, monkeypatch):
+        """A crash mid-write must not leave the operator with nothing"""
+        before = canary_copy.read_bytes()
+
+        def explode(self, file_or_filename, **kwargs):  # pylint: disable=unused-argument
+            # Emulate a crash after the target has been opened for writing,
+            # which is what tree.write() does before it can fail.
+            if not hasattr(file_or_filename, "write"):
+                with open(file_or_filename, "wb") as handle:
+                    handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
+            raise OSError("simulated I/O failure mid-write")
+
+        monkeypatch.setattr(ET.ElementTree, "write", explode)
+
+        redactor = PfSenseRedactor()
+        assert redactor.redact_config(str(canary_copy), str(canary_copy), inplace=True) is False
+        assert canary_copy.read_bytes() == before, (
+            f"original truncated to {canary_copy.stat().st_size} bytes "
+            f"from {len(before)}"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-19: a failed write leaves the partial file behind "
+               "rather than removing it",
+    )
+    def test_interrupted_write_leaves_no_partial_output(self, canary_copy, tmp_path, monkeypatch):
+        """A truncated file that looks like output is worse than none"""
+        out = tmp_path / "out.xml"
+
+        def explode(self, file_or_filename, **kwargs):  # pylint: disable=unused-argument
+            if not hasattr(file_or_filename, "write"):
+                with open(file_or_filename, "wb") as handle:
+                    handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
+            raise OSError("simulated I/O failure mid-write")
+
+        monkeypatch.setattr(ET.ElementTree, "write", explode)
+
+        PfSenseRedactor().redact_config(str(canary_copy), str(out))
+
+        assert not out.exists(), (
+            "a truncated file that looks like output is worse than no output"
+        )
+
+    def test_no_temporary_files_are_left_behind(self, canary_copy, run_redactor, tmp_path):
+        """Whatever the write strategy, the directory must be clean afterwards"""
+        out = tmp_path / "out.xml"
+        run_redactor(canary_copy, out)
+
+        leftovers = {p.name for p in tmp_path.iterdir()} - {"config.xml", "out.xml"}
+        assert not leftovers, leftovers
+
+
+class TestSpecialFiles:
+    """Non-regular inputs must be diagnosed, not half-read"""
+
+    def test_directory_as_input_is_diagnosed(self, tmp_path, run_redactor):
+        """A directory is refused cleanly"""
+        result = run_redactor(tmp_path, "--stdout")
+        assert result.returncode != 0
+        assert "Traceback" not in result.stderr
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX FIFOs only")
+    def test_fifo_as_input_is_diagnosed(self, tmp_path, run_redactor):
+        """So is a FIFO"""
+        fifo = tmp_path / "fifo.xml"
+        os.mkfifo(fifo)
+        result = run_redactor(fifo, "--stdout")
+        assert result.returncode != 0
+        assert "Traceback" not in result.stderr
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-20: the input is accepted on stat().st_size alone; "
+               "there is no is_file() check, so a FIFO is diagnosed as 'empty' "
+               "rather than as the wrong kind of file",
+    )
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX FIFOs only")
+    def test_fifo_is_diagnosed_as_a_non_regular_file(self, tmp_path, run_redactor):
+        """And the diagnosis names the real problem"""
+        fifo = tmp_path / "fifo.xml"
+        os.mkfifo(fifo)
+        result = run_redactor(fifo, "--stdout")
+        assert "empty" not in result.stderr.lower(), (
+            "a FIFO is not an empty file, and saying so sends the operator "
+            "looking for the wrong problem"
+        )
+
+    def test_hardlinked_output_write_is_in_place(self, canary_copy, run_redactor, tmp_path):
+        """Writing over one name of a hard-linked file changes every name
+
+        tests/unit/test_symlink_security.py:139 documents --inplace on a hard
+        link. This pins the *output* side, and it matters to whoever implements
+        FINDING-19: an atomic temp-file-plus-rename write would break the link
+        instead, leaving the alias holding the unredacted content. That is a
+        behaviour change, and this test is where it will surface.
+        """
+        out = tmp_path / "out.xml"
+        out.write_text("<pfsense><old/></pfsense>")
+        alias = tmp_path / "alias.xml"
+        os.link(out, alias)
+
+        run_redactor(canary_copy, out, "--force")
+
+        assert out.stat().st_nlink == 2, "the write broke the hard link"
+        assert Path(alias).read_bytes() == out.read_bytes()
+        assert "<old/>" not in alias.read_text()

--- a/tests/adversarial/test_harness.py
+++ b/tests/adversarial/test_harness.py
@@ -23,6 +23,7 @@ asking the question.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -49,8 +50,18 @@ class TestTheHarnessCanRunTheTool:
         assert result.returncode == 0, result.stderr
 
     def test_the_project_root_is_on_the_child_pythonpath(self):
-        """The mechanism, pinned so it is not removed as redundant"""
-        assert str(PROJECT_ROOT) in _subprocess_env()["PYTHONPATH"].split(":")
+        """The mechanism, pinned so it is not removed as redundant
+
+        os.pathsep, not ':'. Windows separates PYTHONPATH entries with ';' and
+        its paths contain a colon in the drive letter, so splitting on ':'
+        turns 'D:\\a\\repo' into ['D', '\\a\\repo'] and the entry is never
+        found. _subprocess_env has always used os.pathsep; this assertion did
+        not, and it failed on all six Windows cells while passing everywhere
+        else.
+        """
+        entries = _subprocess_env()["PYTHONPATH"].split(os.pathsep)
+
+        assert str(PROJECT_ROOT) in entries, entries
 
     def test_a_run_from_a_temporary_directory_produces_output(self, tmp_path, run_redactor):
         """The end-to-end version of the two above"""

--- a/tests/adversarial/test_harness.py
+++ b/tests/adversarial/test_harness.py
@@ -1,0 +1,123 @@
+"""The harness itself, because everything else in this directory trusts it
+
+Most tests here assert some combination of "the run exited non-zero" and "the
+file was not modified". An interpreter that could not import the package
+satisfies both without executing a line of the code under test - so a broken
+harness does not look like a broken harness, it looks like a passing security
+suite.
+
+That is not hypothetical. `python -m pfsense_redactor` resolves the package
+from the current directory, and several tests here run the CLI with cwd set to
+a temporary directory. In a CI job that ran pytest without `pip install -e .`,
+every one of those runs failed to start:
+
+    test_implicit_allowlist_changes_the_output   compared '' with ''
+    test_no_default_allowlist_disables_it        compared '' with ''
+    test_same_file_via_relative_indirection      XPASSed a strict xfail for
+                                                 FINDING-15, which was not
+                                                 fixed, because a crashed
+                                                 subprocess is also a refusal
+
+The third is the one that matters: a security test reporting success without
+asking the question.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from .conftest import PROJECT_ROOT, _subprocess_env
+
+
+class TestTheHarnessCanRunTheTool:
+    """The preconditions every other test in this directory depends on"""
+
+    def test_the_package_is_importable_from_anywhere(self, tmp_path):
+        """Not only from the repository root
+
+        This is what fails when the package is not installed and the child
+        process is started somewhere else.
+        """
+        result = subprocess.run(
+            [sys.executable, "-c", "import pfsense_redactor"],
+            capture_output=True, text=True, cwd=str(tmp_path),
+            env=_subprocess_env(), check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+    def test_the_project_root_is_on_the_child_pythonpath(self):
+        """The mechanism, pinned so it is not removed as redundant"""
+        assert str(PROJECT_ROOT) in _subprocess_env()["PYTHONPATH"].split(":")
+
+    def test_a_run_from_a_temporary_directory_produces_output(self, tmp_path, run_redactor):
+        """The end-to-end version of the two above"""
+        config = tmp_path / "config.xml"
+        config.write_text("<pfsense><system><hostname>fw</hostname></system></pfsense>")
+
+        result = run_redactor("config.xml", "--stdout", cwd=tmp_path)
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip(), "no output from a run that should succeed"
+
+
+class TestTheHarnessRefusesToPassSilently:
+    """A subprocess that never started must not be mistaken for a refusal"""
+
+    # What CPython actually prints when `-m pfsense_redactor` cannot resolve
+    # the package. Reproduced as a literal because the package is installed in
+    # any environment able to run this suite, so the condition cannot be
+    # created for real here - only in the CI job that lacked the install.
+    NEVER_STARTED_STDERR = (
+        "/usr/bin/python3: Error while finding module specification for "
+        "'pfsense_redactor' (ModuleNotFoundError: No module named "
+        "'pfsense_redactor')\n"
+    )
+
+    def test_a_run_that_never_started_fails_the_test_rather_than_returning(
+        self, tmp_path, run_redactor, monkeypatch
+    ):
+        """The guard, exercised
+
+        A crashed subprocess exits non-zero and touches nothing, which is what
+        a refusal also looks like. The harness must turn that into a loud
+        failure rather than hand back a CompletedProcess the caller reads as a
+        successful refusal.
+        """
+        def never_starts(*args, **kwargs):
+            del args, kwargs
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=self.NEVER_STARTED_STDERR
+            )
+
+        monkeypatch.setattr(subprocess, "run", never_starts)
+
+        with pytest.raises(pytest.fail.Exception, match="never started"):
+            run_redactor("config.xml", "--stdout", cwd=tmp_path)
+
+    def test_that_stderr_would_otherwise_have_looked_like_a_refusal(self, tmp_path):
+        """Why the guard is needed, stated as an assertion
+
+        Without it, the shape below satisfies both halves of what most tests
+        in this directory check.
+        """
+        crashed = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=self.NEVER_STARTED_STDERR
+        )
+        before = tmp_path / "config.xml"
+        before.write_text("<pfsense/>")
+        unchanged = before.read_bytes()
+
+        assert crashed.returncode != 0            # "it was refused"
+        assert before.read_bytes() == unchanged   # "and nothing was written"
+
+    def test_the_guard_does_not_fire_on_an_ordinary_failure(self, tmp_path, run_redactor):
+        """A real refusal still comes back as a result, not a test failure"""
+        missing = tmp_path / "does-not-exist.xml"
+
+        result = run_redactor(missing, "--stdout")
+
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower()

--- a/tests/adversarial/test_parser_limits.py
+++ b/tests/adversarial/test_parser_limits.py
@@ -1,0 +1,155 @@
+"""Phase 4: hostile-input safety and resource bounds
+
+The prolog guard against DOCTYPE and entity expansion is already well covered
+by tests/unit/test_doctype_rejection.py and is not repeated here. What is left
+is the work the tool does *after* parsing, where the bounds are less explicit.
+"""
+from __future__ import annotations
+
+import time
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor
+
+
+def nested_config(depth: int) -> str:
+    """A well-formed pfSense config nested `depth` elements deep"""
+    return f"<pfsense>{'<a>' * depth}x{'</a>' * depth}</pfsense>"
+
+
+class TestRecursionBounds:
+    """redact_element recurses once per level of XML nesting"""
+
+    def test_ordinary_nesting_is_fine(self):
+        """A real config is a handful of levels deep; 200 is generous"""
+        root = ET.fromstring(nested_config(200))
+        PfSenseRedactor().redact_element(root)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-13: redact_element has no depth bound, so nesting past "
+               "the interpreter recursion limit raises RecursionError, which "
+               "redact_config does not catch",
+    )
+    def test_deep_nesting_is_refused_not_crashed(self):
+        """Nesting past the recursion limit must be handled, not fatal"""
+        root = ET.fromstring(nested_config(2000))
+        redactor = PfSenseRedactor()
+        try:
+            redactor.redact_element(root)
+        except RecursionError:
+            pytest.fail("RecursionError escaped redact_element")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-13: the RecursionError reaches the shell as an "
+               "unhandled traceback rather than a diagnosed refusal",
+    )
+    def test_deep_nesting_reports_cleanly_through_the_cli(self, tmp_path, run_redactor):
+        """And must reach the shell as a diagnosis"""
+        deep = tmp_path / "deep.xml"
+        deep.write_text(nested_config(2000))
+
+        result = run_redactor(deep, "--stdout")
+
+        assert result.returncode != 0, "must not report success"
+        assert "Traceback" not in result.stderr, (
+            "an unhandled traceback is not a diagnosis, and it prints "
+            "interpreter paths the operator did not ask for"
+        )
+
+
+class TestTextSizeBounds:
+    """MAX_TEXT_CHUNK bounds the work, but silently discards the excess"""
+
+    def test_oversized_text_is_bounded(self):
+        """The bound itself works - this is the control"""
+        redactor = PfSenseRedactor()
+        started = time.monotonic()
+        result = redactor.redact_text("A" * (redactor.MAX_TEXT_CHUNK + 200_000))
+        assert time.monotonic() - started < 30
+        assert len(result) <= redactor.MAX_TEXT_CHUNK
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-14: text over MAX_TEXT_CHUNK is truncated, so the "
+               "output silently loses config data while the run reports success",
+    )
+    def test_oversized_text_is_not_silently_truncated(self, tmp_path, run_redactor):
+        """Discarding config data is not a successful run"""
+        oversized = "A" * 1_200_000
+        config = tmp_path / "big.xml"
+        config.write_text(
+            f"<pfsense><system><hostname>{oversized}</hostname></system></pfsense>"
+        )
+
+        result = run_redactor(config, "--stdout")
+        root = ET.fromstring(result.stdout)
+        kept = root.find("system/hostname").text or ""
+
+        assert len(kept) == len(oversized) or result.returncode != 0, (
+            f"{len(oversized) - len(kept)} characters discarded, exit code "
+            f"{result.returncode}"
+        )
+
+
+class TestPathologicalPatterns:
+    """Regex passes over attacker-controlled text must stay near-linear"""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "a-" * 4000 + "!",                       # FQDN_RE label chain
+            "x@" + "a." * 4000 + "!",                # EMAIL_RE domain chain
+            "https://" + "a" * 4000 + "/" + "b" * 4000,
+            "askpass " + "A" * 200_000 + "\t",       # BLOB_DIRECTIVE_RE lazy tail
+        ],
+        ids=["fqdn-chain", "email-chain", "long-url", "directive-tail"],
+    )
+    def test_pathological_text_completes_quickly(self, text):
+        """A generous ceiling - catastrophic backtracking blows past it by orders"""
+        redactor = PfSenseRedactor()
+        started = time.monotonic()
+        redactor.redact_text(text)
+        assert time.monotonic() - started < 10
+
+    def test_blob_element_with_pathological_line(self):
+        """custom_options is scanned line by line, so it gets its own check"""
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(
+            "<pfsense><openvpn><custom_options>"
+            + "askpass " + "A" * 200_000
+            + "</custom_options></openvpn></pfsense>"
+        )
+        started = time.monotonic()
+        redactor.redact_element(root)
+        assert time.monotonic() - started < 10
+
+
+class TestMalformedInput:
+    """Malformed XML must be diagnosed, never half-processed"""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "<pfsense><unclosed></pfsense>",
+            "<pfsense>\x00</pfsense>",
+            "<pfsense><a attr='unterminated></a></pfsense>",
+            "not xml at all",
+            "<?xml version='1.0' encoding='utf-32'?><pfsense/>",
+        ],
+        ids=["unclosed", "nul-byte", "unterminated-attr", "not-xml", "bad-encoding"],
+    )
+    def test_malformed_input_writes_nothing(self, tmp_path, run_redactor, content):
+        """A rejected input must leave no output behind"""
+        config = tmp_path / "bad.xml"
+        config.write_bytes(content.encode("utf-8", errors="ignore"))
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(config, out)
+
+        assert result.returncode != 0
+        assert not out.exists(), "a rejected input must not leave an output file"
+        assert "Traceback" not in result.stderr

--- a/tests/adversarial/test_redaction_gaps.py
+++ b/tests/adversarial/test_redaction_gaps.py
@@ -287,6 +287,17 @@ class TestStructuredContent:
         out = redact(wrap('<cfg>{"api_secret": "CANARY_JSON_SECRET", "n": 3}</cfg>'))
         assert "CANARY_JSON_SECRET" not in out
 
+    @pytest.mark.parametrize("descr", ["<descr></descr>", "<descr>   </descr>"],
+                             ids=["empty", "whitespace"])
+    def test_an_empty_description_is_left_alone(self, descr):
+        """--redact-descriptions must not put a placeholder where nothing was
+
+        Replacing an empty element with [REDACTED] invents a value the config
+        never had, and a reader cannot tell that from a redacted one.
+        """
+        out = redact(wrap(f"<rule>{descr}</rule>"), redact_descriptions=True)
+        assert "[REDACTED]" not in out
+
     def test_secret_in_cdata_is_reached(self):
         """CDATA is flattened by ElementTree, so name rules still apply
 
@@ -375,6 +386,23 @@ class TestNameCoverage:
         out = redact("<pfsense><ipsec><phase1><digest>SHA384</digest></phase1></ipsec></pfsense>")
         assert "SHA384" in out
 
+    def test_digest_element_with_children_is_not_read_as_an_algorithm_name(self):
+        """A container is not a value
+
+        <digest><item>..</item></digest> has no text of its own. Without the
+        child guard, that empty text reads as "no value", the element is
+        classified as an algorithm choice, and the whole secret-name treatment
+        is skipped for it - including its attributes. The attribute below is
+        redacted only because the guard fires first.
+        """
+        out = redact(
+            '<pfsense><pkg><digest algo="CANARY_DIGEST_ATTR">'
+            '<item>x</item></digest></pkg></pfsense>'
+        )
+
+        assert "CANARY_DIGEST_ATTR" not in out
+        assert "<item>" in out, "the container was collapsed instead of traversed"
+
     def test_digest_element_loses_anything_else(self):
         """The same element holding a digest, rather than naming one, is a secret"""
         out = redact("<pfsense><pkg><digest>CANARY_DIGEST_VALUE</digest></pkg></pfsense>")
@@ -442,6 +470,26 @@ class TestNameCoverage:
         for fragment in ("CANARYPRIVATEKEY", "BEGIN RSA PRIVATE KEY", "eyJhbGciOiJIUzI1NiIs"):
             assert fragment not in as_element, f"element kept {fragment}"
             assert fragment not in as_attribute, f"attribute kept {fragment}"
+
+    def test_a_repeated_path_is_listed_once(self):
+        """Two siblings of the same name produce one retained path, not two
+
+        The path is computed from the element's ancestors and its own tag, so
+        siblings share it. Without the de-duplication the summary repeats the
+        same location, and an operator counting lines to judge how much is left
+        to review gets the wrong number.
+        """
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(wrap(
+            "<blob>canaryadvlowercaseonlysecretvaluehere</blob>"
+            "<blob>CANARYADVUPPERCASEONLYSECRETVALUEHERE</blob>"
+        ))
+        redactor.redact_element(root)
+
+        assert redactor.stats['high_entropy_retained'] == 2, "both must be counted"
+        assert redactor.high_entropy_paths.count(
+            'pfsense/installedpackages/vendorpkg/config/blob'
+        ) == 1, redactor.high_entropy_paths
 
     def test_mixed_case_tag_is_matched(self):
         """Regression pin: _normalise_tag lower-cases, so case cannot evade"""

--- a/tests/adversarial/test_redaction_gaps.py
+++ b/tests/adversarial/test_redaction_gaps.py
@@ -1,0 +1,434 @@
+"""Phase 2/3: redaction completeness and privacy leakage
+
+Every test here asserts the property that should hold. Tests carrying
+``xfail(strict=True)`` document a confirmed gap; the rest are regression pins
+for behaviour that already works and must keep working.
+
+All canaries are synthetic. The "PEM" bodies are base64-legal runs of the word
+CANARY and decode to nothing.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import (
+    SECRET_TAG_PATTERN,
+    SENSITIVE_ATTR_PATTERN,
+    SECRET_TAG_DENYLIST,
+    PfSenseRedactor,
+)
+
+from .decode_scan import find_key_material, find_markers
+
+CANARY_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+    "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV4567\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+
+def redact(xml: str, **kwargs) -> str:
+    """Run a full redaction over `xml` and return the serialised result
+
+    Mirrors what redact_config does around the traversal - refid collection in
+    particular - so tests exercise the same code path the CLI does.
+    """
+    redactor = PfSenseRedactor(**kwargs)
+    root = ET.fromstring(xml)
+    redactor.known_refids = redactor._collect_refids(root)  # pylint: disable=protected-access
+    redactor.redact_element(root)
+    return ET.tostring(root, encoding='unicode')
+
+
+def wrap(inner: str) -> str:
+    """Put `inner` inside a minimal but realistic package config"""
+    return f"<pfsense><installedpackages><vendorpkg><config>{inner}</config></vendorpkg></installedpackages></pfsense>"
+
+
+# ==========================================================================
+# Key material in places the name patterns do not reach
+# ==========================================================================
+class TestKeyMaterialSurvival:
+    """A private key must not survive, whatever element or attribute holds it"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-01: a PEM private key in an unrecognised element is "
+               "reported as high-entropy but retained in default mode",
+    )
+    def test_pem_in_unknown_element_is_redacted(self):
+        """Key material must not depend on the element being recognised"""
+        out = redact(wrap(f"<vendorblob>{CANARY_PEM}</vendorblob>"))
+        assert "BEGIN RSA PRIVATE KEY" not in out
+        assert "CANARYPRIVATEKEY" not in out
+
+    def test_pem_in_unknown_element_is_redacted_under_aggressive(self):
+        """The documented escape hatch must actually work"""
+        out = redact(wrap(f"<vendorblob>{CANARY_PEM}</vendorblob>"), aggressive=True)
+        assert "BEGIN RSA PRIVATE KEY" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-02: a PEM private key in an attribute whose name is not "
+               "matched by SENSITIVE_ATTR_PATTERN is reported but retained",
+    )
+    def test_pem_in_attribute_is_redacted(self):
+        """Nor on the attribute name being recognised"""
+        out = redact(wrap(f'<endpoint privkey="{CANARY_PEM}"/>'))
+        assert "BEGIN RSA PRIVATE KEY" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-03: no decoding layer - base64-wrapped key material is "
+               "never decoded, so the PEM marker is never seen",
+    )
+    def test_base64_wrapped_pem_is_redacted(self):
+        """One layer of encoding must not conceal a key"""
+        import base64  # pylint: disable=import-outside-toplevel
+        encoded = base64.b64encode(CANARY_PEM.encode()).decode()
+        out = redact(wrap(f"<payload>{encoded}</payload>"))
+        assert not find_key_material(out), "key material recoverable by decoding"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-03: double-base64-wrapped key material is not decoded",
+    )
+    def test_double_base64_wrapped_pem_is_redacted(self):
+        """Nor two"""
+        import base64  # pylint: disable=import-outside-toplevel
+        once = base64.b64encode(CANARY_PEM.encode()).decode()
+        twice = base64.b64encode(once.encode()).decode()
+        out = redact(wrap(f"<blob>{twice}</blob>"))
+        assert not find_key_material(out), "key material recoverable by decoding twice"
+
+
+# ==========================================================================
+# The entropy detector's blind spots
+# ==========================================================================
+class TestEntropyDetectorBlindSpots:
+    """A value the detector cannot see is neither redacted nor reported
+
+    Being reported is the weaker of the two outcomes, so these tests assert
+    only that - if the tool notices at all, --fail-on-warn and the summary can
+    do their job.
+    """
+
+    @staticmethod
+    def _noticed(value: str) -> bool:
+        """Whether the tool either redacted or at least reported the value"""
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(wrap(f"<opaque>{value}</opaque>"))
+        redactor.redact_element(root)
+        return bool(redactor.stats['high_entropy_retained']) or '[REDACTED' in ET.tostring(
+            root, encoding='unicode'
+        )
+
+    def test_mixed_class_base64_blob_is_noticed(self):
+        """The case that works today - the control for the three below"""
+        assert self._noticed("aGVsbG8gd29ybGQxMjM0NTY3ODkwQUJDREVGRw==")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-04: _has_mixed_character_classes requires two of "
+               "digit/upper/lower, so an all-lowercase blob is invisible",
+    )
+    def test_lowercase_only_blob_is_noticed(self):
+        """Character-class uniformity must not confer invisibility"""
+        assert self._noticed("canaryadvlowercaseonlysecretvaluehere")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-04: an all-uppercase blob is invisible for the same reason",
+    )
+    def test_uppercase_only_blob_is_noticed(self):
+        """The same, in the other direction"""
+        assert self._noticed("CANARYADVUPPERCASEONLYSECRETVALUEHERE")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-04: the hex branch requires a digit, so a hex secret "
+               "made only of a-f is invisible",
+    )
+    def test_digitless_hex_blob_is_noticed(self):
+        """A hex secret spelled only in a-f is still a secret"""
+        assert self._noticed("deadbeefdeadbeefdeadbeefcafefeedcafefeed")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-05: the '.' separators fail BASE64ISH_RE, so a JWT is "
+               "not seen as high-entropy",
+    )
+    def test_jwt_is_noticed(self):
+        """A JWT is a credential whatever its separators do to the shape test"""
+        assert self._noticed(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            ".eyJzdWIiOiJDQU5BUllfSldUIn0"
+            ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+        )
+
+
+# ==========================================================================
+# Structured content inside element text
+# ==========================================================================
+class TestStructuredContent:
+    """Secrets carried inside another format that happens to live in XML"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-06: element text is never parsed as JSON, so a "
+               "secret-named JSON key is not reached",
+    )
+    def test_secret_in_embedded_json_is_redacted(self):
+        """A secret-named JSON key must be reached"""
+        out = redact(wrap('<cfg>{"api_secret": "CANARY_JSON_SECRET", "n": 3}</cfg>'))
+        assert "CANARY_JSON_SECRET" not in out
+
+    def test_secret_in_cdata_is_reached(self):
+        """CDATA is flattened by ElementTree, so name rules still apply
+
+        Pins the behaviour explicitly: a secret in a CDATA section inside a
+        *secret-named* element is redacted, which proves CDATA content is not
+        skipped wholesale.
+        """
+        out = redact(wrap("<password><![CDATA[CANARY_CDATA_SECRET]]></password>"))
+        assert "CANARY_CDATA_SECRET" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-07: CDATA in a non-secret-named element gets no "
+               "treatment beyond the name rules, so free-text secrets survive",
+    )
+    def test_secret_in_cdata_in_unnamed_element_is_redacted(self):
+        """CDATA free text must be scanned like any other free text"""
+        out = redact(wrap("<freeform><![CDATA[deploy key CANARY_CDATA_FREE]]></freeform>"))
+        assert "CANARY_CDATA_FREE" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-08: element tails are only processed under --aggressive",
+    )
+    def test_secret_in_element_tail_is_reached(self):
+        """Mixed-content tails are text too"""
+        out = redact("<pfsense><notes><marker/>203.0.113.9</notes></pfsense>")
+        assert "203.0.113.9" not in out
+
+
+# ==========================================================================
+# Tag- and attribute-name coverage
+# ==========================================================================
+class TestNameCoverage:
+    """What the two name patterns do and do not agree about"""
+
+    ALREADY_MATCHED = ["password", "passwd", "pass", "secret", "token",
+                       "apikey", "privkey", "clientsecret", "passphrase", "psk"]
+
+    # Names that carry credentials in real package configs but match neither
+    # pattern. Each is a live false negative, not a hypothetical.
+    UNMATCHED = ["pwd", "bearer", "salt", "seed", "otpseed", "digest",
+                 "hash", "nonce", "keydata", "keystore", "authorization",
+                 "sessionid", "totp"]
+
+    @pytest.mark.parametrize("tag", ALREADY_MATCHED)
+    def test_known_secret_tags_are_matched(self, tag):
+        """Regression pin for the names that do work"""
+        redactor = PfSenseRedactor()
+        assert redactor._is_secret_tag(tag, tag)  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("tag", UNMATCHED)
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-09: SECRET_TAG_PATTERN does not cover these credential-"
+               "bearing element names",
+    )
+    def test_unmatched_secret_tags_are_matched(self, tag):
+        """Credential-bearing element names the pattern misses"""
+        redactor = PfSenseRedactor()
+        assert redactor._is_secret_tag(tag, tag)  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize(
+        "name", ["bearer", "cookie", "signature", "credentials", "privkey",
+                 "licensekey", "psk", "passphrase", "community"]
+    )
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-10: SECRET_TAG_PATTERN and SENSITIVE_ATTR_PATTERN "
+               "disagree, so an element and an attribute of the same name get "
+               "different treatment",
+    )
+    def test_element_and_attribute_patterns_agree(self, name):
+        """The same name must mean the same thing either side"""
+        denied = name in SECRET_TAG_DENYLIST
+        as_element = bool(SECRET_TAG_PATTERN.search(name)) and not denied
+        as_attribute = bool(SENSITIVE_ATTR_PATTERN.search(name))
+        assert as_element == as_attribute, (
+            f"'{name}': element={as_element} attribute={as_attribute}"
+        )
+
+    def test_mixed_case_tag_is_matched(self):
+        """Regression pin: _normalise_tag lower-cases, so case cannot evade"""
+        out = redact(wrap("<ApiKey>CANARY_MIXEDCASE</ApiKey><PASSWORD>CANARY_UPPER</PASSWORD>"))
+        assert "CANARY_MIXEDCASE" not in out
+        assert "CANARY_UPPER" not in out
+
+    def test_namespaced_tag_is_matched(self):
+        """Regression pin: the {ns} prefix is stripped before matching"""
+        out = redact(
+            '<pfsense xmlns:p="urn:example"><cfg><p:password>CANARY_NS</p:password></cfg></pfsense>'
+        )
+        assert "CANARY_NS" not in out
+
+
+# ==========================================================================
+# Privacy identifiers outside the known-tag allowlist
+# ==========================================================================
+class TestIdentifierCoverage:
+    """IP and domain redaction is gated on IP_CONTAINING_ELEMENTS by default"""
+
+    def test_public_ip_in_known_element_is_redacted(self):
+        """The control: a listed element does get scanned"""
+        out = redact(wrap("<dnsserver>198.18.51.77</dnsserver>"))
+        assert "198.18.51.77" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-11: an element outside IP_CONTAINING_ELEMENTS keeps its "
+               "public addresses unless --aggressive is used",
+    )
+    def test_public_ip_in_unknown_element_is_redacted(self):
+        """An unlisted element leaks the address"""
+        out = redact(wrap("<syslogtarget>198.18.51.77</syslogtarget>"))
+        assert "198.18.51.77" not in out
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-11: the same applies to hostnames in unknown elements",
+    )
+    def test_domain_in_unknown_element_is_redacted(self):
+        """And the hostname beside it"""
+        out = redact(wrap("<collector_note>ships to host.megacorp.example</collector_note>"))
+        assert "megacorp.example" not in out
+
+    def test_credential_url_is_redacted_in_every_mode(self):
+        """Regression pin - the strongest area of the codebase"""
+        url = "https://svc:CANARY_URLPW@feeds.vendor.invalid/l?token=CANARY_QTOKEN"
+        for kwargs in ({}, {"aggressive": True}, {"anonymise": True}):
+            out = redact(wrap(f"<updateurl>{url}</updateurl>"), **kwargs)
+            assert "CANARY_URLPW" not in out, kwargs
+            assert "CANARY_QTOKEN" not in out, kwargs
+
+    def test_feed_filename_is_not_mangled_into_a_domain(self):
+        """Over-redaction is a failure too: a corrupted feed path helps nobody"""
+        out = redact(wrap("<path>/var/db/pfblockerng/deny.megacorp.example.txt</path>"))
+        assert "deny.megacorp.example.txt" in out or "example.com" not in out
+
+
+# ==========================================================================
+# Sample previews shown by --dry-run-verbose
+# ==========================================================================
+class TestPreviewLeakage:
+    """The preview exists to be safe to paste into a ticket or CI log"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-12: _mask_fqdn_sample keeps the registrable domain, so "
+               "the organisation is named in the 'safe' preview",
+    )
+    def test_fqdn_preview_hides_the_registrable_domain(self):
+        """The preview must not name the organisation"""
+        redactor = PfSenseRedactor(dry_run_verbose=True)
+        masked = redactor._safe_mask_for_sample(  # pylint: disable=protected-access
+            "vpn.internal.megacorp-holdings.example", "FQDN"
+        )
+        assert "megacorp-holdings" not in masked
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-12: _mask_ip_sample keeps three of four octets, which "
+               "identifies the network",
+    )
+    def test_ip_preview_hides_the_network(self):
+        """Nor identify the network"""
+        redactor = PfSenseRedactor(dry_run_verbose=True)
+        masked = redactor._safe_mask_for_sample("198.18.240.17", "IP")  # pylint: disable=protected-access
+        assert "198.18" not in masked
+
+    def test_url_preview_redacts_embedded_credentials(self):
+        """Regression pin: the preview must not print a live token"""
+        redactor = PfSenseRedactor(dry_run_verbose=True)
+        masked = redactor._safe_mask_for_sample(  # pylint: disable=protected-access
+            "https://admin:CANARY_PW@host.example/x?token=CANARY_TOKEN", "URL"
+        )
+        assert "CANARY_PW" not in masked
+        assert "CANARY_TOKEN" not in masked
+
+
+# ==========================================================================
+# End-to-end over the adversarial corpus
+# ==========================================================================
+class TestAdversarialCorpusEndToEnd:
+    """The corpus, through the real CLI, in the mode the README leads with"""
+
+    def test_default_mode_produces_valid_xml(self, adversarial_canary, run_redactor):
+        """Whatever else it does, the output must parse"""
+        result = run_redactor(adversarial_canary, "--stdout")
+        assert result.returncode == 0
+        ET.fromstring(result.stdout)
+
+    def test_input_is_never_modified(self, adversarial_canary, run_redactor, tmp_path):
+        """No read-only mode may touch the source"""
+        before = adversarial_canary.read_bytes()
+        run_redactor(adversarial_canary, tmp_path / "out.xml")
+        run_redactor(adversarial_canary, "--stdout")
+        run_redactor(adversarial_canary, "--dry-run-verbose")
+        assert adversarial_canary.read_bytes() == before
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="FINDING-01/02/03: private key material survives default-mode "
+               "redaction of the adversarial corpus",
+    )
+    def test_no_key_material_survives_default_mode(self, adversarial_canary, run_redactor):
+        """The mode the README leads with must not emit a private key"""
+        result = run_redactor(adversarial_canary, "--stdout")
+        assert not find_key_material(result.stdout)
+
+    def test_no_key_material_survives_aggressive_mode(self, adversarial_canary, run_redactor):
+        """--aggressive does clear these, but by shape rather than by decoding
+
+        Worth pinning because the mechanism is incidental: the base64 wrappings
+        in the corpus happen to mix character classes, so _is_high_entropy_value
+        catches them. An encoding that produced a single character class would
+        not be caught (FINDING-04), which is why this passing does not make
+        FINDING-03 moot.
+        """
+        result = run_redactor(adversarial_canary, "--stdout", "--aggressive")
+        assert not find_key_material(result.stdout)
+
+    def test_baseline_secrets_always_die(self, adversarial_canary, run_redactor):
+        """The classes the tool claims to cover must be gone in every mode"""
+        always = {"CANARY_ADV_BCRYPT_BASELINE_HASH_VALUE",
+                  "CANARY_ADV_AUTHKEYS_BASELINE",
+                  "CANARY_ADV_ROCOMMUNITY_BASELINE",
+                  "CANARY_ADV07_URLPASS",
+                  "CANARY_ADV07_QUERYTOKEN",
+                  "CANARY_ADV10_MIXEDCASE",
+                  "CANARY_ADV10_UPPERCASE"}
+        for flags in ([], ["--aggressive"], ["--anonymise"], ["--redact-descriptions"]):
+            result = run_redactor(adversarial_canary, "--stdout", *flags)
+            survivors = find_markers(result.stdout) & always
+            assert not survivors, f"{flags or 'default'}: {sorted(survivors)}"
+
+    def test_idempotent_across_modes(self, adversarial_canary, run_redactor, tmp_path):
+        """redact(redact(x)) must reveal nothing redact(x) did not"""
+        for name, flags in [("default", []), ("aggr", ["--aggressive"]),
+                            ("anon", ["--anonymise"])]:
+            once = run_redactor(adversarial_canary, "--stdout", *flags).stdout
+            staged = tmp_path / f"{name}.xml"
+            staged.write_text(once)
+            twice = run_redactor(staged, "--stdout", *flags).stdout
+
+            assert not (find_markers(twice) - find_markers(once)), name
+            assert not (find_key_material(twice) - find_key_material(once)), name

--- a/tests/adversarial/test_redaction_gaps.py
+++ b/tests/adversarial/test_redaction_gaps.py
@@ -408,6 +408,41 @@ class TestNameCoverage:
             f"'{name}': element={as_element} attribute={as_attribute}"
         )
 
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (CANARY_PEM, "private-key"),
+            (JWT, "jwt"),
+            ("aGVsbG8gd29ybGQxMjM0NTY3ODkwQUJDREVGRw==", None),
+            ("deadbeefdeadbeefdeadbeefcafefeedcafefeed", None),
+            ("an ordinary rule description", None),
+            ("-----BEGIN PUBLIC KEY-----\nAAAA\n", None),
+        ],
+        ids=["pem", "jwt", "base64-blob", "hex", "prose", "public-key"],
+    )
+    def test_the_same_value_decides_the_same_way_in_both_positions(self, value, expected):
+        """The value parity law, the counterpart of the name one above
+
+        Private-key material and JWTs are removed in every mode whatever holds
+        them, and the element and attribute paths must not disagree about which
+        values those are. Both classify through one function, so this asserts
+        the classification itself rather than each path separately.
+        """
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            unambiguous_secret_kind,
+        )
+        assert unambiguous_secret_kind(value) == expected
+
+    @pytest.mark.parametrize("value", [CANARY_PEM, JWT])
+    def test_element_and_attribute_remove_the_same_values(self, value):
+        """And the two paths act on that classification identically"""
+        as_element = redact(wrap(f"<vendorblob>{value}</vendorblob>"))
+        as_attribute = redact(wrap(f'<endpoint blob="{value}"/>'))
+
+        for fragment in ("CANARYPRIVATEKEY", "BEGIN RSA PRIVATE KEY", "eyJhbGciOiJIUzI1NiIs"):
+            assert fragment not in as_element, f"element kept {fragment}"
+            assert fragment not in as_attribute, f"attribute kept {fragment}"
+
     def test_mixed_case_tag_is_matched(self):
         """Regression pin: _normalise_tag lower-cases, so case cannot evade"""
         out = redact(wrap("<ApiKey>CANARY_MIXEDCASE</ApiKey><PASSWORD>CANARY_UPPER</PASSWORD>"))

--- a/tests/adversarial/test_redaction_gaps.py
+++ b/tests/adversarial/test_redaction_gaps.py
@@ -29,6 +29,14 @@ CANARY_PEM = (
     "-----END RSA PRIVATE KEY-----"
 )
 
+# Synthetic: HS256 header, a payload naming a canary subject, and a signature
+# segment that is not a signature of anything.
+JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJDQU5BUllfSldUIn0"
+    ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+)
+
 
 def redact(xml: str, **kwargs) -> str:
     """Run a full redaction over `xml` and return the serialised result
@@ -54,11 +62,6 @@ def wrap(inner: str) -> str:
 class TestKeyMaterialSurvival:
     """A private key must not survive, whatever element or attribute holds it"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-01: a PEM private key in an unrecognised element is "
-               "reported as high-entropy but retained in default mode",
-    )
     def test_pem_in_unknown_element_is_redacted(self):
         """Key material must not depend on the element being recognised"""
         out = redact(wrap(f"<vendorblob>{CANARY_PEM}</vendorblob>"))
@@ -70,21 +73,21 @@ class TestKeyMaterialSurvival:
         out = redact(wrap(f"<vendorblob>{CANARY_PEM}</vendorblob>"), aggressive=True)
         assert "BEGIN RSA PRIVATE KEY" not in out
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-02: a PEM private key in an attribute whose name is not "
-               "matched by SENSITIVE_ATTR_PATTERN is reported but retained",
-    )
     def test_pem_in_attribute_is_redacted(self):
         """Nor on the attribute name being recognised"""
         out = redact(wrap(f'<endpoint privkey="{CANARY_PEM}"/>'))
         assert "BEGIN RSA PRIVATE KEY" not in out
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-03: no decoding layer - base64-wrapped key material is "
-               "never decoded, so the PEM marker is never seen",
-    )
+    def test_pem_in_wholly_unremarkable_attribute_is_redacted(self):
+        """Not even a name-pattern match: the value alone must be enough
+
+        'privkey' now matches the unified name pattern, so it no longer proves
+        the value path works. 'blob' matches nothing at all.
+        """
+        out = redact(wrap(f'<endpoint blob="{CANARY_PEM}"/>'))
+        assert "BEGIN RSA PRIVATE KEY" not in out
+        assert "CANARYPRIVATEKEY" not in out
+
     def test_base64_wrapped_pem_is_redacted(self):
         """One layer of encoding must not conceal a key"""
         import base64  # pylint: disable=import-outside-toplevel
@@ -92,10 +95,6 @@ class TestKeyMaterialSurvival:
         out = redact(wrap(f"<payload>{encoded}</payload>"))
         assert not find_key_material(out), "key material recoverable by decoding"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-03: double-base64-wrapped key material is not decoded",
-    )
     def test_double_base64_wrapped_pem_is_redacted(self):
         """Nor two"""
         import base64  # pylint: disable=import-outside-toplevel
@@ -103,6 +102,79 @@ class TestKeyMaterialSurvival:
         twice = base64.b64encode(once.encode()).decode()
         out = redact(wrap(f"<blob>{twice}</blob>"))
         assert not find_key_material(out), "key material recoverable by decoding twice"
+
+    def test_base64url_wrapped_pem_is_redacted(self):
+        """The URL-safe alphabet is the same secret in a different spelling"""
+        import base64  # pylint: disable=import-outside-toplevel
+        encoded = base64.urlsafe_b64encode(CANARY_PEM.encode()).decode()
+        out = redact(wrap(f"<payload>{encoded}</payload>"))
+        assert not find_key_material(out)
+
+    def test_unpadded_base64_wrapped_pem_is_redacted(self):
+        """Values stored in attributes and JSON routinely lose their padding"""
+        import base64  # pylint: disable=import-outside-toplevel
+        encoded = base64.b64encode(CANARY_PEM.encode()).decode().rstrip("=")
+        out = redact(wrap(f"<payload>{encoded}</payload>"))
+        assert not find_key_material(out)
+
+    @pytest.mark.parametrize(
+        "label",
+        ["PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY", "DSA PRIVATE KEY",
+         "OPENSSH PRIVATE KEY", "ENCRYPTED PRIVATE KEY", "ED25519 PRIVATE KEY",
+         "PGP PRIVATE KEY BLOCK", "OPENVPN STATIC KEY V1"],
+    )
+    def test_every_private_key_header_is_redacted(self, label):
+        """One container header per supported form, in an unknown element"""
+        pem = (f"-----BEGIN {label}-----\n"
+               "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+               f"-----END {label}-----")
+        out = redact(wrap(f"<vendorblob>{pem}</vendorblob>"))
+
+        assert f"BEGIN {label}" not in out, label
+        assert "CANARYPRIVATEKEY" not in out, label
+
+    def test_public_key_header_is_not_treated_as_private(self):
+        """Over-redaction is a failure too: a public key is not a private one
+
+        Pins the boundary of the unconditional rule, so widening it later is a
+        deliberate act rather than a regex accident.
+        """
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            contains_private_key_material,
+        )
+        pem = ("-----BEGIN PUBLIC KEY-----\n"
+               "CANARYPUBLICKEYCANARYPUBLICKEYCANARYPUBLIC0123\n"
+               "-----END PUBLIC KEY-----")
+
+        assert not contains_private_key_material(pem)
+        assert not contains_private_key_material("-----BEGIN CERTIFICATE-----\nAAAA\n")
+
+    @pytest.mark.parametrize(
+        "wrapper",
+        ["{pem}", "   {pem}   ", "\n\n{pem}\n\n", "\t{pem}\t"],
+        ids=["bare", "spaces", "newlines", "tabs"],
+    )
+    def test_surrounding_whitespace_does_not_conceal_a_key(self, wrapper):
+        """Leading and trailing whitespace is not a hiding place"""
+        out = redact(wrap(f"<vendorblob>{wrapper.format(pem=CANARY_PEM)}</vendorblob>"))
+        assert "BEGIN RSA PRIVATE KEY" not in out
+
+    def test_pem_is_redacted_in_a_known_field_too(self):
+        """The known path must not regress while the unknown one is fixed"""
+        out = redact(f"<pfsense><cert><refid>abc</refid><prv>{CANARY_PEM}</prv></cert></pfsense>")
+        assert "BEGIN RSA PRIVATE KEY" not in out
+
+    @pytest.mark.parametrize(
+        "flags",
+        [{}, {"aggressive": True}, {"anonymise": True}, {"redact_descriptions": True},
+         {"keep_private_ips": True}],
+        ids=["default", "aggressive", "anonymise", "descriptions", "keep-private"],
+    )
+    def test_pem_dies_in_every_mode(self, flags):
+        """'Every mode' is the claim, so every mode is the test"""
+        out = redact(wrap(f"<vendorblob>{CANARY_PEM}</vendorblob>"), **flags)
+        assert "BEGIN RSA PRIVATE KEY" not in out, flags
+        assert "CANARYPRIVATEKEY" not in out, flags
 
 
 # ==========================================================================
@@ -130,44 +202,73 @@ class TestEntropyDetectorBlindSpots:
         """The case that works today - the control for the three below"""
         assert self._noticed("aGVsbG8gd29ybGQxMjM0NTY3ODkwQUJDREVGRw==")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-04: _has_mixed_character_classes requires two of "
-               "digit/upper/lower, so an all-lowercase blob is invisible",
-    )
     def test_lowercase_only_blob_is_noticed(self):
         """Character-class uniformity must not confer invisibility"""
         assert self._noticed("canaryadvlowercaseonlysecretvaluehere")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-04: an all-uppercase blob is invisible for the same reason",
-    )
     def test_uppercase_only_blob_is_noticed(self):
         """The same, in the other direction"""
         assert self._noticed("CANARYADVUPPERCASEONLYSECRETVALUEHERE")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-04: the hex branch requires a digit, so a hex secret "
-               "made only of a-f is invisible",
-    )
     def test_digitless_hex_blob_is_noticed(self):
         """A hex secret spelled only in a-f is still a secret"""
         assert self._noticed("deadbeefdeadbeefdeadbeefcafefeedcafefeed")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-05: the '.' separators fail BASE64ISH_RE, so a JWT is "
-               "not seen as high-entropy",
-    )
+    def test_digit_only_blob_is_noticed(self):
+        """Nor does being all digits make a 40-character value ordinary"""
+        assert self._noticed("8163264128256512102420484096819216384327")
+
     def test_jwt_is_noticed(self):
         """A JWT is a credential whatever its separators do to the shape test"""
-        assert self._noticed(
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-            ".eyJzdWIiOiJDQU5BUllfSldUIn0"
-            ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+        assert self._noticed(JWT)
+
+    def test_jwt_is_redacted_not_merely_reported(self):
+        """A JWT is unambiguous, so report-only is not good enough for it"""
+        out = redact(wrap(f"<sometoken_field>{JWT}</sometoken_field>"))
+
+        assert "eyJhbGciOiJIUzI1NiIs" not in out
+        assert "[REDACTED]" in out
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "host.internal.example",
+            "1.2.3",
+            "10.20.30.40",
+            "one.two.three",
+            "archive.tar.gz",
+            "backup-2026-07-28.config.xml",
+            "org.freedesktop.systemd1",
+            "com.example.someverylongreversedpackagename",
+        ],
+    )
+    def test_ordinary_dotted_strings_are_not_jwts(self, value):
+        """The cost of a JWT detector is what else it decides is a JWT"""
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            contains_jwt,
         )
+        assert not contains_jwt(value), value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "deadbeef",                                # short hex
+            "550e8400-e29b-41d4-a716-446655440000",    # UUID
+            "ac:de:48:00:11:22",                       # MAC
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",  # IPv6
+            "This is an ordinary operator note about the WAN link",
+            "https://feeds.example.net/lists/blocklist.txt",
+            "<rule><descr>allow web</descr></rule>",
+            "3",                                       # certificate serial
+            "00a3f1",                                  # short certificate serial
+            "1234567890",                              # short numeric identifier
+            "0000000000000000000000000000000000000000",  # all-zero field
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",  # padding
+        ],
+    )
+    def test_benign_values_are_not_opaque_secrets(self, value):
+        """Every one of these appears in a real config and none is a secret"""
+        assert not self._noticed(value), value
 
 
 # ==========================================================================
@@ -237,32 +338,72 @@ class TestNameCoverage:
         redactor = PfSenseRedactor()
         assert redactor._is_secret_tag(tag, tag)  # pylint: disable=protected-access
 
+    # Names that match the pattern but denote a choice, a length or a
+    # reference. Each was observed in a real pfSense or package config.
+    NOT_SECRETS = ["keylen", "certref", "caref", "keyid", "publickey",
+                   "pass_order", "password_type", "sendcommunity",
+                   "source_hash_key", "hash-algorithm", "hashalgo",
+                   "digestalgo", "auth-retry-none"]
+
+    # Innocent names that contain a secret-ish word as a substring. These are
+    # what the word-anchored half of the pattern exists to protect.
+    INNOCENT = ["author", "bypass", "compass_heading", "monkeys_allowed",
+                "authserver", "authdomain", "proxy_authtype",
+                "authentication_method", "enable_cookie", "normalize_cookies",
+                "signature_algorithm"]
+
     @pytest.mark.parametrize("tag", UNMATCHED)
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-09: SECRET_TAG_PATTERN does not cover these credential-"
-               "bearing element names",
-    )
     def test_unmatched_secret_tags_are_matched(self, tag):
-        """Credential-bearing element names the pattern misses"""
+        """Credential-bearing element names the pattern used to miss"""
         redactor = PfSenseRedactor()
         assert redactor._is_secret_tag(tag, tag)  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("tag", NOT_SECRETS)
+    def test_deny_listed_names_stay_deny_listed(self, tag):
+        """Widening the pattern must not consume the deny-list"""
+        redactor = PfSenseRedactor()
+        assert not redactor._is_secret_tag(tag, tag)  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("name", INNOCENT)
+    def test_innocent_names_are_not_classified_as_secrets(self, name):
+        """A substring is not a meaning: 'author' is not 'auth'"""
+        redactor = PfSenseRedactor()
+        assert not redactor._is_secret_name(name), name  # pylint: disable=protected-access
+
+    def test_digest_element_keeps_an_algorithm_name(self):
+        """<digest>SHA384</digest> selects an algorithm and is not a secret"""
+        out = redact("<pfsense><ipsec><phase1><digest>SHA384</digest></phase1></ipsec></pfsense>")
+        assert "SHA384" in out
+
+    def test_digest_element_loses_anything_else(self):
+        """The same element holding a digest, rather than naming one, is a secret"""
+        out = redact("<pfsense><pkg><digest>CANARY_DIGEST_VALUE</digest></pkg></pfsense>")
+        assert "CANARY_DIGEST_VALUE" not in out
 
     @pytest.mark.parametrize(
         "name", ["bearer", "cookie", "signature", "credentials", "privkey",
                  "licensekey", "psk", "passphrase", "community"]
-    )
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-10: SECRET_TAG_PATTERN and SENSITIVE_ATTR_PATTERN "
-               "disagree, so an element and an attribute of the same name get "
-               "different treatment",
     )
     def test_element_and_attribute_patterns_agree(self, name):
         """The same name must mean the same thing either side"""
         denied = name in SECRET_TAG_DENYLIST
         as_element = bool(SECRET_TAG_PATTERN.search(name)) and not denied
         as_attribute = bool(SENSITIVE_ATTR_PATTERN.search(name))
+        assert as_element == as_attribute, (
+            f"'{name}': element={as_element} attribute={as_attribute}"
+        )
+
+    @pytest.mark.parametrize("name", ALREADY_MATCHED + UNMATCHED + NOT_SECRETS + INNOCENT)
+    def test_the_same_name_decides_the_same_way_in_both_positions(self, name):
+        """The parity law, stated over every name this file knows about
+
+        Asserted through the predicate rather than the raw pattern, so the
+        deny-list is part of the law rather than an exception to it.
+        """
+        redactor = PfSenseRedactor()
+        as_element = redactor._is_secret_tag(name, name)  # pylint: disable=protected-access
+        as_attribute = redactor._should_redact_attribute(name)  # pylint: disable=protected-access
+
         assert as_element == as_attribute, (
             f"'{name}': element={as_element} attribute={as_attribute}"
         )
@@ -385,15 +526,21 @@ class TestAdversarialCorpusEndToEnd:
         run_redactor(adversarial_canary, "--dry-run-verbose")
         assert adversarial_canary.read_bytes() == before
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-01/02/03: private key material survives default-mode "
-               "redaction of the adversarial corpus",
-    )
     def test_no_key_material_survives_default_mode(self, adversarial_canary, run_redactor):
         """The mode the README leads with must not emit a private key"""
         result = run_redactor(adversarial_canary, "--stdout")
         assert not find_key_material(result.stdout)
+
+    def test_no_key_material_reaches_stderr_either(self, adversarial_canary, run_redactor):
+        """A key printed in a diagnostic is still a key that left the machine"""
+        for flags in ([], ["--aggressive"], ["--verbose"], ["--dry-run-verbose"],
+                      ["--fail-on-warn"]):
+            result = run_redactor(adversarial_canary, "--stdout", *flags)
+            combined = result.stdout + result.stderr
+
+            assert not find_key_material(combined), flags
+            assert "CANARYADV02PRIVATEKEY" not in combined, flags
+            assert "CANARYADV03PRIVATEKEY" not in combined, flags
 
     def test_no_key_material_survives_aggressive_mode(self, adversarial_canary, run_redactor):
         """--aggressive does clear these, but by shape rather than by decoding

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.1 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_encoded_secret_detection.py
+++ b/tests/unit/test_encoded_secret_detection.py
@@ -106,6 +106,39 @@ class TestBoundedDecoding:
 
         assert time.monotonic() - started < 10
 
+    def test_a_run_of_only_padding_decodes_to_nothing(self):
+        """'====' strips to an empty body, which is not a decoding
+
+        Reachable from real input: a run of padding characters satisfies
+        ENCODED_RUN_RE, so the decoder has to have an answer for it.
+        """
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            _b64_decode_bounded,
+        )
+        assert _b64_decode_bounded("=" * 40) is None
+
+    def test_a_run_decoding_past_the_byte_bound_is_refused(self):
+        """The size bound is enforced on the decoded result, not just the input
+
+        A run can be short enough to attempt and still produce more than
+        MAX_DECODED_BYTES, which is the case this bound exists for.
+        """
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            _b64_decode_bounded,
+        )
+        oversized = base64.b64encode(b"A" * (MAX_DECODED_BYTES + 1024)).decode()
+
+        assert _b64_decode_bounded(oversized) is None
+
+    def test_a_run_decoding_within_the_bound_is_accepted(self):
+        """The control, so the test above is not passing on the wrong branch"""
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            _b64_decode_bounded,
+        )
+        payload = base64.b64encode(b"A" * (MAX_DECODED_BYTES - 1024)).decode()
+
+        assert _b64_decode_bounded(payload) is not None
+
     def test_input_is_never_returned_as_a_layer(self):
         """Returning the source would double-count it in every caller"""
         source = wrap_b64(PEM)

--- a/tests/unit/test_encoded_secret_detection.py
+++ b/tests/unit/test_encoded_secret_detection.py
@@ -1,0 +1,323 @@
+"""Bounded decoding, private-key recognition, JWT and opaque-value shape
+
+These are the primitives the redactor's classification rests on, so they are
+tested directly as well as through the tree walk. The bounds matter as much as
+the detection: a scanner that decodes without limit is a denial of service
+wearing a security control's clothes.
+
+Every value here is synthetic. The "PEM" bodies are base64-legal runs of the
+word CANARY and decode to nothing.
+"""
+import base64
+import time
+
+import pytest
+
+from pfsense_redactor.redactor import (
+    MAX_DECODE_DEPTH,
+    MAX_DECODED_BYTES,
+    MIN_OPAQUE_ENTROPY_BITS,
+    OPAQUE_UNIFORM_MIN_LENGTH,
+    PfSenseRedactor,
+    contains_jwt,
+    contains_private_key_material,
+    decoded_layers,
+    shannon_entropy_bits,
+)
+
+PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJDQU5BUllfSldUIn0"
+    ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+)
+
+
+def wrap_b64(value, times=1):
+    """Base64-encode `value` `times` over"""
+    data = value.encode() if isinstance(value, str) else value
+    for _ in range(times):
+        data = base64.b64encode(data)
+    return data.decode()
+
+
+class TestBoundedDecoding:
+    """decoded_layers must find what is hidden and stop where it is told"""
+
+    def test_finds_a_single_layer(self):
+        """The ordinary case"""
+        layers = decoded_layers(wrap_b64(PEM))
+        assert any("BEGIN RSA PRIVATE KEY" in layer for layer in layers)
+
+    def test_finds_a_double_layer(self):
+        """Wrapping twice hides the marker from any first-layer heuristic"""
+        layers = decoded_layers(wrap_b64(PEM, 2))
+        assert any("BEGIN RSA PRIVATE KEY" in layer for layer in layers)
+
+    def test_finds_a_triple_layer(self):
+        """Three is the documented depth, so three must work"""
+        layers = decoded_layers(wrap_b64(PEM, 3))
+        assert any("BEGIN RSA PRIVATE KEY" in layer for layer in layers)
+
+    def test_stops_at_the_documented_depth(self):
+        """Four layers is past the bound, and the bound is the point"""
+        layers = decoded_layers(wrap_b64(PEM, MAX_DECODE_DEPTH + 1))
+        assert not any("BEGIN RSA PRIVATE KEY" in layer for layer in layers)
+
+    def test_depth_argument_is_honoured(self):
+        """Callers can tighten the bound; nobody can loosen it past the loop"""
+        assert not decoded_layers(wrap_b64(PEM, 2), max_depth=1) or not any(
+            "BEGIN RSA PRIVATE KEY" in layer
+            for layer in decoded_layers(wrap_b64(PEM, 2), max_depth=1)
+        )
+
+    def test_invalid_base64_yields_nothing(self):
+        """Strict validation, so text that was never encoded is not 'decoded'"""
+        assert not decoded_layers("!!!! not base64 at all !!!!")
+
+    def test_short_values_are_not_decoded_at_all(self):
+        """Below the candidate floor there is no room to hide a key header"""
+        assert not decoded_layers("QUJD")
+
+    def test_unchanged_decoding_is_not_expanded_again(self):
+        """A value that decodes to itself is a dead end, not a loop"""
+        layers = decoded_layers("A" * 64)
+        assert len(layers) <= MAX_DECODE_DEPTH
+
+    def test_oversized_encoded_run_is_refused(self):
+        """A run that would decode past the byte bound is skipped, not decoded"""
+        oversized = wrap_b64("x" * (MAX_DECODED_BYTES * 2))
+        started = time.monotonic()
+        layers = decoded_layers(oversized)
+
+        assert time.monotonic() - started < 10
+        assert not any(len(layer) > MAX_DECODED_BYTES for layer in layers)
+
+    def test_decoding_a_large_document_stays_quick(self):
+        """The operation budget is shared, so many runs cost no more than a few"""
+        text = " ".join(wrap_b64(f"value-number-{n}-padding") for n in range(5000))
+        started = time.monotonic()
+        decoded_layers(text)
+
+        assert time.monotonic() - started < 10
+
+    def test_input_is_never_returned_as_a_layer(self):
+        """Returning the source would double-count it in every caller"""
+        source = wrap_b64(PEM)
+        assert source not in decoded_layers(source)
+
+
+class TestPrivateKeyRecognition:
+    """The one classification with no over-redaction trade-off"""
+
+    @pytest.mark.parametrize(
+        "label",
+        ["PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY", "DSA PRIVATE KEY",
+         "ED25519 PRIVATE KEY", "OPENSSH PRIVATE KEY", "ENCRYPTED PRIVATE KEY",
+         "SSH2 ENCRYPTED PRIVATE KEY", "PGP PRIVATE KEY BLOCK",
+         "OPENVPN STATIC KEY V1"],
+    )
+    def test_recognises_every_supported_header(self, label):
+        """One per container header the tool claims to recognise"""
+        assert contains_private_key_material(f"-----BEGIN {label}-----\nAAAA\n")
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "-----BEGIN CERTIFICATE-----",
+            "-----BEGIN PUBLIC KEY-----",
+            "-----BEGIN RSA PUBLIC KEY-----",
+            "-----BEGIN DH PARAMETERS-----",
+            "-----BEGIN CERTIFICATE REQUEST-----",
+            "the private key is stored elsewhere",
+        ],
+    )
+    def test_does_not_overclaim(self, text):
+        """A certificate, a public key and a sentence are not private keys"""
+        assert not contains_private_key_material(text)
+
+    def test_recognises_through_one_encoding(self):
+        """An encoding is not a protection"""
+        assert contains_private_key_material(wrap_b64(PEM))
+
+    def test_recognises_through_two_encodings(self):
+        """Nor two"""
+        assert contains_private_key_material(wrap_b64(PEM, 2))
+
+    def test_recognises_through_urlsafe_encoding(self):
+        """The URL-safe alphabet is the same secret spelled differently"""
+        assert contains_private_key_material(
+            base64.urlsafe_b64encode(PEM.encode()).decode()
+        )
+
+    def test_recognises_without_padding(self):
+        """Attributes and JSON routinely strip the padding"""
+        assert contains_private_key_material(wrap_b64(PEM).rstrip("="))
+
+
+class TestJwtRecognition:
+    """A compact token, and the dotted strings that are not one"""
+
+    def test_recognises_a_compact_jwt(self):
+        """The ordinary case"""
+        assert contains_jwt(JWT)
+
+    def test_recognises_a_jwt_inside_a_header_value(self):
+        """'Authorization: Bearer <token>' is where these actually live"""
+        assert contains_jwt(f"Bearer {JWT}")
+
+    def test_recognises_a_jwt_in_a_url_query(self):
+        """Tokens reach configs in a query string as often as in a header"""
+        assert contains_jwt(f"https://api.example.invalid/v1?access_token={JWT}")
+
+    def test_recognises_a_long_jwt(self):
+        """Length is not what identifies it, so length must not defeat it"""
+        long_payload = base64.urlsafe_b64encode(
+            b'{"sub":"' + b'CANARY' * 200 + b'"}'
+        ).decode().rstrip("=")
+        assert contains_jwt(f"eyJhbGciOiJIUzI1NiJ9.{long_payload}.c2lnbmF0dXJl")
+
+    def test_recognises_a_whitespace_formatted_header(self):
+        """A header serialised with spaces does not start with 'eyJ'"""
+        header = base64.urlsafe_b64encode(b'{ "alg": "HS256" }').decode().rstrip("=")
+        assert contains_jwt(f"{header}.eyJzdWIiOiJhIn0.c2lnbmF0dXJlc2lnbmF0dXJl")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "no dots here at all",
+            "host.internal.example",
+            "vpn.corp.megacorp-holdings.example",
+            "1.2.3",
+            "23.09.1",
+            "192.0.2.1",
+            "2001:db8::1",
+            "one.two.three",
+            "archive.tar.gz",
+            "config-backup-2026-07-28.old.xml",
+            "com.example.averylongreversedpackagenameindeed",
+            "/var/db/pfblockerng/deny.megacorp-holdings.example.txt",
+        ],
+    )
+    def test_ordinary_dotted_strings_are_not_tokens(self, value):
+        """The whole cost of this detector is what else it decides is a token"""
+        assert not contains_jwt(value), value
+
+    def test_three_long_segments_alone_are_not_enough(self):
+        """The general shape only counts when segment one is a JOSE header"""
+        assert not contains_jwt(
+            "aaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc"
+        )
+
+
+class TestEntropyAndShape:
+    """The one heuristic of the three, and its thresholds"""
+
+    def test_entropy_of_uniform_text_is_zero(self):
+        """One repeated character carries no information"""
+        assert shannon_entropy_bits("A" * 64) == 0.0
+
+    def test_entropy_of_empty_text_is_zero(self):
+        """And neither does nothing at all"""
+        assert shannon_entropy_bits("") == 0.0
+
+    def test_entropy_of_a_base64_secret_is_high(self):
+        """The control for the floor below"""
+        assert shannon_entropy_bits(wrap_b64(PEM)) > 4.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "canaryadvlowercaseonlysecretvaluehere",
+            "CANARYADVUPPERCASEONLYSECRETVALUEHERE",
+            "deadbeefdeadbeefdeadbeefcafefeedcafefeed",
+            "DEADBEEFDEADBEEFDEADBEEFCAFEFEEDCAFEFEED",
+            "deadbeefdeadbeefdeadbeefdeadbeef",
+            "8163264128256512102420484096819216384327",
+            "aGVsbG8gd29ybGQxMjM0NTY3ODkwQUJDREVGRw==",
+        ],
+        ids=["lower", "upper", "hex-lower", "hex-upper", "hex-32", "digits", "mixed"],
+    )
+    def test_opaque_secrets_are_detected(self, value):
+        """Single-character-class uniformity is not a disguise"""
+        assert PfSenseRedactor()._is_high_entropy_value(value), value  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "deadbeef",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "550E8400-E29B-41D4-A716-446655440000",
+            "ac:de:48:00:11:22",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "This is an ordinary operator note about the WAN link and its ISP",
+            "https://feeds.example.net/lists/blocklist.txt",
+            "<rule><descr>allow web traffic from the office</descr></rule>",
+            "3",
+            "00a3f1",
+            "1234567890",
+            "0000000000000000000000000000000000000000",
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "abababababababababababababababababababab",
+        ],
+        ids=["short-hex", "uuid", "uuid-upper", "mac", "ipv6", "prose", "url",
+             "xml", "serial", "short-serial", "numeric-id", "zeroes", "padding",
+             "repeated"],
+    )
+    def test_benign_values_are_not_detected(self, value):
+        """Each of these appears in a real config and none is a secret"""
+        assert not PfSenseRedactor()._is_high_entropy_value(value), value  # pylint: disable=protected-access
+
+    def test_the_uniform_length_band_is_where_it_is_documented(self):
+        """A single-class value just under the floor stays out of scope
+
+        Pins the threshold rather than leaving it implicit, so moving it is a
+        deliberate act with a visible cost.
+        """
+        redactor = PfSenseRedactor()
+        just_under = "abcdefghij" * 4
+        just_under = just_under[:OPAQUE_UNIFORM_MIN_LENGTH - 1]
+        just_over = ("abcdefghij" * 4)[:OPAQUE_UNIFORM_MIN_LENGTH]
+
+        assert not redactor._is_high_entropy_value(just_under)  # pylint: disable=protected-access
+        assert redactor._is_high_entropy_value(just_over)  # pylint: disable=protected-access
+
+    def test_the_entropy_floor_is_load_bearing(self):
+        """Below it, a value satisfying the shape carries nothing"""
+        assert shannon_entropy_bits("ab" * 32) < MIN_OPAQUE_ENTROPY_BITS
+        assert not PfSenseRedactor()._is_high_entropy_value("ab" * 32)  # pylint: disable=protected-access
+
+
+class TestNothingDecodedIsEverEmitted:
+    """Decoded plaintext is the thing someone chose to encode"""
+
+    def test_decoding_leaves_no_trace_in_logs(self, caplog):
+        """The decoder must not log what it found, at any level"""
+        import logging  # pylint: disable=import-outside-toplevel
+
+        with caplog.at_level(logging.DEBUG, logger='pfsense_redactor'):
+            assert contains_private_key_material(wrap_b64(PEM, 2))
+
+        assert "BEGIN RSA PRIVATE KEY" not in caplog.text
+        assert "CANARYPRIVATEKEY" not in caplog.text
+
+    def test_decoded_content_is_not_placed_in_samples(self):
+        """--dry-run-verbose prints samples, so samples must not carry it"""
+        import xml.etree.ElementTree as ET  # pylint: disable=import-outside-toplevel
+
+        redactor = PfSenseRedactor(dry_run_verbose=True)
+        root = ET.fromstring(
+            f"<pfsense><pkg><payload>{wrap_b64(PEM)}</payload></pkg></pfsense>"
+        )
+        redactor.redact_element(root)
+
+        rendered = str(dict(redactor.samples))
+        assert "BEGIN RSA PRIVATE KEY" not in rendered
+        assert "CANARYPRIVATEKEY" not in rendered


### PR DESCRIPTION
Five classes of credential could survive redaction while the run exited 0. None
of them was visible to `--fail-on-warn` either, because a value the transformer
cannot classify is not counted among the retained ones. This PR makes the
transformer see them.

## Findings addressed

| Finding | Status | Evidence |
| --- | --- | --- |
| FINDING-01 | Fixed | `test_redaction_gaps.py::TestKeyMaterialSurvival` (13 cases); `redactor.py` `_redact_unknown_blob_element` |
| FINDING-02 | Fixed | `…::test_pem_in_attribute_is_redacted`, `…::test_pem_in_wholly_unremarkable_attribute_is_redacted`; `_account_for_attribute_blob` |
| FINDING-03 | Fixed | `…::test_base64_wrapped_pem_is_redacted`, `…::test_double_base64_wrapped_pem_is_redacted`, `test_encoded_secret_detection.py::TestBoundedDecoding` (11 cases) |
| FINDING-04 | Fixed | `TestEntropyDetectorBlindSpots` (4 cases), `TestEntropyAndShape` (24 cases) |
| FINDING-05 | Fixed | `…::test_jwt_is_noticed`, `TestJwtRecognition` (18 cases) |
| FINDING-09 | Fixed | `TestNameCoverage::test_unmatched_secret_tags_are_matched` (13 cases) |
| FINDING-10 | Fixed | `…::test_element_and_attribute_patterns_agree` (9), `…::test_the_same_name_decides_the_same_way_in_both_positions` (46) |

## Security invariants

- A PEM private key cannot survive because its XML tag or attribute name is unrecognised.
- An encoding is not a protection: Base64 and Base64URL are decoded to depth 3 and re-examined.
- A compact JWT is a credential in every mode.
- Character-class uniformity does not confer invisibility.
- A name means the same thing whether it is an element or an attribute.
- Decoded content is never logged, sampled, or placed in an exception.

## Behaviour changes

- Values in unrecognised elements/attributes may now be redacted where they were previously retained and listed for review. Nothing previously redacted is now kept.
- `<digest>`/`<hash>` decided by value: `SHA384` preserved, anything else redacted.
- Retained-value warning is shorter; the `--fail-on-warn` count no longer includes private keys or JWTs.
- No CLI option, default, or exit code changes. Output remains valid pfSense XML.

## Regression analysis

- Baseline (`main` @ `5e15f4c`, before this branch): **825 passed, 1 skipped, 57 xfailed**
- After committing the adversarial suite + tracker: **829 passed, 1 skipped, 57 xfailed**
- After this PR: **1123 passed, 1 skipped, 26 xfailed**
- Previously passing tests affected: 1 — `test_assurance_signals.py::test_retained_paths_are_named_on_stderr`

**Modified expectation.** That test asserted `telemetryagent/config/vendorblob` and `endpoint[@privkey]` appeared in the retained-value warning. Both held private-key material and are now redacted, so listing them as retained would be false. The invariant — a kept value is located precisely enough to audit, not merely counted — is unchanged and still asserted, on values the tool still keeps. A new test asserts the converse: a redacted value must not appear in the retained list.

Reference snapshots regenerated: the only changed line across all 21 files is the version comment. No unrelated xfail changed status.

## Tests

```
python -m pytest tests/ -q                                  1123 passed, 1 skipped, 26 xfailed
python -m pytest tests/adversarial/test_redaction_gaps.py -q  174 passed, 7 xfailed
python tools/check_structure.py                             exit 0
python -m pylint --rcfile=.pylintrc  $(git ls-files 'pfsense_redactor/*.py')   10.00/10
python -m pylint --rcfile=.pylintrc-tests $(git ls-files 'tests/**/*.py')      10.00/10
gitleaks detect --no-git --source <generated output>        no leaks found
xmllint --noout <generated output>                          valid
```

## Xfail changes

Removed (31): FINDING-01 ×4, FINDING-02 ×1, FINDING-03 ×2, FINDING-04 ×3, FINDING-05 ×1, FINDING-09 ×13, FINDING-10 ×9.
Retained (26): FINDING-06, 07, 08, 11 ×2, 12 ×2, 13 ×2, 14, 15 ×2, 16, 17, 18, 19 ×2, 20, 21, 22, 23, 24, 25 ×2, 26, 27.
New markers: none.

## Remaining risks

- The retention of a secret in an unrecognised element with no distinguishing shape is unaddressed here (`CANARY_ADV01_UNEXPECTED_TAG` still survives). PR 2's verifier is what sees it.
- The opaque-value bands are heuristics with documented thresholds; a long space-free identifier may be reported as retained.
- Unknown encodings other than Base64/Base64URL remain opaque.

## Review guidance

Security-critical: `pfsense_redactor/redactor.py` — the constants block (`PRIVATE_KEY_PEM_RE`, `JWT_PREFIXED_RE`, the decode bounds), `decoded_layers`, `_is_opaque_secret_shape`, and the two call sites in `_redact_unknown_blob_element` / `_account_for_attribute_blob`.

Suggested order: commit 2 (production) → the deny-list and algorithm carve-out → commit 3 (tests).

---

## Update: CI fix (`f1ade84`)

The `build` job of `python-app.yml` failed on the first run with three errors. It installs only `flake8` and `pytest` — no `pip install -e .` — so `python -m pfsense_redactor` resolved the package from the current directory only. Several tests here run the CLI with `cwd` set to a temporary directory, and from there every one of those runs died with `ModuleNotFoundError` before executing a line of the tool. `tests.yml` does install the package, which is why all 18 matrix cells passed.

Two of the three were plain failures (`'' != ''`). The third was not: `test_same_file_via_relative_indirection_is_refused` **XPASSed a strict xfail for FINDING-15**, which this PR does not fix. It asserts "exited non-zero" and "the input is unchanged", and a subprocess that never started satisfies both.

Fixed in `tests/adversarial/conftest.py`:

- `_subprocess_env` puts `PROJECT_ROOT` on the child's `PYTHONPATH`, so the package is importable whatever the cwd and whether or not it is installed.
- `run_redactor` turns a never-started child into an immediate `pytest.fail` rather than returning it. Most tests here cannot tell a refusal from a crash, so the harness has to.

`tests/adversarial/test_harness.py` (new, 6 cases) covers both, including that the guard fires on a never-started child and does not fire on an ordinary refusal.

Verified in both CI environments, on every branch in the stack:

| Branch | Installed | Not installed |
| --- | --- | --- |
| #65 | 1123 passed, 1 skipped, 26 xfailed | 1123 passed, 1 skipped, 26 xfailed |
| #66 | 1174 / 26 | 1174 / 26 |
| #67 | 1222 / 18 | 1222 / 18 |
| #68 | 1291 / 9 | 1291 / 9 |
| #69 | 1315 / 9 | 1315 / 9 |

FINDING-15's marker is `XFAIL` again in the uninstalled environment, which is correct for this PR.

---

## Update: rebased onto #70, and one function split

**Base changed to `security/restore-codescene-structure` (#70).** That PR restores the CodeScene work from #62, which never reached `main` — it merged into `ipv6-zone-leak` 27 seconds after that branch had been squash-merged. This stack was built on a `main` that should have contained it.

Conflict resolved in the rebase: `_should_redact_completely` loses its `redact_ips`/`redact_domains` parameters to per-run instance state (#62's change), and keeps this PR's `_names_an_algorithm_choice` carve-out.

**`_redact_unknown_blob_element` split** (`e7b0014`). CodeScene reported it at complexity 9 — it went from 5 branches to 7 when this PR added the private-key and JWT cases, and it is security-critical enough that the shape matters. Two policies decided on different grounds, so one method each:

- `_redact_unambiguous_secret_element` — private-key material and JWTs, removed in every mode because the value settles the question by itself
- `_account_for_opaque_element` — everything else, where the shape is only evidence and report-only stays the default

The attribute path had the identical three-way structure, duplicated. Both now classify through a module-level `unambiguous_secret_kind(text) -> 'private-key' | 'jwt' | None` and dispatch through one placeholder table, so **the two cannot decide the same value differently** — the parity the name patterns already have from FINDING-10, applied to values. A new value-parity law sits beside the existing name one in `tests/adversarial/test_redaction_gaps.py`.

Behaviour-preserving, verified by the decode-aware scan reporting identical marker counts before and after: 6 default, 4 aggressive, 6 anonymise, **0 key types throughout**.

Totals after the rebase, both CI environments identical:

| Branch | Suite | Xfails |
| --- | --- | --- |
| #65 | 1123 passed, 1 skipped | 26 |
| #66 | 1174 | 26 |
| #67 | 1222 | 18 |
| #68 | 1291 | 9 |
| #69 | 1315 | 9 |

`tools/check_structure.py` (the stricter restored version) passes on all of them, and `flake8 --select=C901 --max-complexity=8` reports 0.

---

## Update: rebased onto merged main, review comments addressed

#70 merged, so this now targets `main` directly.

Two Codacy comments, both correct:

**Redundant structural checks.** `_account_for_opaque_element` and
`_account_for_attribute_blob` called `_is_high_entropy_value` *after*
`_redact_unambiguous_secret_*` had already run `contains_private_key_material`
and `contains_jwt` and found neither — so `decoded_layers` ran a second time
over the same text, which is the expensive half. The predicate is split rather
than the checks deleted, because `_is_high_entropy_value` is called directly by
tests and is the right entry point when nothing is known about the value:

| | |
| --- | --- |
| `_is_high_entropy_value` | `unambiguous_secret_kind(text)` or `_is_opaque_value` — complete, contract unchanged |
| `_is_opaque_value` | the heuristic half alone |

**`findall` → `finditer`** in `_decode_encoded_runs`: the loop usually stops on
the operation budget long before the runs are exhausted.

**Coverage.** Codecov reported 5 uncovered lines in this diff. All five are now
covered by real tests — no `# pragma: no cover` added:

- a run of only padding, which strips to an empty body
- a run decoding past `MAX_DECODED_BYTES`, plus its control
- `<digest>` with children, where the guard stops empty text reading as "no algorithm named" and skipping the secret-name treatment
- an empty `<descr>` under `--redact-descriptions`, which must not gain a placeholder for a value that never existed
- the de-duplication in `_record_retained_path`, which had no test for two siblings sharing a path

Totals after the rebase, identical in both CI environments:

| Branch | Suite | Xfails |
| --- | --- | --- |
| #65 | 1123 passed, 1 skipped | 26 |
| #66 | 1174 | 26 |
| #67 | 1222 | 18 |
| #68 | 1291 | 9 |
| #69 | 1315 | 9 |


---

## Versions renumbered

The stack was numbered 1.3.0–1.8.0, one minor bump per PR, because the
repository forbids an open `[Unreleased]` section so each PR had to name a
version. That claimed six releases that never happened: **PyPI's latest is
1.1.2**, and `main`'s 1.2.0 has not shipped either.

Renumbered to patches, with a minor only where compatibility actually breaks:

| PR | Was | Now | |
| --- | --- | --- | --- |
| #65 | 1.3.0 | **1.2.1** | additive detection |
| #66 | 1.4.0 | **1.2.2** | verifier, advisory only |
| #67 | 1.5.0 | **1.3.0** | breaking: `--inplace` needs `--force`, hard links refused, failed gate writes nothing |
| #68 | 1.6.0 | **1.4.0** | breaking: usage errors exit 1, not 2 |
| #69 | 1.7.0 | **1.4.1** | workflows and docs only |
| #71 | 1.8.0 | **1.4.2** | verifier containment |

Sequence: `1.2.0 → 1.2.1 → 1.2.2 → 1.3.0 → 1.4.0 → 1.4.1 → 1.4.2`.

Test totals are unchanged by the renumber, and reference snapshots differ only
in the version comment.
