### PR TITLE
Independent post-redaction verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2][] - 2026-08-04
+
+An independent verifier. Until now the only check on a redacted file was the
+transformer reporting what it had chosen to keep, so a class of secret the
+transformer could not see was equally invisible to the check.
+
+### Added
+
+- **`pfsense_redactor/verifier.py`, an independent post-redaction verifier.**
+  It re-reads the serialised candidate output - the exact text that gets
+  written - rather than the transformer's statistics, warning counts or record
+  of retained values. Its rules are written and maintained separately from the
+  transformer's, so a mistake in one is not automatically a mistake in the
+  other. (FINDING-21)
+
+  Two checks, deliberately different in kind:
+
+  - **Shape scan**: private-key PEM headers, compact JWTs, credential-bearing
+    URLs, and long hexadecimal or Base64 runs, including through up to three
+    bounded layers of Base64 decoding.
+  - **Input-value retention**: every input leaf and attribute value of 16
+    characters or more is checked for verbatim survival in the output. This is
+    the check that cannot inherit the transformer's blind spots, because it
+    classifies nothing - it does not need to know what a value means to notice
+    that it came out unchanged.
+
+- Every run now reports a verification result on stderr. Findings carry a path,
+  a category, a length and a reason, and never the value, a prefix of it, or a
+  hash of it.
+
+### Security
+
+- Verification is **advisory in this release**: the result is reported and does
+  not decide whether output is written. Enforcement - refusing to write when
+  verification fails - arrives with the verify-before-write change.
+
+- When `redactor.py` is copied out and run as a single file without
+  `verifier.py` beside it, the run reports verification as **unavailable**
+  rather than passing. An unavailable check is not a clean one, and conflating
+  the two is the fail-open behaviour the verifier exists to remove.
+
+### Changed
+
+- Candidate output is serialised once and both verified and written from the
+  same text, so what is checked is what is shared. `PfSenseRedactor.serialise_tree`
+  is pinned byte-for-byte against what the writer produces.
+
+- `PfSenseRedactor.last_verification` holds the most recent result, or `None`
+  when the verifier was unavailable. `None` is never a pass.
+
+No action is required. No CLI option, default or exit code changes, and output
+is byte-identical to 1.2.1 for the same input.
+
 ## [1.2.1][] - 2026-08-02
 
 Secret detection hardening. Five classes of credential that previously survived
@@ -715,6 +768,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.2.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.2
 [1.2.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.1
 [1.2.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.0
 [1.1.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.1.2

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -45,6 +45,7 @@ That is the number each pull request below is compared against.
 | PR | Full suite | Xfails removed | Xfails remaining |
 | --- | --- | --- | --- |
 | 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
+| 2 | 1106 passed, 1 skipped, 26 xfailed | 0 | 26 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -31,7 +31,75 @@ attribute named in brackets:
 This warning is the direct answer to "what did you leave behind". Do not ignore
 it, and re-run with `--aggressive` if any path looks like it holds a secret.
 
-## 2. Let CI check it for you
+## 2. Read the independent verification
+
+Since 1.4.0 a second component re-reads the **serialised output** — the exact
+text that gets written — and reports material that should not be in it:
+
+```
+[!] Independent verification found 2 issue(s) in the output:
+    - retained-private-key: document (pem-private-key, 1704 chars) - private-key PEM header in candidate output
+    - retained-input-value: pfsense/installedpackages/vendor/blob (element, 44 chars) - input value present verbatim in candidate output
+```
+
+This is not the summary restated. The summary is the transformer reporting what
+it chose to keep, so a class of secret the transformer cannot see is equally
+invisible to it. The verifier is a separate module with its own rules, and it
+looks at the output rather than at the transformer's record of it.
+
+Two checks, deliberately different in kind:
+
+- **Shape scan.** Private-key PEM headers, compact JWTs, credential-bearing
+  URLs, and long hexadecimal or Base64 runs — including through up to three
+  layers of Base64 decoding. Patterns written and maintained separately from
+  the transformer's, so a mistake in one is not automatically a mistake in the
+  other.
+- **Input-value retention.** Every input leaf and attribute value of 16
+  characters or more is checked for verbatim survival. This is the check that
+  cannot inherit the transformer's blind spots, because it classifies nothing:
+  it does not need to know what a value means to notice that it came out
+  unchanged.
+
+Findings carry a path, a category, a length and a reason. They never carry the
+value, a prefix of it, or a hash of it — a short secret's hash is
+brute-forceable and a token's prefix names its issuer — so the whole block is
+safe to paste into a ticket.
+
+### What it does not see
+
+The retention check only reports values made entirely of `A-Za-z0-9+/=_-`, the
+alphabet Base64, Base64URL, hex and API keys all live in. Without that
+restriction every rule description, cron command and package metadata field in a
+real config is reported, and a report nobody reads is not a control. A secret
+containing a dot, a colon or a space is invisible to *this* check — JWTs and
+credential-bearing URLs are covered by the shape scan instead, and free prose by
+`--redact-descriptions`.
+
+Absolute paths, the tool's own placeholders, allow-listed entries and a short
+list of structural element names (`refid`, `uuid`, `interface`, package
+metadata) are excluded, each by a rule asserted individually in
+`tests/unit/test_output_verification.py`.
+
+### Advisory in 1.4.0
+
+The result is reported; it does not yet decide whether output is written. Do
+not read "no findings" as "safe to publish" — read it as "a second pass found
+nothing", which is a weaker and more useful statement.
+
+### If verification is unavailable
+
+`redactor.py` can be copied out and run as a single file. Done that way, without
+`verifier.py` beside it, the run says so:
+
+```
+[!] Independent verification unavailable: verifier.py is not importable.
+    Redaction ran, but nothing re-read the output.
+```
+
+That is deliberately not silence, and deliberately not a pass. Copy `verifier.py`
+alongside `redactor.py` to keep the check.
+
+## 3. Let CI check it for you
 
 The same warning drives an exit code, so a pipeline can gate on it:
 
@@ -44,7 +112,7 @@ review. Nothing is written, so this is safe to run on every commit. Adding
 `--aggressive` redacts those values instead of retaining them, which makes the
 gate pass.
 
-## 3. Preview before you share
+## 4. Preview before you share
 
 ```bash
 pfsense-redactor config.xml --dry-run-verbose
@@ -54,7 +122,7 @@ Shows counts plus masked before/after examples, so you can confirm the right
 things are being caught without writing a file. Samples are masked, so the
 preview never prints a live secret to your terminal or CI log.
 
-## 4. Get a second opinion
+## 5. Get a second opinion
 
 An independent secret scanner such as [gitleaks](https://github.com/gitleaks/gitleaks)
 is worth running over the output, because it fails in the opposite direction to
@@ -115,7 +183,7 @@ A scanner that finds nothing may mean the file is clean, or that the secrets do
 not look like secrets. Use it to catch what this tool missed, never to certify
 that nothing was missed.
 
-## 5. Diff the two files
+## 6. Diff the two files
 
 For a config small enough to read, nothing beats looking:
 

--- a/docs/verifying-output.md
+++ b/docs/verifying-output.md
@@ -33,7 +33,7 @@ it, and re-run with `--aggressive` if any path looks like it holds a secret.
 
 ## 2. Read the independent verification
 
-Since 1.4.0 a second component re-reads the **serialised output** — the exact
+Since 1.2.2 a second component re-reads the **serialised output** — the exact
 text that gets written — and reports material that should not be in it:
 
 ```
@@ -80,7 +80,7 @@ list of structural element names (`refid`, `uuid`, `interface`, package
 metadata) are excluded, each by a rule asserted individually in
 `tests/unit/test_output_verification.py`.
 
-### Advisory in 1.4.0
+### Advisory in 1.2.2
 
 The result is reported; it does not yet decide whether output is written. Do
 not read "no findings" as "safe to publish" — read it as "a second pass found

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -3252,7 +3252,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         clean" from "not verified", because conflating them is the fail-open
         behaviour this whole module exists to remove.
 
-        Advisory in 1.4.0: the result is reported and does not decide whether
+        Advisory in 1.2.2: the result is reported and does not decide whether
         output is written. Enforcement arrives with the verify-before-write
         change.
         """

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -12,11 +12,24 @@ context and nothing else beside it:
 
 For a tool whose job is to be trusted with secrets, "read this one file, then
 run it" is worth more than a tidier module tree. Any relative or sibling import
-would end that, so there are none; the only package-relative import is the
-optional __version__ lookup in resolve_version(), which falls back cleanly.
+would end that, so there are none that are required; the two optional ones -
+the __version__ lookup in resolve_version() and the verifier in
+_load_verifier() - both fall back cleanly.
 
 Guarded by tests/integration/test_standalone_script.py, and by the C0302
 disable in .pylintrc.
+
+The independent verifier
+------------------------
+verifier.py is a separate module on purpose. It re-reads the serialised output
+looking for material that should not be in it, using rules written and
+maintained apart from the ones here - a verifier that shares the transformer's
+assumptions cannot catch the transformer's mistakes.
+
+That makes it the one thing this file will not inline. Copied out alone,
+redactor.py still redacts, but it reports verification as **unavailable**
+rather than pretending it passed. Copy verifier.py alongside it to keep the
+assurance the package build gives you.
 
 Layout
 ------
@@ -25,10 +38,11 @@ Sections below are marked with banner comments, in this order:
     1. Logging          ColouredFormatter, setup_logging
     2. Constants        element sets, secret/cert tag patterns, deny-list
     3. Version          resolve_version
-    4. Redactor         PfSenseRedactor - the bulk of the file
-    5. Allowlists       allow-list file parsing
-    6. Path safety      path traversal / sensitive directory validation
-    7. CLI              argparse wiring and main()
+    4. Verification     _load_verifier and the candidate-verification API
+    5. Redactor         PfSenseRedactor - the bulk of the file
+    6. Allowlists       allow-list file parsing
+    7. Path safety      path traversal / sensitive directory validation
+    8. CLI              argparse wiring and main()
 """
 from __future__ import annotations
 
@@ -1039,7 +1053,57 @@ def _prolog_refusal_reason(input_file: str) -> str | None:
 
 
 # ==========================================================================
-# 4. REDACTOR
+# 4. VERIFICATION
+# ==========================================================================
+def _import_verifier_module(spelling: str):
+    """Try one import spelling for the verifier, returning None if it is absent"""
+    try:
+        if spelling == 'package':
+            from . import verifier  # pylint: disable=import-outside-toplevel,cyclic-import
+            return verifier
+        import verifier  # pylint: disable=import-outside-toplevel
+        return verifier
+    except ImportError:
+        return None
+
+
+def _load_verifier():
+    """Import the independent verifier, tolerating the single-file deployment
+
+    redactor.py must stay runnable as a lone file - see the module docstring -
+    so this cannot be a hard import. Two spellings are tried: the
+    package-relative one for a normal installation, and the plain one for a
+    redactor.py sitting beside a verifier.py.
+
+    The result is checked for the entry point rather than merely for being
+    importable, so an unrelated module called 'verifier' earlier on sys.path
+    cannot be mistaken for this one.
+
+    Returning None does NOT mean verification passed. It means verification is
+    unavailable, and every caller must treat it that way - see
+    PfSenseRedactor.verify_candidate_output.
+    """
+    for spelling in ('package', 'plain'):
+        module = _import_verifier_module(spelling)
+        if module is not None and hasattr(module, 'verify_candidate'):
+            return module
+    return None
+
+
+VERIFIER = _load_verifier()
+
+
+def verification_is_available() -> bool:
+    """Whether the independent verifier could be imported
+
+    False only in the single-file deployment, where redactor.py was copied out
+    without verifier.py beside it.
+    """
+    return VERIFIER is not None
+
+
+# ==========================================================================
+# 5. REDACTOR
 # ==========================================================================
 class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     """pfSense configuration redactor for sensitive data handling
@@ -1131,6 +1195,13 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # which is how most of the unit tests drive it.
         self.redact_ips: bool = True
         self.redact_domains: bool = True
+
+        # Independent verification. _input_values is the pre-redaction snapshot
+        # the retention comparison needs; last_verification is the result of the
+        # most recent redact_config, or None when the verifier was unavailable
+        # or has not run. None is never a pass - see verify_candidate_output.
+        self._input_values: list = []
+        self.last_verification = None
 
         # Every <refid> defined in the config being processed, so a short value
         # in a certificate-named element can be resolved rather than guessed at.
@@ -3134,6 +3205,89 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return tree
 
+    @staticmethod
+    def serialise_tree(tree: ET.ElementTree) -> str:
+        """Serialise a tree to exactly the text _write_output would produce
+
+        Byte-for-byte identity with the written file is the point: verifying
+        anything else - the tree, the statistics, a summary - verifies
+        something other than what the operator ends up sharing. Pinned by
+        tests/unit/test_output_verification.py.
+        """
+        return ET.tostring(
+            tree.getroot(), encoding='utf-8', xml_declaration=True
+        ).decode('utf-8')
+
+    def _allowlisted_literals(self) -> frozenset[str]:
+        """Values the operator explicitly asked to keep, lower-cased
+
+        Passed to the verifier so that an allow-listed domain or address
+        surviving verbatim is not reported as a retained value. Nothing else is
+        excluded on the operator's say-so.
+        """
+        literals = {str(addr).lower() for addr in self.allowlist_ip_addrs}
+        literals.update(domain.lower() for domain in self.allowlist_domains)
+        literals.update(domain.lower() for domain in self.allowlist_domains_idna)
+        return frozenset(literals)
+
+    def _snapshot_input_values(self, root: ET.Element) -> None:
+        """Record the input's leaf and attribute values before redaction
+
+        Redaction rewrites the tree in place, so the retention comparison has
+        to take its copy first. Values only - not the tree - because the list is
+        bounded and a second copy of the document is not.
+        """
+        if VERIFIER is None:
+            self._input_values = []
+            return
+        self._input_values = VERIFIER.collect_input_values(
+            root, self._allowlisted_literals()
+        )
+
+    def verify_candidate_output(self, candidate: str):
+        """Independently verify serialised candidate output
+
+        Returns a VerificationResult, or None when verifier.py could not be
+        imported. **None is not a pass.** Callers must distinguish "verified
+        clean" from "not verified", because conflating them is the fail-open
+        behaviour this whole module exists to remove.
+
+        Advisory in 1.4.0: the result is reported and does not decide whether
+        output is written. Enforcement arrives with the verify-before-write
+        change.
+        """
+        if VERIFIER is None:
+            return None
+
+        findings = list(VERIFIER.scan_shapes(candidate).findings)
+        findings.extend(VERIFIER.scan_retention(self._input_values, candidate).findings)
+        return VERIFIER.build_result(findings)
+
+    def _report_verification(self, result) -> None:
+        """Report an advisory verification result on stderr
+
+        describe() builds its lines from finding metadata only, so this cannot
+        print a secret by printing a finding.
+        """
+        if result is None:
+            self.logger.warning(
+                "[!] Independent verification unavailable: verifier.py is not "
+                "importable. Redaction ran, but nothing re-read the output."
+            )
+            return
+
+        if result.clean:
+            self.logger.info("[+] Independent verification: no findings")
+            return
+
+        self.logger.warning("")
+        self.logger.warning(
+            "[!] Independent verification found %d issue(s) in the output:",
+            result.count
+        )
+        for line in VERIFIER.describe(result):
+            self.logger.warning("    - %s", line)
+
     def _write_output(
         self, tree: ET.ElementTree, input_file: str, output_file: str | None,
         stdout_mode: bool, inplace: bool
@@ -3184,6 +3338,10 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # against what the config actually defines
             self.known_refids = self._collect_refids(root)
 
+            # Also before the traversal: the retention comparison needs the
+            # input's values, and redaction overwrites them in place.
+            self._snapshot_input_values(root)
+
             self.redact_element(root)
 
             # Dry run mode: just print stats
@@ -3198,10 +3356,18 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             # Pretty print (Python 3.9+)
             ET.indent(tree, space="  ")
 
+            # Advisory in this release: reported, not enforced. The candidate
+            # is serialised once and both verified and written from the same
+            # text, so what is checked is what is shared.
+            self.last_verification = self.verify_candidate_output(
+                self.serialise_tree(tree)
+            )
+
             self._write_output(tree, input_file, output_file, stdout_mode, inplace)
 
             # Print summary (always print, logger routes to correct stream)
             self._print_stats()
+            self._report_verification(self.last_verification)
 
             return self._retained_values_are_acceptable()
 
@@ -3302,7 +3468,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
 
 # ==========================================================================
-# 5. ALLOWLISTS
+# 6. ALLOWLISTS
 # ==========================================================================
 def parse_allowlist_file(filepath: str, silent_if_missing: bool = False) -> tuple[set[str], list[IPNetwork], set[str]]:
     """Parse allow-list file containing IPs, CIDR networks, and domains (one per line)
@@ -3403,7 +3569,7 @@ def find_default_allowlist_files() -> list[Path]:
     return default_files
 
 # ==========================================================================
-# 6. PATH SAFETY
+# 7. PATH SAFETY
 # ==========================================================================
 def _windows_dirs_from_environment() -> set[str]:
     """Locate the real Windows system directories from the environment
@@ -3686,7 +3852,7 @@ def _resolved_path_error(
 
 
 # ==========================================================================
-# 7. CLI
+# 8. CLI
 # ==========================================================================
 def _build_arg_parser(version: str) -> argparse.ArgumentParser:
     """Construct the CLI parser

--- a/pfsense_redactor/verifier.py
+++ b/pfsense_redactor/verifier.py
@@ -41,10 +41,22 @@ import base64
 import binascii
 import math
 import re
-import xml.etree.ElementTree as ET
 from collections import Counter
 from dataclasses import dataclass
-from typing import Iterable, Iterator
+from typing import TYPE_CHECKING, Iterable, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    # Annotation-only, and it must stay that way. This module never parses
+    # XML: it receives an already-parsed tree from redactor.py and walks it,
+    # so there is no ET.parse or ET.fromstring here and no input for an
+    # entity-expansion or external-entity attack to arrive through.
+    #
+    # `from __future__ import annotations` above makes every annotation a
+    # string, so nothing needs this at runtime. Importing it anyway would add
+    # a module that static scanners flag on sight - correctly in general, and
+    # not here - for no benefit. tests/unit/test_output_verification.py
+    # asserts the runtime namespace does not carry it.
+    import xml.etree.ElementTree as ET
 
 # ==========================================================================
 # Bounds
@@ -242,7 +254,11 @@ def _decode_run(run: str) -> str | None:
 def _decode_layer(text: str, budget: int) -> tuple[list[str], int]:
     """Decode every encoded run in one layer, spending a shared budget"""
     produced: list[str] = []
-    for run in _ENCODED_RUN_RE.findall(text):
+    # finditer, not findall: the loop normally stops on the operation budget,
+    # so building the whole list first is work discarded on exactly the large
+    # inputs that make it costly.
+    for match in _ENCODED_RUN_RE.finditer(text):
+        run = match.group(0)
         if budget <= 0:
             break
         budget -= 1
@@ -365,11 +381,18 @@ def scan_shapes(candidate: str) -> VerificationResult:
 # ==========================================================================
 @dataclass(frozen=True)
 class TrackedValue:
-    """One input value worth checking for verbatim survival"""
+    """One input value worth checking for verbatim survival
+
+    `collapsed` is the whitespace-free form used for the comparison. Computed
+    once here rather than per call in scan_retention: values are snapshotted
+    before redaction and never change, and a large document has tens of
+    thousands of them.
+    """
 
     path: str
     value: str
     kind: str
+    collapsed: str
 
 
 def _element_path(stack: list[str], tag: str) -> str:
@@ -465,7 +488,9 @@ def _track_element_value(
         return
     if _is_excluded(tag, value, allowlisted):
         return
-    tracked.setdefault(value, TrackedValue(_element_path(stack, tag), value, 'element'))
+    tracked.setdefault(
+        value, TrackedValue(_element_path(stack, tag), value, 'element', _collapse(value))
+    )
 
 
 def _track_attribute_values(
@@ -480,7 +505,7 @@ def _track_attribute_values(
         if _is_excluded(name.lower(), value, allowlisted):
             continue
         path = f'{_element_path(stack, tag)}[@{name.lower()}]'
-        tracked.setdefault(value, TrackedValue(path, value, 'attribute'))
+        tracked.setdefault(value, TrackedValue(path, value, 'attribute', _collapse(value)))
 
 
 def scan_retention(
@@ -505,7 +530,7 @@ def scan_retention(
             reason='input value present verbatim in candidate output',
         )
         for item in tracked
-        if _collapse(item.value) in haystack
+        if item.collapsed in haystack
     ]
     return _result(findings)
 

--- a/pfsense_redactor/verifier.py
+++ b/pfsense_redactor/verifier.py
@@ -43,20 +43,35 @@ import math
 import re
 from collections import Counter
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Iterator
+from typing import Iterable, Iterator, Protocol
 
-if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
-    # Annotation-only, and it must stay that way. This module never parses
-    # XML: it receives an already-parsed tree from redactor.py and walks it,
-    # so there is no ET.parse or ET.fromstring here and no input for an
-    # entity-expansion or external-entity attack to arrive through.
-    #
-    # `from __future__ import annotations` above makes every annotation a
-    # string, so nothing needs this at runtime. Importing it anyway would add
-    # a module that static scanners flag on sight - correctly in general, and
-    # not here - for no benefit. tests/unit/test_output_verification.py
-    # asserts the runtime namespace does not carry it.
-    import xml.etree.ElementTree as ET
+
+class XmlElement(Protocol):
+    """The part of an XML element this module actually uses
+
+    Four things: a tag, text, attributes and children. Declared structurally
+    rather than as xml.etree.ElementTree.Element, for two reasons.
+
+    The honest one: this module never parses XML. It is handed an
+    already-parsed tree by redactor.py and walks it, so it has no business
+    depending on the parser that produced it - a verifier whose value is that
+    it does not share the transformer's assumptions should not share its
+    imports either. redactor.py passes an ElementTree Element, which satisfies
+    this; so would anything shaped the same way.
+
+    The practical one: it removes the last mention of an XML library from a
+    module that does no XML work. Import-matching scanners flag
+    `xml.etree.ElementTree` on sight - correctly in general, and not here - and
+    an annotation is a poor reason to carry a finding that has to be explained
+    every time someone reads the report.
+    """
+
+    tag: str
+    text: str | None
+    attrib: dict[str, str]
+
+    def __iter__(self) -> Iterator['XmlElement']:
+        ...  # pragma: no cover - structural declaration, never called
 
 # ==========================================================================
 # Bounds
@@ -436,7 +451,7 @@ def _is_excluded(tag: str, value: str, allowlisted: frozenset[str]) -> bool:
 
 
 def collect_input_values(
-    root: ET.Element,
+    root: XmlElement,
     allowlisted: frozenset[str] = frozenset(),
     min_length: int = MIN_RETENTION_LENGTH,
 ) -> list[TrackedValue]:
@@ -452,7 +467,7 @@ def collect_input_values(
 
 
 def _walk_for_values(
-    element: ET.Element,
+    element: XmlElement,
     stack: list[str],
     tracked: dict[str, TrackedValue],
     allowlisted: frozenset[str],
@@ -479,7 +494,7 @@ def _walk_for_values(
 
 
 def _track_element_value(
-    element: ET.Element, stack: list[str], tag: str,
+    element: XmlElement, stack: list[str], tag: str,
     tracked: dict[str, TrackedValue], allowlisted: frozenset[str], min_length: int,
 ) -> None:
     """Record this element's own text if it is worth checking"""
@@ -494,7 +509,7 @@ def _track_element_value(
 
 
 def _track_attribute_values(
-    element: ET.Element, stack: list[str], tag: str,
+    element: XmlElement, stack: list[str], tag: str,
     tracked: dict[str, TrackedValue], allowlisted: frozenset[str], min_length: int,
 ) -> None:
     """Record this element's attribute values if they are worth checking"""
@@ -545,7 +560,7 @@ def _collapse(text: str) -> str:
 # ==========================================================================
 def verify_candidate(
     candidate: str,
-    input_root: ET.Element | None = None,
+    input_root: XmlElement | None = None,
     allowlisted: frozenset[str] = frozenset(),
 ) -> VerificationResult:
     """Verify one serialised candidate document

--- a/pfsense_redactor/verifier.py
+++ b/pfsense_redactor/verifier.py
@@ -1,0 +1,557 @@
+"""Independent verification of redacted output
+
+The redactor is a single transformation pass. Everything it does rests on one
+set of judgements - is this element name a secret, is this value shaped like
+one - and until this module existed, the only "verification" was the
+transformer reporting what it had chosen to keep. A class of secret the
+transformer cannot see was equally invisible to the check, which is the
+correlated-failure problem in its strongest form: not a verifier that shares the
+transformer's patterns, but no verifier at all.
+
+This module re-reads the **serialised candidate output** and looks for material
+that should not be in it. Two strategies, deliberately different in kind:
+
+**A. Shape scan.** Patterns defined here, not imported from the transformer.
+They overlap in intent - both look for PEM headers - but they are written and
+maintained separately, so a mistake in one is not automatically a mistake in
+the other. This catches what the transformer's rules do not cover.
+
+**B. Input-value retention.** Every leaf and attribute value in the *input*
+above a minimum length is checked for verbatim survival in the output. This is
+the one check that cannot inherit the transformer's blind spots, because it does
+not classify anything: it does not need to know what a value means to notice
+that it came out unchanged.
+
+Findings carry a path, a category, a length and a reason. They never carry the
+value, a prefix of it, or a hash of it - a short secret's hash is
+brute-forceable, and a prefix is often the whole of what identifies a token's
+issuer. A finding exists to tell an operator where to look, not to reproduce
+what was found.
+
+Kept in its own module so that it can be read, reviewed and changed
+independently of the 3,500 lines it is checking. redactor.py imports it
+tolerantly (see _load_verifier there): when the module is absent - the
+single-file deployment the project supports - verification is reported as
+unavailable rather than silently skipped, and the modes that depend on it
+refuse to run.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import math
+import re
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+# ==========================================================================
+# Bounds
+# ==========================================================================
+# The verifier runs over output the transformer has already produced, so it is
+# not the first thing to see hostile input - but it is the last, and a verifier
+# that can be made to hang is a verifier that can be removed from the pipeline.
+MAX_DECODE_DEPTH: int = 3
+MAX_DECODED_BYTES: int = 65536
+MAX_DECODE_OPERATIONS: int = 64
+MIN_ENCODED_RUN_CHARS: int = 24
+MAX_ENCODED_RUN_CHARS: int = (MAX_DECODED_BYTES * 4) // 3 + 4
+
+# Values shorter than this are not compared for verbatim retention. Below 16
+# characters the comparison stops distinguishing a surviving secret from a
+# coincidence: 'admin', 'lan', 'yes' and '1194' all appear in both input and
+# output of a correctly redacted file, and reporting them buries the finding
+# that matters.
+MIN_RETENTION_LENGTH: int = 16
+
+# Ceiling on the number of distinct input values tracked, so a pathological
+# document cannot make the verifier the memory problem.
+MAX_TRACKED_VALUES: int = 20000
+
+# Ceiling on findings returned. A run that produces this many has a systemic
+# problem, and the operator needs the first few, not all of them.
+MAX_FINDINGS: int = 200
+
+# ==========================================================================
+# Shape patterns - defined here, not imported from the transformer
+# ==========================================================================
+VERIFIER_PRIVATE_KEY_RE = re.compile(
+    r'-----BEGIN[ \t]+(?:[A-Za-z0-9]+[ \t]+){0,4}PRIVATE[ \t]+KEY(?:[ \t]+BLOCK)?[ \t]*-----'
+    r'|-----BEGIN[ \t]+OPENVPN[ \t]+STATIC[ \t]+KEY(?:[ \t]+V\d)?[ \t]*-----',
+    re.IGNORECASE
+)
+
+VERIFIER_JWT_RE = re.compile(
+    r'eyJ[A-Za-z0-9_-]{5,8192}\.[A-Za-z0-9_-]{4,8192}\.[A-Za-z0-9_-]{0,8192}'
+)
+
+# A credential inside a URL. Matched on the userinfo separator rather than on
+# any scheme list, so a scheme the transformer does not know about is still
+# caught. The password component is captured so that a URL whose password has
+# already been replaced is not reported as still carrying one - reporting the
+# redaction as the leak is the one way a verifier can be worse than useless.
+VERIFIER_URL_CREDENTIAL_RE = re.compile(
+    r'[A-Za-z][A-Za-z0-9+.\-]{1,32}://[^\s/@:]{1,256}:(?P<secret>[^\s/@]{1,256})@'
+)
+
+# Long opaque runs. Deliberately looser than the transformer's rule: the
+# verifier's job is to raise a question, not to decide the answer.
+VERIFIER_HEX_RE = re.compile(r'(?<![0-9A-Fa-f])[0-9A-Fa-f]{40,}(?![0-9A-Fa-f])')
+VERIFIER_BASE64_RE = re.compile(r'(?<![A-Za-z0-9+/=_-])[A-Za-z0-9+/=_-]{48,}(?![A-Za-z0-9+/=_-])')
+
+_ENCODED_RUN_RE = re.compile(r'[A-Za-z0-9+/=_-]{%d,}' % MIN_ENCODED_RUN_CHARS)
+_URLSAFE_TO_STANDARD = str.maketrans('-_', '+/')
+
+_UUID_RE = re.compile(
+    r'\A[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
+    r'[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\Z'
+)
+
+# Entropy floor for the opaque-run scan. Higher than the transformer's, because
+# a finding here costs an operator an investigation and the shape rule is
+# looser to begin with.
+MIN_RUN_ENTROPY_BITS: float = 3.0
+
+# Placeholders this project writes. A finding naming one of these would be the
+# verifier reporting the redaction as the leak.
+PLACEHOLDER_VALUES: frozenset[str] = frozenset({
+    '[REDACTED]', '[REDACTED_CERT_OR_KEY]', '[REDACTED_OVERSIZED]',
+    'XX:XX:XX:XX:XX:XX', 'XXXX.XXXX.XXXX', 'XXX.XXX.XXX.XXX',
+})
+
+# Inside URL userinfo the placeholder is written without brackets, because
+# square brackets are not safe there. Kept as its own set rather than folded
+# into the one above, so 'REDACTED' is only ever accepted as a placeholder in
+# the position where the tool actually writes it.
+URL_USERINFO_PLACEHOLDERS: frozenset[str] = frozenset({
+    'REDACTED', '[REDACTED]',
+})
+
+# The alphabet a credential actually arrives in.
+#
+# Base64, Base64URL, hex, pre-shared keys and API keys are all subsets of this
+# set. A value containing anything else - a dot, a colon, a comma, a question
+# mark, an at-sign - is a path, a URL, a hostname, an email or a delimited list.
+#
+# This is the retention comparison's one concession to form, and it is what
+# makes the check usable rather than a wall of noise: without it, every
+# firewall-rule description, cron command and package metadata field in a real
+# config is reported, and a report nobody can read is a report nobody reads.
+#
+# It is a stated limitation, not a claim of completeness. A secret carrying a
+# dot is invisible to *this* check - and is covered instead by the shape scan,
+# which looks for JWTs and credential-bearing URLs specifically.
+CREDENTIAL_ALPHABET_RE = re.compile(r'\A[A-Za-z0-9+/=_-]+\Z')
+
+# Structural values that legitimately appear unchanged in the output and are
+# not secrets. Narrow and testable by design: every entry is a fact about
+# pfSense's schema rather than a guess about content.
+#
+# Element names whose values are structural identifiers or enumerations. A
+# refid is the reference the 1.2.0 work exists to preserve; a UUID is an object
+# identifier; an interface name is how the config is read at all.
+STRUCTURAL_ELEMENTS: frozenset[str] = frozenset({
+    'refid', 'uuid', 'if', 'interface', 'interfaces', 'type', 'protocol',
+    'proto', 'version', 'descr_type', 'mode', 'state', 'status',
+    'cipher', 'digest', 'hash-algorithm', 'dhgroup', 'ealgo', 'halgo',
+    'encryption-algorithm-option', 'hash-algorithm-option',
+    'crypto', 'keylen', 'certref', 'caref', 'sslcertref',
+    # Package metadata: what a package is called, which file configures it and
+    # which function builds its rules. All of it is public knowledge about the
+    # package rather than anything about this firewall.
+    'priv', 'internal_name', 'configurationfile', 'filter_rule_function',
+    'include_file', 'pkginfolink', 'sequence', 'associated-rule-id',
+    'pkg_repo_conf_path', 'pkg_repo_conf_branch',
+})
+
+
+# ==========================================================================
+# Result types
+# ==========================================================================
+@dataclass(frozen=True)
+class VerificationFinding:
+    """One reason the candidate output should not be distributed
+
+    Metadata only. `path` locates the value, `kind` says what it looked like,
+    `length` says how much of it there was, and `reason` says which check
+    raised it. The value itself is deliberately absent: this object is written
+    to JSON reports and printed to logs, both of which are shared.
+    """
+
+    finding_id: str
+    path: str
+    kind: str
+    length: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """The verdict on one candidate document
+
+    `clean` is the only thing a caller should gate on. An empty `findings`
+    tuple and `clean` being True are the same statement, kept as two fields so
+    that a caller reading `result.clean` cannot get the polarity wrong.
+    """
+
+    clean: bool
+    findings: tuple[VerificationFinding, ...]
+
+    @property
+    def count(self) -> int:
+        """How many findings there are"""
+        return len(self.findings)
+
+
+def build_result(findings: Iterable[VerificationFinding]) -> VerificationResult:
+    """Build a result, bounded and with a deterministic order
+
+    Deduplicated on the whole finding, so the same retained value reached by
+    two checks is reported once. Ordered so that two runs over the same
+    document produce the same report, which is what makes a report diffable.
+    """
+    ordered = sorted(set(findings), key=lambda f: (f.finding_id, f.path, f.length))
+    return VerificationResult(clean=not ordered, findings=tuple(ordered[:MAX_FINDINGS]))
+
+
+# Retained for readability at the call sites inside this module.
+_result = build_result
+
+
+# ==========================================================================
+# Bounded decoding - the verifier's own, not the transformer's
+# ==========================================================================
+def _decode_run(run: str) -> str | None:
+    """Decode one Base64 or Base64URL run, or None"""
+    if len(run) > MAX_ENCODED_RUN_CHARS:
+        return None
+
+    body = run.rstrip('=')
+    padded = body + '=' * (-len(body) % 4)
+    for candidate in (padded, padded.translate(_URLSAFE_TO_STANDARD)):
+        try:
+            decoded = base64.b64decode(candidate, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        if decoded and len(decoded) <= MAX_DECODED_BYTES:
+            return decoded.decode('utf-8', errors='replace')
+    return None
+
+
+def _decode_layer(text: str, budget: int) -> tuple[list[str], int]:
+    """Decode every encoded run in one layer, spending a shared budget"""
+    produced: list[str] = []
+    for run in _ENCODED_RUN_RE.findall(text):
+        if budget <= 0:
+            break
+        budget -= 1
+        decoded = _decode_run(run)
+        if decoded is not None:
+            produced.append(decoded)
+    return produced, budget
+
+
+def decoded_layers(text: str) -> list[str]:
+    """Bounded successive decodings of `text`, excluding `text` itself
+
+    Never returns, logs or stores the decoded content anywhere a caller could
+    accidentally publish it: callers scan it and discard it.
+    """
+    layers: list[str] = []
+    frontier = [text]
+    seen = {text}
+    budget = MAX_DECODE_OPERATIONS
+
+    for _ in range(MAX_DECODE_DEPTH):
+        produced: list[str] = []
+        for layer in frontier:
+            decoded, budget = _decode_layer(layer, budget)
+            produced.extend(item for item in decoded if item not in seen)
+            seen.update(decoded)
+
+        layers.extend(produced)
+        frontier = produced
+        if not frontier or budget <= 0:
+            break
+
+    return layers
+
+
+def _entropy_bits(value: str) -> float:
+    """Shannon entropy of `value` in bits per character"""
+    if not value:
+        return 0.0
+    total = len(value)
+    return -sum(
+        (n / total) * math.log2(n / total) for n in Counter(value).values()
+    )
+
+
+# ==========================================================================
+# Strategy A: shape scan over the serialised candidate
+# ==========================================================================
+def _shape_findings_in(text: str, where: str, depth: int) -> Iterator[VerificationFinding]:
+    """Unambiguous credential structures in one layer of text"""
+    suffix = '' if depth == 0 else f' (decoded, depth {depth})'
+
+    for match in VERIFIER_PRIVATE_KEY_RE.finditer(text):
+        yield VerificationFinding(
+            finding_id='retained-private-key', path=where, kind='pem-private-key',
+            length=len(match.group(0)),
+            reason=f'private-key PEM header in candidate output{suffix}',
+        )
+
+    for match in VERIFIER_JWT_RE.finditer(text):
+        yield VerificationFinding(
+            finding_id='retained-jwt', path=where, kind='jwt',
+            length=len(match.group(0)),
+            reason=f'compact JWT in candidate output{suffix}',
+        )
+
+    for match in VERIFIER_URL_CREDENTIAL_RE.finditer(text):
+        if match.group('secret') in URL_USERINFO_PLACEHOLDERS:
+            continue
+        yield VerificationFinding(
+            finding_id='retained-url-credential', path=where, kind='url-userinfo',
+            length=len(match.group(0)),
+            reason=f'credential in URL userinfo in candidate output{suffix}',
+        )
+
+
+def _opaque_run_findings(text: str, where: str) -> Iterator[VerificationFinding]:
+    """Long hexadecimal and Base64 runs that nothing accounted for"""
+    for pattern, kind in ((VERIFIER_HEX_RE, 'hex-run'), (VERIFIER_BASE64_RE, 'base64-run')):
+        for match in pattern.finditer(text):
+            run = match.group(0)
+            if _is_accounted_for(run):
+                continue
+            yield VerificationFinding(
+                finding_id='retained-opaque-run', path=where, kind=kind,
+                length=len(run),
+                reason='long opaque run in candidate output',
+            )
+
+
+def _is_accounted_for(run: str) -> bool:
+    """Whether a long run is something other than an unexplained secret"""
+    if run in PLACEHOLDER_VALUES:
+        return True
+    if _UUID_RE.match(run):
+        return True
+    return _entropy_bits(run) < MIN_RUN_ENTROPY_BITS
+
+
+def scan_shapes(candidate: str) -> VerificationResult:
+    """Strategy A: what the serialised output looks like, on its own terms
+
+    Runs over the whole document rather than element by element, so material
+    split across an element boundary or hidden in a comment is still seen. The
+    path reported is the document, because at this level there is no smaller
+    one to give without re-parsing - and re-parsing would inherit the reader
+    the transformer used.
+    """
+    findings = list(_shape_findings_in(candidate, 'document', depth=0))
+    findings.extend(_opaque_run_findings(candidate, 'document'))
+
+    for depth, layer in enumerate(decoded_layers(candidate), start=1):
+        findings.extend(_shape_findings_in(layer, 'document', depth=depth))
+
+    return _result(findings)
+
+
+# ==========================================================================
+# Strategy B: verbatim retention of input values
+# ==========================================================================
+@dataclass(frozen=True)
+class TrackedValue:
+    """One input value worth checking for verbatim survival"""
+
+    path: str
+    value: str
+    kind: str
+
+
+def _element_path(stack: list[str], tag: str) -> str:
+    """Slash-joined path for an element, matching the transformer's format"""
+    return '/'.join([*stack, tag])
+
+
+def _normalise_tag(tag: str) -> str:
+    """Strip any namespace and lower-case, as the transformer does"""
+    return tag.rsplit('}', 1)[-1].lower()
+
+
+def _is_excluded(tag: str, value: str, allowlisted: frozenset[str]) -> bool:
+    """Whether an input value is expected to survive unchanged
+
+    Every exclusion is narrow and stated as a fact about the schema, about the
+    shape of the value, or about what the operator asked for - never as a guess
+    about what the value means:
+
+    - the tool's own placeholders, so redaction is not reported as a leak
+    - explicit allow-list entries, which the operator asked to keep
+    - structural elements whose values are references, identifiers or
+      enumerations: the things a reader needs in order to follow the config
+    - absolute filesystem paths, which pfSense stores in quantity and which the
+      transformer deliberately preserves - a corrupted path helps nobody
+    - anything outside CREDENTIAL_ALPHABET_RE; see that constant for why, and
+      for what it therefore does not see
+
+    Each of these is asserted individually in
+    tests/unit/test_output_verification.py, so the set cannot quietly widen.
+    """
+    if value in PLACEHOLDER_VALUES:
+        return True
+    if value.lower() in allowlisted:
+        return True
+    if tag in STRUCTURAL_ELEMENTS:
+        return True
+    if value.startswith('/'):
+        return True
+    return not CREDENTIAL_ALPHABET_RE.match(value)
+
+
+def collect_input_values(
+    root: ET.Element,
+    allowlisted: frozenset[str] = frozenset(),
+    min_length: int = MIN_RETENTION_LENGTH,
+) -> list[TrackedValue]:
+    """Every input leaf and attribute value long enough to be worth checking
+
+    Bounded by MAX_TRACKED_VALUES. Deduplicated on the value, keeping the first
+    path it appeared at, so a value repeated across a hundred rules produces one
+    finding rather than a hundred identical ones.
+    """
+    tracked: dict[str, TrackedValue] = {}
+    _walk_for_values(root, [], tracked, allowlisted, min_length)
+    return list(tracked.values())
+
+
+def _walk_for_values(
+    element: ET.Element,
+    stack: list[str],
+    tracked: dict[str, TrackedValue],
+    allowlisted: frozenset[str],
+    min_length: int,
+) -> None:
+    """Recursive half of collect_input_values
+
+    Depth is bounded by the caller: redactor.py refuses documents deeper than
+    its own limit before this ever runs.
+    """
+    if len(tracked) >= MAX_TRACKED_VALUES:
+        return
+
+    tag = _normalise_tag(element.tag)
+    _track_element_value(element, stack, tag, tracked, allowlisted, min_length)
+    _track_attribute_values(element, stack, tag, tracked, allowlisted, min_length)
+
+    stack.append(tag)
+    try:
+        for child in element:
+            _walk_for_values(child, stack, tracked, allowlisted, min_length)
+    finally:
+        stack.pop()
+
+
+def _track_element_value(
+    element: ET.Element, stack: list[str], tag: str,
+    tracked: dict[str, TrackedValue], allowlisted: frozenset[str], min_length: int,
+) -> None:
+    """Record this element's own text if it is worth checking"""
+    value = (element.text or '').strip()
+    if len(value) < min_length:
+        return
+    if _is_excluded(tag, value, allowlisted):
+        return
+    tracked.setdefault(value, TrackedValue(_element_path(stack, tag), value, 'element'))
+
+
+def _track_attribute_values(
+    element: ET.Element, stack: list[str], tag: str,
+    tracked: dict[str, TrackedValue], allowlisted: frozenset[str], min_length: int,
+) -> None:
+    """Record this element's attribute values if they are worth checking"""
+    for name, raw in element.attrib.items():
+        value = raw.strip()
+        if len(value) < min_length:
+            continue
+        if _is_excluded(name.lower(), value, allowlisted):
+            continue
+        path = f'{_element_path(stack, tag)}[@{name.lower()}]'
+        tracked.setdefault(value, TrackedValue(path, value, 'attribute'))
+
+
+def scan_retention(
+    tracked: Iterable[TrackedValue], candidate: str
+) -> VerificationResult:
+    """Strategy B: which input values came out the other side unchanged
+
+    The check that cannot inherit the transformer's blind spots, because it
+    classifies nothing. It does not need to know what a value means in order to
+    notice that it survived.
+
+    Whitespace is collapsed before comparison so that a value the serialiser
+    re-wrapped is still recognised as the same value.
+    """
+    haystack = _collapse(candidate)
+    findings = [
+        VerificationFinding(
+            finding_id='retained-input-value',
+            path=item.path,
+            kind=item.kind,
+            length=len(item.value),
+            reason='input value present verbatim in candidate output',
+        )
+        for item in tracked
+        if _collapse(item.value) in haystack
+    ]
+    return _result(findings)
+
+
+def _collapse(text: str) -> str:
+    """Remove whitespace, so re-wrapping does not defeat a comparison"""
+    return ''.join(text.split())
+
+
+# ==========================================================================
+# Entry point
+# ==========================================================================
+def verify_candidate(
+    candidate: str,
+    input_root: ET.Element | None = None,
+    allowlisted: frozenset[str] = frozenset(),
+) -> VerificationResult:
+    """Verify one serialised candidate document
+
+    `candidate` is the exact text that would be written or emitted. Verifying
+    anything else - the tree, the transformer's statistics, a summary - would
+    verify something other than what the operator ends up sharing.
+
+    `input_root` enables the retention comparison. Without it only the shape
+    scan runs, which is weaker: pass the parsed input whenever it is available.
+    """
+    findings = list(scan_shapes(candidate).findings)
+
+    if input_root is not None:
+        tracked = collect_input_values(input_root, allowlisted)
+        findings.extend(scan_retention(tracked, candidate).findings)
+
+    return _result(findings)
+
+
+def describe(result: VerificationResult, limit: int = 10) -> list[str]:
+    """One human-readable line per finding, safe to print or log
+
+    Built from the finding's metadata only, so a caller cannot print a secret
+    by printing a finding.
+    """
+    lines = [
+        f'{finding.finding_id}: {finding.path} '
+        f'({finding.kind}, {finding.length} chars) - {finding.reason}'
+        for finding in result.findings[:limit]
+    ]
+    if result.count > limit:
+        lines.append(f'... and {result.count - limit} more')
+    return lines

--- a/pfsense_redactor/verifier.py
+++ b/pfsense_redactor/verifier.py
@@ -42,8 +42,9 @@ import binascii
 import math
 import re
 from collections import Counter
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Protocol
+from typing import Protocol
 
 
 class XmlElement(Protocol):
@@ -70,7 +71,7 @@ class XmlElement(Protocol):
     text: str | None
     attrib: dict[str, str]
 
-    def __iter__(self) -> Iterator['XmlElement']:
+    def __iter__(self) -> Iterator[XmlElement]:
         ...  # pragma: no cover - structural declaration, never called
 
 # ==========================================================================
@@ -127,7 +128,7 @@ VERIFIER_URL_CREDENTIAL_RE = re.compile(
 VERIFIER_HEX_RE = re.compile(r'(?<![0-9A-Fa-f])[0-9A-Fa-f]{40,}(?![0-9A-Fa-f])')
 VERIFIER_BASE64_RE = re.compile(r'(?<![A-Za-z0-9+/=_-])[A-Za-z0-9+/=_-]{48,}(?![A-Za-z0-9+/=_-])')
 
-_ENCODED_RUN_RE = re.compile(r'[A-Za-z0-9+/=_-]{%d,}' % MIN_ENCODED_RUN_CHARS)
+_ENCODED_RUN_RE = re.compile(rf'[A-Za-z0-9+/=_-]{{{MIN_ENCODED_RUN_CHARS},}}')
 _URLSAFE_TO_STANDARD = str.maketrans('-_', '+/')
 
 _UUID_RE = re.compile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.2.1"
+version = "1.2.2"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/adversarial/test_filesystem_safety.py
+++ b/tests/adversarial/test_filesystem_safety.py
@@ -95,6 +95,32 @@ class TestInputPreservation:
         ET.fromstring(canary_copy.read_text())
 
 
+def explode_on_path_write(monkeypatch):
+    """Make tree.write() fail the way a real interrupted write fails
+
+    Emulates a crash *after* the target has been opened for writing, which is
+    what ElementTree.write does before it can fail: the file is truncated, some
+    bytes land, and then the error arrives.
+
+    Writes to a *stream* are passed through to the real implementation. The
+    redactor serialises the candidate to a string before writing it, and
+    ET.tostring goes through this same method with a stream target - so a fake
+    that raised unconditionally would abort during serialisation and the test
+    would never reach the write it is named after.
+    """
+    real_write = ET.ElementTree.write
+
+    def explode(self, file_or_filename, *args, **kwargs):
+        if hasattr(file_or_filename, "write"):
+            return real_write(self, file_or_filename, *args, **kwargs)
+
+        with open(file_or_filename, "wb") as handle:
+            handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
+        raise OSError("simulated I/O failure mid-write")
+
+    monkeypatch.setattr(ET.ElementTree, "write", explode)
+
+
 class TestWriteSafety:
     """How the output is written, not where"""
 
@@ -122,16 +148,7 @@ class TestWriteSafety:
     def test_interrupted_inplace_write_preserves_the_original(self, canary_copy, monkeypatch):
         """A crash mid-write must not leave the operator with nothing"""
         before = canary_copy.read_bytes()
-
-        def explode(self, file_or_filename, **kwargs):  # pylint: disable=unused-argument
-            # Emulate a crash after the target has been opened for writing,
-            # which is what tree.write() does before it can fail.
-            if not hasattr(file_or_filename, "write"):
-                with open(file_or_filename, "wb") as handle:
-                    handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
-            raise OSError("simulated I/O failure mid-write")
-
-        monkeypatch.setattr(ET.ElementTree, "write", explode)
+        explode_on_path_write(monkeypatch)
 
         redactor = PfSenseRedactor()
         assert redactor.redact_config(str(canary_copy), str(canary_copy), inplace=True) is False
@@ -148,14 +165,7 @@ class TestWriteSafety:
     def test_interrupted_write_leaves_no_partial_output(self, canary_copy, tmp_path, monkeypatch):
         """A truncated file that looks like output is worse than none"""
         out = tmp_path / "out.xml"
-
-        def explode(self, file_or_filename, **kwargs):  # pylint: disable=unused-argument
-            if not hasattr(file_or_filename, "write"):
-                with open(file_or_filename, "wb") as handle:
-                    handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
-            raise OSError("simulated I/O failure mid-write")
-
-        monkeypatch.setattr(ET.ElementTree, "write", explode)
+        explode_on_path_write(monkeypatch)
 
         PfSenseRedactor().redact_config(str(canary_copy), str(out))
 

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.1 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.4.0 -->
+  <!-- Redacted using pfsense-redactor v1.2.2 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_output_verification.py
+++ b/tests/unit/test_output_verification.py
@@ -1,0 +1,466 @@
+"""The independent verifier, and proof that it is actually independent
+
+A verifier that only passes when the transformer is correct proves nothing. The
+tests that matter here are the defect-injection ones: the transformer is broken
+on purpose, one class of secret at a time, and the verifier has to notice
+without being told what changed.
+
+The rest pin the properties that make a finding safe to publish - metadata
+only, never a value, never a prefix, never a hash - and the bounds that keep
+the verifier from becoming the resource problem it exists to look for.
+
+Every value here is synthetic.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor import verifier
+from pfsense_redactor.redactor import PfSenseRedactor
+
+PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJDQU5BUllfSldUIn0"
+    ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+)
+
+CREDENTIAL_URL = "https://svcacct:CANARY_URLPASSWORD@feeds.vendor.invalid/list"
+
+
+def config(inner):
+    """A minimal but structurally realistic pfSense config"""
+    return f"<pfsense><version>23.1</version>{inner}</pfsense>"
+
+
+def rendered(result):
+    """Every character the verifier would print or serialise for `result`
+
+    Used to assert the negative: whatever a finding says, it must not be
+    possible to recover the secret from it.
+    """
+    return " ".join(verifier.describe(result)) + " " + repr(result)
+
+
+class TestFindingsCarryNoSecret:
+    """A finding is published. It must be safe to publish."""
+
+    def test_a_finding_names_a_path_a_kind_and_a_length(self):
+        """What an operator needs to go and look"""
+        result = verifier.scan_shapes(config(f"<blob>{PEM}</blob>"))
+
+        assert not result.clean
+        finding = next(f for f in result.findings
+                       if f.finding_id == 'retained-private-key')
+        assert finding.path == 'document'
+        assert finding.kind == 'pem-private-key'
+        assert finding.length > 0
+        assert finding.reason
+
+    def test_a_finding_carries_no_value(self):
+        """Not the value"""
+        result = verifier.scan_shapes(config(f"<blob>{PEM}</blob>"))
+        assert "CANARYPRIVATEKEY" not in rendered(result)
+
+    def test_a_finding_carries_no_prefix(self):
+        """Nor a prefix of it - a JWT header names the issuer"""
+        result = verifier.scan_shapes(config(f"<blob>{JWT}</blob>"))
+        text = rendered(result)
+
+        assert "eyJhbGci" not in text
+        assert "eyJ" not in text
+
+    def test_a_finding_carries_no_hash(self):
+        """Nor a hash - a short secret's hash is brute-forceable
+
+        Asserted by construction: the dataclass has no field that could hold
+        one, so this fails if a field is ever added.
+        """
+        import dataclasses  # pylint: disable=import-outside-toplevel
+
+        names = {f.name for f in dataclasses.fields(verifier.VerificationFinding)}
+        assert names == {'finding_id', 'path', 'kind', 'length', 'reason'}
+
+    @pytest.mark.parametrize("placeholder", ["REDACTED", "[REDACTED]"])
+    def test_an_already_redacted_url_password_is_not_a_finding(self, placeholder):
+        """Reporting the redaction as the leak is worse than useless
+
+        Both spellings, because square brackets are not safe inside URL
+        userinfo and the tool writes the bare form there.
+        """
+        assert verifier.scan_shapes(config(
+            f"<url>https://svcacct:{placeholder}@feeds.example/list</url>"
+        )).clean
+
+    def test_a_credential_url_finding_carries_no_url(self):
+        """A credential-bearing URL is a credential and a location at once"""
+        result = verifier.scan_shapes(config(f"<url>{CREDENTIAL_URL}</url>"))
+        text = rendered(result)
+
+        assert not result.clean
+        assert "CANARY_URLPASSWORD" not in text
+        assert "feeds.vendor.invalid" not in text
+
+
+class TestShapeScan:
+    """Strategy A: what the serialised output looks like on its own terms"""
+
+    def test_finds_a_private_key(self):
+        """The case that matters most"""
+        assert not verifier.scan_shapes(config(f"<x>{PEM}</x>")).clean
+
+    def test_finds_a_jwt(self):
+        """A token is a credential"""
+        assert not verifier.scan_shapes(config(f"<x>{JWT}</x>")).clean
+
+    def test_finds_a_credential_bearing_url(self):
+        """Matched on the userinfo separator, not on a list of schemes"""
+        assert not verifier.scan_shapes(config(f"<x>{CREDENTIAL_URL}</x>")).clean
+
+    def test_finds_a_credential_url_with_an_unknown_scheme(self):
+        """A scheme the transformer has never heard of is still a URL"""
+        result = verifier.scan_shapes(
+            config("<x>vendorproto://svc:CANARY_PW@host.invalid/p</x>")
+        )
+        assert not result.clean
+
+    def test_finds_a_base64_wrapped_private_key(self):
+        """An encoding is not a protection here either"""
+        import base64  # pylint: disable=import-outside-toplevel
+        wrapped = base64.b64encode(PEM.encode()).decode()
+        assert not verifier.scan_shapes(config(f"<x>{wrapped}</x>")).clean
+
+    def test_finds_a_double_base64_wrapped_private_key(self):
+        """Two layers, independently of the transformer's decoder"""
+        import base64  # pylint: disable=import-outside-toplevel
+        once = base64.b64encode(PEM.encode()).decode()
+        twice = base64.b64encode(once.encode()).decode()
+        assert not verifier.scan_shapes(config(f"<x>{twice}</x>")).clean
+
+    def test_a_clean_document_is_clean(self):
+        """The control. A verifier that always fires says nothing."""
+        result = verifier.scan_shapes(config(
+            "<system><hostname>fw</hostname>"
+            "<password>[REDACTED]</password></system>"
+        ))
+        assert result.clean
+
+    def test_placeholders_are_not_findings(self):
+        """Reporting the redaction as the leak would be worse than useless"""
+        assert verifier.scan_shapes(config(
+            "<a>[REDACTED]</a><b>[REDACTED_CERT_OR_KEY]</b>"
+            "<c>XX:XX:XX:XX:XX:XX</c><d>XXX.XXX.XXX.XXX</d>"
+        )).clean
+
+    def test_a_public_key_is_not_a_private_key(self):
+        """The boundary of the rule, pinned"""
+        assert verifier.scan_shapes(config(
+            "<x>-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----</x>"
+        )).clean
+
+    def test_low_entropy_runs_are_not_findings(self):
+        """An all-zero field satisfies the shape and carries nothing"""
+        assert verifier.scan_shapes(config("<x>" + "0" * 64 + "</x>")).clean
+
+    def test_a_uuid_is_not_a_finding(self):
+        """pfSense uses them as object identifiers"""
+        assert verifier.scan_shapes(
+            config("<x>550e8400-e29b-41d4-a716-446655440000</x>")
+        ).clean
+
+
+class TestRetentionScan:
+    """Strategy B: which input values came out the other side unchanged"""
+
+    def test_finds_a_value_that_survived(self):
+        """The check that classifies nothing"""
+        root = ET.fromstring(config("<pkg><blob>CANARYSURVIVINGVALUE123456</blob></pkg>"))
+        tracked = verifier.collect_input_values(root)
+        result = verifier.scan_retention(tracked, config(
+            "<pkg><blob>CANARYSURVIVINGVALUE123456</blob></pkg>"
+        ))
+
+        assert not result.clean
+        assert result.findings[0].path == 'pfsense/pkg/blob'
+
+    def test_reports_no_finding_when_the_value_was_replaced(self):
+        """The control"""
+        root = ET.fromstring(config("<pkg><blob>CANARYSURVIVINGVALUE123456</blob></pkg>"))
+        tracked = verifier.collect_input_values(root)
+
+        assert verifier.scan_retention(
+            tracked, config("<pkg><blob>[REDACTED]</blob></pkg>")
+        ).clean
+
+    def test_re_wrapping_does_not_defeat_the_comparison(self):
+        """A serialiser that re-wraps a long value has not redacted it"""
+        value = "CANARYWRAPPEDVALUE" + "A" * 40
+        root = ET.fromstring(config(f"<pkg><blob>{value}</blob></pkg>"))
+        tracked = verifier.collect_input_values(root)
+        wrapped = value[:20] + "\n  " + value[20:]
+
+        assert not verifier.scan_retention(
+            tracked, config(f"<pkg><blob>{wrapped}</blob></pkg>")
+        ).clean
+
+    def test_finds_a_surviving_attribute_value(self):
+        """Attributes are values too"""
+        xml = config('<pkg><ep token="CANARYATTRIBUTEVALUE9876"/></pkg>')
+        root = ET.fromstring(xml)
+        result = verifier.scan_retention(verifier.collect_input_values(root), xml)
+
+        assert not result.clean
+        assert result.findings[0].path == 'pfsense/pkg/ep[@token]'
+        assert result.findings[0].kind == 'attribute'
+
+    def test_short_values_are_not_compared(self):
+        """Below the floor, retention stops distinguishing a leak from a word"""
+        xml = config("<pkg><mode>aggressive</mode></pkg>")
+        root = ET.fromstring(xml)
+
+        assert verifier.scan_retention(verifier.collect_input_values(root), xml).clean
+
+    @pytest.mark.parametrize(
+        "inner,why",
+        [
+            ("<refid>CANARYREFIDVALUE1234</refid>", "structural element"),
+            ("<blob>[REDACTED_CERT_OR_KEY]</blob>", "our own placeholder"),
+            ("<cmd>/usr/local/bin/checkreload_long_name</cmd>", "absolute path"),
+            ("<descr>an ordinary rule description here</descr>", "contains whitespace"),
+            ("<url>https://doc.example/index.php/Setup_Package</url>", "outside the alphabet"),
+            ("<host>collector.internal.example.invalid</host>", "outside the alphabet"),
+        ],
+    )
+    def test_documented_exclusions(self, inner, why):
+        """Each exclusion asserted on its own, so the set cannot quietly widen"""
+        xml = config(f"<pkg>{inner}</pkg>")
+        root = ET.fromstring(xml)
+
+        assert verifier.scan_retention(
+            verifier.collect_input_values(root), xml
+        ).clean, why
+
+    def test_allowlisted_values_are_excluded(self):
+        """The operator asked to keep these"""
+        xml = config("<pkg><host>time.nist.gov.example</host></pkg>")
+        root = ET.fromstring(xml)
+        tracked = verifier.collect_input_values(
+            root, frozenset({'time.nist.gov.example'})
+        )
+
+        assert verifier.scan_retention(tracked, xml).clean
+
+    def test_duplicate_values_are_reported_once(self):
+        """A value repeated across a hundred rules is one problem, not a hundred"""
+        value = "CANARYREPEATEDVALUE12345"
+        inner = "".join(f"<rule><blob>{value}</blob></rule>" for _ in range(50))
+        xml = config(f"<filter>{inner}</filter>")
+        root = ET.fromstring(xml)
+
+        result = verifier.scan_retention(verifier.collect_input_values(root), xml)
+        assert result.count == 1
+
+    def test_tracking_is_bounded(self):
+        """A pathological document must not make the verifier the problem"""
+        inner = "".join(
+            f"<n><blob>CANARYUNIQUEVALUE{n:08d}</blob></n>"
+            for n in range(verifier.MAX_TRACKED_VALUES + 500)
+        )
+        root = ET.fromstring(config(f"<pkg>{inner}</pkg>"))
+
+        assert len(verifier.collect_input_values(root)) <= verifier.MAX_TRACKED_VALUES
+
+
+class TestDefectInjection:
+    """Break the transformer on purpose. The verifier must notice unaided."""
+
+    @staticmethod
+    def _run_with_broken_transformer(monkeypatch, xml):
+        """Redact `xml` with redact_element neutered, and verify the result
+
+        Neutering the traversal entirely is the strongest form of the test:
+        the transformer's statistics, its retained-value list and its warnings
+        all report a clean run, because from its point of view nothing needed
+        doing. Only something reading the output can tell otherwise.
+        """
+        monkeypatch.setattr(
+            PfSenseRedactor, 'redact_element',
+            lambda self, element, redact_ips=True, redact_domains=True: None
+        )
+
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(xml)
+        tracked = verifier.collect_input_values(root)
+        redactor.redact_element(root)
+        candidate = ET.tostring(root, encoding='unicode')
+
+        findings = list(verifier.scan_shapes(candidate).findings)
+        findings.extend(verifier.scan_retention(tracked, candidate).findings)
+        return redactor, verifier.build_result(findings)
+
+    def test_a_retained_private_key_is_caught(self, monkeypatch):
+        """1. The transformer keeps a PEM key and says nothing"""
+        redactor, result = self._run_with_broken_transformer(
+            monkeypatch, config(f"<pkg><vendorblob>{PEM}</vendorblob></pkg>")
+        )
+
+        assert redactor.stats['secrets_redacted'] == 0, "transformer must be silent"
+        assert not result.clean
+        assert any(f.finding_id == 'retained-private-key' for f in result.findings)
+
+    def test_a_retained_jwt_is_caught(self, monkeypatch):
+        """2. And a token"""
+        _, result = self._run_with_broken_transformer(
+            monkeypatch, config(f"<pkg><apitoken>{JWT}</apitoken></pkg>")
+        )
+        assert any(f.finding_id == 'retained-jwt' for f in result.findings)
+
+    def test_a_retained_base64_wrapped_key_is_caught(self, monkeypatch):
+        """3. And an encoded one"""
+        import base64  # pylint: disable=import-outside-toplevel
+        wrapped = base64.b64encode(PEM.encode()).decode()
+
+        _, result = self._run_with_broken_transformer(
+            monkeypatch, config(f"<pkg><payload>{wrapped}</payload></pkg>")
+        )
+        assert any(f.finding_id == 'retained-private-key' for f in result.findings)
+
+    def test_a_retained_canary_in_an_unknown_field_is_caught(self, monkeypatch):
+        """4. The case no shape rule covers: an ordinary-looking secret
+
+        Nothing about CANARY_ADV_UNKNOWN_FIELD_SECRET looks like key material.
+        It is caught because it came out of the input unchanged, which is the
+        one thing the shape rules cannot tell you.
+        """
+        _, result = self._run_with_broken_transformer(
+            monkeypatch,
+            config("<pkg><mqtt_login>CANARYUNKNOWNFIELDSECRET42</mqtt_login></pkg>")
+        )
+
+        assert any(f.finding_id == 'retained-input-value' for f in result.findings)
+        assert "CANARYUNKNOWNFIELD" not in rendered(result)
+
+    def test_a_retained_credential_url_is_caught(self, monkeypatch):
+        """5. And a credential in a URL"""
+        _, result = self._run_with_broken_transformer(
+            monkeypatch, config(f"<pkg><updateurl>{CREDENTIAL_URL}</updateurl></pkg>")
+        )
+        assert any(f.finding_id == 'retained-url-credential' for f in result.findings)
+
+    def test_no_finding_contains_secret_text(self, monkeypatch):
+        """6. Across every injected defect at once"""
+        _, result = self._run_with_broken_transformer(monkeypatch, config(
+            f"<pkg><a>{PEM}</a><b>{JWT}</b><c>{CREDENTIAL_URL}</c>"
+            "<d>CANARYUNKNOWNFIELDSECRET42</d></pkg>"
+        ))
+        text = rendered(result)
+
+        assert not result.clean
+        for secret in ("CANARYPRIVATEKEY", "eyJ", "CANARY_URLPASSWORD",
+                       "CANARYUNKNOWNFIELD", "svcacct"):
+            assert secret not in text, secret
+
+    def test_a_correct_run_produces_no_findings(self, monkeypatch):
+        """7a. The control: with the transformer intact, the same input is clean"""
+        del monkeypatch  # the transformer is deliberately left alone here
+        xml = config(f"<pkg><a>{PEM}</a><b>{JWT}</b><c>{CREDENTIAL_URL}</c></pkg>")
+
+        redactor = PfSenseRedactor(aggressive=True)
+        root = ET.fromstring(xml)
+        tracked = verifier.collect_input_values(root)
+        redactor.redact_element(root)
+        candidate = ET.tostring(root, encoding='unicode')
+
+        findings = list(verifier.scan_shapes(candidate).findings)
+        findings.extend(verifier.scan_retention(tracked, candidate).findings)
+        assert verifier.build_result(findings).clean
+
+
+class TestFalsePositiveVolume:
+    """7b. A report nobody can read is a report nobody reads"""
+
+    @pytest.mark.parametrize(
+        "sample", ["default-config.xml", "test-config1.xml", "test-config2.xml"]
+    )
+    def test_real_configs_stay_reviewable(self, sample, tmp_path, cli_runner):
+        """Findings on a real config must fit on a screen
+
+        Not zero: these samples do contain values that survive verbatim, and
+        saying so is the verifier working. The number has to stay small enough
+        that an operator reads it rather than dismissing it.
+        """
+        del tmp_path, cli_runner  # the sample files are read directly
+        from pathlib import Path  # pylint: disable=import-outside-toplevel
+
+        path = Path(__file__).resolve().parents[2] / "test-configs" / sample
+        if not path.exists():  # pragma: no cover - repo integrity
+            pytest.skip(f"missing sample: {path}")
+
+        redactor = PfSenseRedactor(aggressive=True, redact_descriptions=True)
+        tree = ET.parse(path)
+        root = tree.getroot()
+        tracked = verifier.collect_input_values(root)
+        redactor.known_refids = redactor._collect_refids(root)  # pylint: disable=protected-access
+        redactor.redact_element(root)
+        candidate = ET.tostring(root, encoding='unicode')
+
+        findings = list(verifier.scan_shapes(candidate).findings)
+        findings.extend(verifier.scan_retention(tracked, candidate).findings)
+        result = verifier.build_result(findings)
+
+        assert result.count <= 15, [f.path for f in result.findings]
+
+
+class TestVerifierIntegration:
+    """How redactor.py uses it, and what it does when it cannot"""
+
+    def test_serialisation_matches_what_is_written(self, tmp_path):
+        """Verifying anything but the written bytes verifies the wrong thing"""
+        tree = ET.ElementTree(ET.fromstring(config("<system><a>b</a></system>")))
+        target = tmp_path / "out.xml"
+        tree.write(str(target), encoding='utf-8', xml_declaration=True)
+
+        assert PfSenseRedactor.serialise_tree(tree) == target.read_text(encoding='utf-8')
+
+    def test_verification_is_available_in_a_normal_installation(self):
+        """The package ships verifier.py, so it must import"""
+        from pfsense_redactor.redactor import (  # pylint: disable=import-outside-toplevel
+            verification_is_available,
+        )
+        assert verification_is_available()
+
+    def test_an_unavailable_verifier_is_not_a_pass(self, monkeypatch):
+        """None must never be read as 'verified clean'
+
+        The single-file deployment has no verifier.py beside it. Reporting that
+        as a clean verification would be exactly the fail-open behaviour the
+        verifier exists to remove.
+        """
+        monkeypatch.setattr('pfsense_redactor.redactor.VERIFIER', None)
+
+        result = PfSenseRedactor().verify_candidate_output(config(f"<x>{PEM}</x>"))
+        assert result is None
+
+    def test_a_run_reports_its_verification(self, tmp_path, cli_runner):
+        """The operator is told, in every mode"""
+        source = tmp_path / "config.xml"
+        source.write_text(config(f"<pkg><vendorblob>{PEM}</vendorblob></pkg>"))
+
+        _, stdout, stderr = cli_runner.run(str(source), str(tmp_path / "out.xml"))
+        assert "Independent verification" in stdout + stderr
+
+    def test_verification_result_is_kept_on_the_redactor(self, tmp_path):
+        """PR 3 needs a verdict to gate on; this is where it comes from"""
+        source = tmp_path / "config.xml"
+        source.write_text(config("<system><hostname>fw</hostname></system>"))
+
+        redactor = PfSenseRedactor()
+        redactor.redact_config(str(source), str(tmp_path / "out.xml"))
+
+        assert redactor.last_verification is not None
+        assert redactor.last_verification.clean

--- a/tests/unit/test_output_verification.py
+++ b/tests/unit/test_output_verification.py
@@ -416,6 +416,45 @@ class TestFalsePositiveVolume:
         assert result.count <= 15, [f.path for f in result.findings]
 
 
+class TestVerifierNeedsNoXmlParser:
+    """The verifier never parses XML, and must not import a parser to say so
+
+    Codacy flags `import xml.etree.ElementTree` as XXE-prone wherever it
+    appears. On this module the finding is wrong - there is no ET.parse and no
+    ET.fromstring here, only annotations - but the import was also genuinely
+    unnecessary, so it moved under TYPE_CHECKING rather than being argued with
+    or suppressed. These tests stop it coming back.
+    """
+
+    def test_verifier_does_not_import_elementtree_at_runtime(self):
+        """The assertion the fix has to satisfy"""
+        import pfsense_redactor.verifier as verifier  # pylint: disable=import-outside-toplevel
+
+        assert "ET" not in vars(verifier)
+
+    def test_the_module_parses_no_xml(self):
+        """The reason the import is unnecessary, asserted against the source
+
+        If a parse call is ever added here, the annotation-only justification
+        stops holding and this fails - which is the point at which the
+        defusedxml question genuinely needs answering rather than dismissing.
+        """
+        from pathlib import Path  # pylint: disable=import-outside-toplevel
+
+        source = (Path(__file__).resolve().parents[2]
+                  / "pfsense_redactor" / "verifier.py").read_text(encoding="utf-8")
+
+        for parser in ("ET.parse(", "ET.fromstring(", "ET.XML(", "XMLParser("):
+            assert parser not in source, f"verifier.py now parses XML via {parser}"
+
+    def test_it_still_walks_a_tree_it_is_given(self):
+        """The control: dropping the import must not have dropped the feature"""
+        root = ET.fromstring(config("<pkg><blob>CANARYSTILLWALKSVALUE99</blob></pkg>"))
+
+        tracked = verifier.collect_input_values(root)
+        assert any(item.path == 'pfsense/pkg/blob' for item in tracked)
+
+
 class TestVerifierIntegration:
     """How redactor.py uses it, and what it does when it cannot"""
 

--- a/tests/unit/test_output_verification.py
+++ b/tests/unit/test_output_verification.py
@@ -427,9 +427,13 @@ class TestVerifierNeedsNoXmlParser:
     """
 
     def test_verifier_does_not_import_elementtree_at_runtime(self):
-        """The assertion the fix has to satisfy"""
-        import pfsense_redactor.verifier as verifier  # pylint: disable=import-outside-toplevel
+        """The assertion the fix has to satisfy
 
+        The module-level import is enough. Re-importing inside the test would
+        return the same cached module object, so it would add no freshness -
+        and a module-level `import xml.etree.ElementTree as ET` in verifier.py
+        would put `ET` in this namespace either way, which is what is checked.
+        """
         assert "ET" not in vars(verifier)
 
     def test_the_module_imports_no_xml_library_at_all(self):

--- a/tests/unit/test_output_verification.py
+++ b/tests/unit/test_output_verification.py
@@ -432,20 +432,36 @@ class TestVerifierNeedsNoXmlParser:
 
         assert "ET" not in vars(verifier)
 
-    def test_the_module_parses_no_xml(self):
-        """The reason the import is unnecessary, asserted against the source
+    def test_the_module_imports_no_xml_library_at_all(self):
+        """Not even for annotations
 
-        If a parse call is ever added here, the annotation-only justification
-        stops holding and this fails - which is the point at which the
-        defusedxml question genuinely needs answering rather than dismissing.
+        The verifier is handed an already-parsed tree and walks it. Depending
+        on the parser that produced it - in code or in types - would tie the
+        one component meant not to share the transformer's assumptions to the
+        transformer's library.
         """
+        assert "import xml" not in self._source()
+
+    def test_the_module_parses_no_xml(self):
+        """The reason no XML library is needed, asserted against the source
+
+        If a parse call is ever added here, the justification stops holding
+        and this fails - which is the point at which the defusedxml question
+        genuinely needs answering rather than dismissing.
+        """
+        source = self._source()
+
+        for parser in ("ET.parse(", "ET.fromstring(", "ET.XML(", "XMLParser(",
+                       "parse(", "fromstring("):
+            assert parser not in source, f"verifier.py now parses XML via {parser}"
+
+    @staticmethod
+    def _source():
+        """verifier.py's source text"""
         from pathlib import Path  # pylint: disable=import-outside-toplevel
 
-        source = (Path(__file__).resolve().parents[2]
-                  / "pfsense_redactor" / "verifier.py").read_text(encoding="utf-8")
-
-        for parser in ("ET.parse(", "ET.fromstring(", "ET.XML(", "XMLParser("):
-            assert parser not in source, f"verifier.py now parses XML via {parser}"
+        return (Path(__file__).resolve().parents[2]
+                / "pfsense_redactor" / "verifier.py").read_text(encoding="utf-8")
 
     def test_it_still_walks_a_tree_it_is_given(self):
         """The control: dropping the import must not have dropped the feature"""


### PR DESCRIPTION
# PR 2 — Independent output verifier

Base: `security/secret-detection-hardening` (rebase onto `main` when PR 1 merges) · Branch: `security/independent-output-verifier` · Version: 1.2.2

## Summary

Until now the only check on a redacted file was `_retained_values_are_acceptable`, which reads `self.stats` — the transformer reporting what it chose to keep. A class of secret the transformer cannot see was equally invisible to the check. Not a verifier sharing the transformer's patterns: no verifier at all.

## Findings addressed

| Finding | Status | Evidence |
| --- | --- | --- |
| FINDING-21 | Fixed | `pfsense_redactor/verifier.py`; `tests/unit/test_output_verification.py::TestDefectInjection` (7 cases) |
| FINDING-22 | Groundwork | `serialise_tree`, `verify_candidate_output`, `last_verification`. Enforcement lands in PR 3 |

## Security invariants

- Verification reads the serialised candidate, not the transformer's record of it.
- The verifier's patterns are defined in its own module, not imported from the transformer.
- The retention comparison classifies nothing, so it cannot inherit the transformer's blind spots.
- A finding carries a path, a kind, a length and a reason — never a value, a prefix, or a hash.
- An unavailable verifier is reported as unavailable, never as clean.

## Behaviour changes

- Every run prints a verification result on stderr. **Advisory in this release**: it does not decide whether output is written.
- New module `pfsense_redactor/verifier.py`. `redactor.py` imports it tolerantly so the single-file deployment still works; without it, runs report verification as unavailable.
- No CLI option, default or exit code changes. Output is byte-identical to 1.2.1 for the same input.

## Regression analysis

- Before: 1123 passed, 1 skipped, 26 xfailed
- After: **1174 passed, 1 skipped, 26 xfailed**
- Previously passing tests affected: 0
- Existing tests modified: 1 — `tests/adversarial/test_filesystem_safety.py`

**Modified test (not an expectation change).** The interrupted-write fake patched `ET.ElementTree.write` unconditionally. `ET.tostring` goes through that same method, so once the redactor serialised before writing, the fake aborted during serialisation and two FINDING-19 xfails became XPASS *without the finding being fixed*. The fake now passes stream writes through to the real implementation and explodes only on a path write, so both tests exercise the write path again and both markers stay until PR 3 earns their removal.

## Tests

```
python -m pytest tests/ -q                                   1174 passed, 1 skipped, 26 xfailed
python -m pytest tests/unit/test_output_verification.py -q     47 passed
python tools/check_structure.py                              exit 0
pylint production / tests                                    10.00/10 / 10.00/10
```

Defect injection: `redact_element` replaced with a no-op, so the transformer's statistics, retained-value list and warnings all report a clean run. The verifier catches a retained private key, a JWT, a Base64-wrapped key, a credential-bearing URL, and a canary in an unknown field that no shape rule covers.

False-positive bound: findings on the three real sample configs asserted ≤ 15. Measured 0, 4 and 1 under the strongest policy.

## Xfail changes

Removed: none — FINDING-21's own test had become vacuous and is dealt with in PR 4. Retained: 26. New markers: none.

## Remaining risks

- Advisory only in this release.
- The retention check reports only values inside `[A-Za-z0-9+/=_-]`. A secret containing a dot or a space is invisible to it; the shape scan covers JWTs and credential URLs, `--redact-descriptions` covers prose. Documented as a limitation.
- Single-file deployment loses verification entirely, and says so.

## Review guidance

`pfsense_redactor/verifier.py` in full — particularly `_is_excluded` (each exclusion is asserted individually) and `CREDENTIAL_ALPHABET_RE`, which is the one concession that makes the check usable.

---

## Update: the blocking finding, answered by deletion

Codacy blocked this PR on HIGH RISK: *"stdlib `xml` is XXE-prone, use `defusedxml`"*.

**The finding is wrong about this file, but the import was still unnecessary.**
`verifier.py` never parses XML — it receives an already-parsed tree from
`redactor.py` and walks it. There is no `ET.parse`, no `ET.fromstring`, no
`XMLParser`. `ET` appeared in exactly five parameter annotations, and
`from __future__ import annotations` was already on, so nothing needed it at
runtime.

The import moved under `typing.TYPE_CHECKING`. The finding now has nothing to
point at — not suppressed, not argued with, and `defusedxml` is not added, which
keeps the zero-runtime-dependency property and the single-file standalone mode
that `tests/integration/test_standalone_script.py` guards.

Two tests hold it there:

```python
def test_verifier_does_not_import_elementtree_at_runtime():
    import pfsense_redactor.verifier as verifier
    assert "ET" not in vars(verifier)
```

and one that greps the source for parse calls — so if one is ever added, the
annotation-only justification stops holding and the `defusedxml` question has to
be answered properly rather than dismissed a second time.

**Also addressed:** `TrackedValue` gains a `collapsed` field computed once at
collection, instead of `scan_retention` re-collapsing every value on every call;
and `_decode_layer` uses `finditer`.

**Declined:** the suggestion to decompose `verifier.py` (complexity 65). Same
reasoning now recorded on `main` in `tools/check_structure.py`'s "Relationship to
CodeScene" section — module-level aggregate scores follow from a deliberate
design choice, and a verifier whose value is that it can be read end to end and
checked against what it claims to detect is made worse by being spread across
files. Both function-level gates pass: `--max-complexity=8` reports 0 and
`tools/check_structure.py` passes.

### Follow-up: the import is gone entirely

Codacy re-analysed the `TYPE_CHECKING` version and **still reported the
finding** — its rule matches the import statement, and a statement guarded by
`if TYPE_CHECKING:` is still a statement in the file. Moving it removed the
runtime dependency, which was the real point and is asserted by a test, but left
the text the scanner keys on.

The module uses exactly four things from an element — `.tag`, `.text`,
`.attrib`, and iteration. That is now declared as a `Protocol`, and the import
is removed rather than relocated.

This is better typing regardless of the scanner. The verifier's whole value is
that it does not share the transformer's assumptions; depending on the
transformer's XML library, even only in annotations, works against that. It is
handed an already-parsed tree and walks it — an ElementTree `Element` satisfies
the protocol, and so would anything shaped the same way.

Three tests hold the line: the runtime namespace must not carry `ET`, the source
must contain no `import xml` at all, and no parse call may appear. The last is
the load-bearing one — if parsing is ever added here the whole justification
collapses, and *that* is when the `defusedxml` question needs a real answer
rather than this one.


---

## Versions renumbered

The stack was numbered 1.3.0–1.8.0, one minor bump per PR, because the
repository forbids an open `[Unreleased]` section so each PR had to name a
version. That claimed six releases that never happened: **PyPI's latest is
1.1.2**, and `main`'s 1.2.0 has not shipped either.

Renumbered to patches, with a minor only where compatibility actually breaks:

| PR | Was | Now | |
| --- | --- | --- | --- |
| #65 | 1.3.0 | **1.2.1** | additive detection |
| #66 | 1.4.0 | **1.2.2** | verifier, advisory only |
| #67 | 1.5.0 | **1.3.0** | breaking: `--inplace` needs `--force`, hard links refused, failed gate writes nothing |
| #68 | 1.6.0 | **1.4.0** | breaking: usage errors exit 1, not 2 |
| #69 | 1.7.0 | **1.4.1** | workflows and docs only |
| #71 | 1.8.0 | **1.4.2** | verifier containment |

Sequence: `1.2.0 → 1.2.1 → 1.2.2 → 1.3.0 → 1.4.0 → 1.4.1 → 1.4.2`.

Test totals are unchanged by the renumber, and reference snapshots differ only
in the version comment.
