### PR TITLE
Verify before write, and atomic 0600 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,86 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0][] - 2026-08-05
+
+Verify, then write. Until now the write happened first and the verdict was
+returned afterwards, so a failing gate reported the problem and still produced
+the artefact.
+
+**This release contains breaking changes.** See *Changed* below.
+
+### Security
+
+- **Candidate output is verified before it becomes externally visible.**
+  Processing is now: parse, transform in memory, serialise the candidate, verify
+  it, decide, and only then write. A failed `--fail-on-warn` run produces no
+  output file, no XML on stdout, and no temporary file. Before this, the gate
+  exited non-zero *after* the file had been written, so a CI job that failed the
+  build still left it in the workspace and in any artifact-upload step that ran
+  regardless. (FINDING-22)
+
+- **`--fail-on-warn` now also fails on independent verification findings**, and
+  fails when the verifier could not be imported at all. "Nothing checked" is not
+  "nothing found", and a gate that passes because its check did not run is not a
+  gate.
+
+- **Output is written atomically.** A temporary file in the destination
+  directory, `0600` before any bytes are written, flushed, `fsync`ed, closed,
+  then `os.replace`d onto the destination, with the directory `fsync`ed
+  afterwards. The destination holds either its previous content or the complete
+  new content, never a truncated mixture. `tree.write()` truncated the target
+  before serialising, so any failure after that point destroyed it: an
+  interrupted `--inplace` was measured reducing a 7,889-byte configuration to
+  36 bytes. Temporary files are removed on every failure path, including
+  `KeyboardInterrupt`. (FINDING-19)
+
+- **Output files are created with mode `0600`** rather than the process umask,
+  which typically produced `0644`. Redacted output can still hold retained
+  high-entropy values by design, plus hostnames, topology and descriptions. This
+  is a POSIX guarantee; on Windows permissions are ACLs and the mode is not
+  claimed. (FINDING-18)
+
+- **An output path that reaches the input is refused.** Compared on device and
+  inode via `os.path.samestat`, so `config.xml config.xml`, `config.xml
+  ./config.xml`, a symlink and a hard link are all caught. Previously this was
+  `--inplace` by accident: without `--inplace`'s symlink guard, without its
+  consent, and with no warning that the only copy of the secrets was being
+  consumed. (FINDING-15)
+
+- **An output path that is a symbolic link is refused.** The write would follow
+  it to a file the operator did not name. (FINDING-16)
+
+### Changed
+
+- **`--inplace` now requires `--force`.** The help epilogue has shown them
+  together since the flag existed and `docs/security.md` described them
+  together, but nothing enforced it. A single mistyped flag rewrote the only
+  unredacted copy of the configuration with no confirmation. **Scripts using
+  bare `--inplace` must add `--force`.** (FINDING-17)
+
+- **An output path with more than one name (a hard link) is refused**, and so is
+  `--inplace` on a hard-linked file. Atomic replacement creates a new inode, so
+  the other name would keep the previous — unredacted — content while the
+  operator, having watched the run report success, has no reason to look at it.
+  Before this release the write went through the link and every name saw the
+  redacted content. Write to a new path instead.
+
+- **A failed `--fail-on-warn` run produces no output.** Previously the redacted
+  file was still written so that the retained paths could be reviewed in it.
+  That reasoning does not survive the case the gate exists for: the candidate
+  can contain a private key in an element the tool did not recognise, and an
+  artefact that exists is one that gets uploaded or attached. `--dry-run`
+  reports the same retained paths and the same verification findings, and never
+  wrote a file in the first place.
+
+- Independent verification now runs under `--dry-run` as well, so what a dry run
+  reports is what the real run would produce.
+
+**Action required:** add `--force` to any script using `--inplace`; change any
+script using `--inplace` on a hard-linked path to write to a new file; and if a
+pipeline reads the output of a failed `--fail-on-warn` run, switch it to
+`--dry-run`.
+
 ## [1.2.2][] - 2026-08-04
 
 An independent verifier. Until now the only check on a redacted file was the
@@ -768,6 +848,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.3.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.3.0
 [1.2.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.2
 [1.2.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.1
 [1.2.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.0

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -78,7 +78,7 @@ pfsense-redactor config.xml --inplace --force
 ```
 
 `--force` is required, not optional. `--inplace` destroys the only unredacted
-copy of the configuration, and until 1.5.0 a single mistyped flag was enough to
+copy of the configuration, and until 1.3.0 a single mistyped flag was enough to
 do it. It is also refused on a file with more than one name (a hard link),
 because output is written by atomic replacement and the other name would keep
 the unredacted content.
@@ -100,7 +100,7 @@ the unredacted content.
 | `input`                  | Input pfSense config.xml file (positional argument)                                                     |
 | `output`                 | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
 | `--stdout`               | Write redacted XML to stdout instead of file                                                            |
-| `--inplace`              | Overwrite input file with redacted output. **Requires `--force`** since 1.5.0; refused on a hard-linked file |
+| `--inplace`              | Overwrite input file with redacted output. **Requires `--force`** since 1.3.0; refused on a hard-linked file |
 | `--force`                | Overwrite output file if it already exists; also the required consent for `--inplace`                   |
 | `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security)                                 |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,6 +77,12 @@ pfsense-redactor config.xml --stdout > redacted.xml
 pfsense-redactor config.xml --inplace --force
 ```
 
+`--force` is required, not optional. `--inplace` destroys the only unredacted
+copy of the configuration, and until 1.5.0 a single mistyped flag was enough to
+do it. It is also refused on a file with more than one name (a hard link),
+because output is written by atomic replacement and the other name would keep
+the unredacted content.
+
 ## Command-Line Flags Reference
 
 ### Version & Help
@@ -94,8 +100,8 @@ pfsense-redactor config.xml --inplace --force
 | `input`                  | Input pfSense config.xml file (positional argument)                                                     |
 | `output`                 | Output redacted config.xml file (positional argument, optional with `--stdout`/`--dry-run`/`--inplace`) |
 | `--stdout`               | Write redacted XML to stdout instead of file                                                            |
-| `--inplace`              | Overwrite input file with redacted output (use with caution)                                            |
-| `--force`                | Overwrite output file if it already exists                                                              |
+| `--inplace`              | Overwrite input file with redacted output. **Requires `--force`** since 1.5.0; refused on a hard-linked file |
+| `--force`                | Overwrite output file if it already exists; also the required consent for `--inplace`                   |
 | `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security)                                 |
 
 ### Redaction Modes

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -46,7 +46,7 @@ That is the number each pull request below is compared against.
 | --- | --- | --- | --- |
 | 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
 | 2 | 1106 passed, 1 skipped, 26 xfailed | 0 | 26 |
-| 3 | (measured below) | 8 | 18 |
+| 3 | 1153 passed, 1 skipped, 18 xfailed | 8 | 18 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -46,6 +46,7 @@ That is the number each pull request below is compared against.
 | --- | --- | --- | --- |
 | 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
 | 2 | 1106 passed, 1 skipped, 26 xfailed | 0 | 26 |
+| 3 | (measured below) | 8 | 18 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -202,6 +202,63 @@ Redacted output is for **analysis only**, because:
 
 Always keep the **original secure copy**.
 
+## Output safety
+
+Where the output goes, and how it gets there. Separate from path safety below,
+which asks whether a path is *allowed*; this asks what writing to it would do to
+files that already exist.
+
+### Verify, then write
+
+Output is produced in this order:
+
+```text
+parse -> transform in memory -> serialise candidate
+      -> verify candidate -> decide -> write
+```
+
+Nothing reaches a file or stdout before the verdict. Until 1.5.0 the write
+happened first and the verdict was returned afterwards, so `--fail-on-warn`
+exited non-zero *after* `_write_output` had already produced the file — the gate
+reported the problem and did not prevent the artefact. A CI job that failed the
+build still left the file in the workspace, and in any `upload-artifact` step
+that ran regardless.
+
+A failed gate now produces nothing: no output file, no XML on stdout, and no
+temporary file. Use `--dry-run` to see the same retained paths and verification
+findings without producing anything, which is what it was always for.
+
+### Atomic writes
+
+Output is written to a temporary file in the **destination directory**, at mode
+`0600` before any bytes are written, then flushed, `fsync`ed, closed, and moved
+onto the destination with `os.replace`. The directory is `fsync`ed afterwards
+where the platform supports it.
+
+The destination therefore holds either its previous content or the complete new
+content. It is never a truncated mixture. `tree.write()` opened the target for
+writing — truncating it — and only then began serialising, so any failure after
+that point left a partial file. Under `--inplace` that file was the operator's
+configuration: measured at 7,889 bytes reduced to 36.
+
+Temporary files are removed on every failure path, including `KeyboardInterrupt`.
+
+`0600` is a POSIX guarantee. On Windows, permissions are ACLs and `os.chmod`
+only controls the read-only bit, so the restrictive mode is not claimed there.
+
+### Destinations that are refused
+
+| Destination | Why |
+| --- | --- |
+| The input file | Redacting a file over itself destroys the only copy of the secrets. Compared on device and inode, so `config.xml`, `./config.xml`, a symlink and a hard link are all caught |
+| A symbolic link | The write would follow it to a file you did not name, and the replacement would then remove the link |
+| A file with more than one name | Atomic replacement creates a new inode, so the other name would keep the previous — unredacted — content |
+
+`--inplace` is the deliberate exception to the first, and requires `--force`. It
+is refused on a hard-linked file for the third reason: before 1.5.0 the write
+went through the link and every name saw the redacted content; it now cannot,
+and a silently stale copy of an unredacted config is worse than a refusal.
+
 ## Path safety
 
 The tool includes built-in protections against malicious file path operations:

--- a/docs/security.md
+++ b/docs/security.md
@@ -217,7 +217,7 @@ parse -> transform in memory -> serialise candidate
       -> verify candidate -> decide -> write
 ```
 
-Nothing reaches a file or stdout before the verdict. Until 1.5.0 the write
+Nothing reaches a file or stdout before the verdict. Until 1.3.0 the write
 happened first and the verdict was returned afterwards, so `--fail-on-warn`
 exited non-zero *after* `_write_output` had already produced the file — the gate
 reported the problem and did not prevent the artefact. A CI job that failed the
@@ -255,7 +255,7 @@ only controls the read-only bit, so the restrictive mode is not claimed there.
 | A file with more than one name | Atomic replacement creates a new inode, so the other name would keep the previous — unredacted — content |
 
 `--inplace` is the deliberate exception to the first, and requires `--force`. It
-is refused on a hard-linked file for the third reason: before 1.5.0 the write
+is refused on a hard-linked file for the third reason: before 1.3.0 the write
 went through the link and every name saw the redacted content; it now cannot,
 and a silently stale copy of an unredacted config is worse than a refusal.
 

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.2.2"
+__version__ = "1.3.0"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -3946,16 +3946,29 @@ def write_bytes_atomically(target: str, payload: bytes) -> None:
     _fsync_directory(directory)
 
 
-def _write_and_sync(handle: int, temp_path: str, payload: bytes) -> None:
-    """Fill the temporary file, set its mode, and get it onto the device
+def _restrict_mode(stream, temp_path: str) -> None:
+    """Set the temporary file to OUTPUT_FILE_MODE, by descriptor where possible
 
-    mkstemp already creates at 0600 on POSIX. The explicit chmod is for
-    platforms where it does not, and is a no-op where it does. On Windows it
-    only clears the read-only bit, because permissions there are ACLs; the
-    restrictive-permissions guarantee is POSIX-only and documented as such.
+    fchmod acts on the descriptor already held open, so nothing can substitute
+    a different file at that path between creating it and setting its mode.
+    chmod-by-path is the same operation with a window in the middle, and there
+    is no reason to keep the window when the descriptor is right there.
+
+    mkstemp already creates at 0600 on POSIX, so this is belt and braces there.
+    Windows has no fchmod, and its chmod only clears the read-only bit because
+    permissions are ACLs - the restrictive-permissions guarantee is POSIX-only
+    and documented as such.
     """
+    if hasattr(os, 'fchmod'):
+        os.fchmod(stream.fileno(), OUTPUT_FILE_MODE)
+        return
+    os.chmod(temp_path, OUTPUT_FILE_MODE)  # pragma: no cover - Windows only
+
+
+def _write_and_sync(handle: int, temp_path: str, payload: bytes) -> None:
+    """Fill the temporary file, set its mode, and get it onto the device"""
     with os.fdopen(handle, 'wb') as stream:
-        os.chmod(temp_path, OUTPUT_FILE_MODE)
+        _restrict_mode(stream, temp_path)
         stream.write(payload)
         stream.flush()
         os.fsync(stream.fileno())

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -60,6 +60,7 @@ from pathlib import Path
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from itertools import islice
+import tempfile
 from typing import NoReturn, Union
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode, SplitResult
 import os
@@ -3288,22 +3289,29 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         for line in VERIFIER.describe(result):
             self.logger.warning("    - %s", line)
 
-    def _write_output(
-        self, tree: ET.ElementTree, input_file: str, output_file: str | None,
+    def _emit_candidate(
+        self, candidate: str, input_file: str, output_file: str | None,
         stdout_mode: bool, inplace: bool
     ) -> None:
-        """Write the redacted tree to stdout, over the input, or to a new file"""
+        """Make the verified candidate externally visible
+
+        Called only after a verdict has been reached. Everything before this
+        point happens in memory, so a run that decides not to produce output
+        leaves nothing behind for someone to find and share.
+        """
+        payload = candidate.encode('utf-8')
+
         if stdout_mode:
-            tree.write(sys.stdout.buffer, encoding='utf-8', xml_declaration=True)
+            sys.stdout.buffer.write(payload)
             return
+
+        target = input_file if inplace else output_file
+        write_bytes_atomically(target, payload)
 
         if inplace:
-            tree.write(input_file, encoding='utf-8', xml_declaration=True)
-            self.logger.info("[+] Redacted configuration written in-place to: %s", input_file)
+            self.logger.info("[+] Redacted configuration written in-place to: %s", target)
             return
-
-        tree.write(output_file, encoding='utf-8', xml_declaration=True)
-        self.logger.info("[+] Redacted configuration written to: %s", output_file)
+        self.logger.info("[+] Redacted configuration written to: %s", target)
 
     def redact_config(
         self,
@@ -3315,62 +3323,28 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         stdout_mode: bool = False,
         inplace: bool = False
     ) -> bool:
-        """Redact pfSense configuration file"""
+        """Redact pfSense configuration file
+
+        The order is load-bearing:
+
+            parse -> transform in memory -> serialise candidate
+                  -> verify candidate -> decide -> write
+
+        Nothing is written to a file or to stdout before the verdict. Before
+        1.5.0 the write happened first and the verdict was returned afterwards,
+        so `--fail-on-warn` reported the problem and still left the artefact on
+        disk for someone to share.
+        """
         try:
-            tree = self._load_config_tree(input_file)
-            if tree is None:
-                return False
-            root = tree.getroot()
-
-            # Both lines are progress reporting under the same condition, and
-            # nothing runs between them, so they share one guard.
-            if not dry_run and not stdout_mode:
-                self.logger.info("[+] Parsing XML configuration from: %s", input_file)
-                self.logger.info("[+] Redacting sensitive information...")
-
             # Policy for this run, set before the traversal reads it. Assigned
             # on every call so a reused instance cannot inherit the previous
             # run's flags.
             self.redact_ips = redact_ips
             self.redact_domains = redact_domains
 
-            # Before the traversal, so certificate references can be resolved
-            # against what the config actually defines
-            self.known_refids = self._collect_refids(root)
-
-            # Also before the traversal: the retention comparison needs the
-            # input's values, and redaction overwrites them in place.
-            self._snapshot_input_values(root)
-
-            self.redact_element(root)
-
-            # Dry run mode: just print stats
-            if dry_run:
-                self.logger.info("[+] Dry run - no files modified")
-                self._print_stats()
-                return self._retained_values_are_acceptable()
-
-            # Add redaction comment to the root element
-            self._add_redaction_comment(root)
-
-            # Pretty print (Python 3.9+)
-            ET.indent(tree, space="  ")
-
-            # Advisory in this release: reported, not enforced. The candidate
-            # is serialised once and both verified and written from the same
-            # text, so what is checked is what is shared.
-            self.last_verification = self.verify_candidate_output(
-                self.serialise_tree(tree)
+            return self._process(
+                input_file, output_file, dry_run, stdout_mode, inplace
             )
-
-            self._write_output(tree, input_file, output_file, stdout_mode, inplace)
-
-            # Print summary (always print, logger routes to correct stream)
-            self._print_stats()
-            self._report_verification(self.last_verification)
-
-            return self._retained_values_are_acceptable()
-
         except ET.ParseError as e:
             self.logger.error("[!] Error parsing XML: %s", e)
             return False
@@ -3380,6 +3354,112 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         except (ValueError, TypeError) as e:
             self.logger.error("[!] Error processing configuration: %s", e)
             return False
+
+    def _process(
+        self,
+        input_file: str,
+        output_file: str | None,
+        dry_run: bool,
+        stdout_mode: bool,
+        inplace: bool
+    ) -> bool:
+        """redact_config's body, with the exception handling lifted out
+
+        The traversal's IP and domain policy is instance state set by
+        redact_config, not a parameter, so it is not threaded through here.
+        """
+        tree = self._load_config_tree(input_file)
+        if tree is None:
+            return False
+        root = tree.getroot()
+
+        # Both lines are progress reporting under the same condition, and
+        # nothing runs between them, so they share one guard.
+        if not dry_run and not stdout_mode:
+            self.logger.info("[+] Parsing XML configuration from: %s", input_file)
+            self.logger.info("[+] Redacting sensitive information...")
+
+        # Before the traversal, so certificate references can be resolved
+        # against what the config actually defines
+        self.known_refids = self._collect_refids(root)
+
+        # Also before the traversal: the retention comparison needs the
+        # input's values, and redaction overwrites them in place.
+        self._snapshot_input_values(root)
+
+        self.redact_element(root)
+
+        candidate = self._build_candidate(tree, root)
+        self.last_verification = self.verify_candidate_output(candidate)
+
+        self._print_stats()
+        self._report_verification(self.last_verification)
+
+        permitted = self._output_is_permitted()
+
+        if dry_run:
+            self.logger.info("[+] Dry run - no files modified")
+            return permitted
+
+        if not permitted:
+            self.logger.error(
+                "[!] No output was produced. The candidate was verified before "
+                "anything was written, so there is no artefact to review or "
+                "share."
+            )
+            return False
+
+        self._emit_candidate(candidate, input_file, output_file, stdout_mode, inplace)
+        return True
+
+    def _build_candidate(self, tree: ET.ElementTree, root: ET.Element) -> str:
+        """Produce the exact text that would be written, without writing it
+
+        Built in every mode including --dry-run, because the verification a
+        dry run reports is only worth anything if it examined the document the
+        real run would produce.
+        """
+        self._add_redaction_comment(root)
+        ET.indent(tree, space="  ")
+        return self.serialise_tree(tree)
+
+    def _output_is_permitted(self) -> bool:
+        """Whether policy allows this candidate to become externally visible
+
+        Two gates, both of which only bite under --fail-on-warn. Without a
+        gate, findings are reported and the output is still produced: an
+        operator troubleshooting privately needs the file, and the
+        retained-value warning has always been advisory. The gate exists
+        precisely to stop the artefact, so under it a finding means no output.
+        """
+        return self._retained_values_are_acceptable() and self._verification_permits_output()
+
+    def _verification_permits_output(self) -> bool:
+        """Whether the independent verification allows output, under a gate
+
+        An unavailable verifier blocks a gated run. "Nothing checked" is not
+        "nothing found", and a gate that passes because its check did not run
+        is not a gate.
+        """
+        if not self.fail_on_warn:
+            return True
+
+        if self.last_verification is None:
+            self.logger.error(
+                "[!] Failing because --fail-on-warn is set and independent "
+                "verification could not run: verifier.py is not importable."
+            )
+            return False
+
+        if self.last_verification.clean:
+            return True
+
+        self.logger.error(
+            "[!] Failing because --fail-on-warn is set and independent "
+            "verification reported %d finding(s) in the candidate output.",
+            self.last_verification.count
+        )
+        return False
 
     def _retained_values_are_acceptable(self) -> bool:
         """Whether the run should be treated as successful
@@ -3666,6 +3746,221 @@ DANGEROUS_OUTPUT_FILES: frozenset[str] = frozenset({
 })
 
 
+# ==========================================================================
+# File identity and secure writing
+# ==========================================================================
+# Redacted output can still hold retained high-entropy values by design, plus
+# hostnames, topology and free-text descriptions. On a shared host, umask
+# permissions typically make that world-readable.
+OUTPUT_FILE_MODE: int = 0o600
+
+# Temporary files are created in the *destination* directory, so that
+# os.replace is a rename within one filesystem and therefore atomic. A
+# distinctive prefix makes anything left behind by a killed process
+# identifiable rather than mysterious.
+TEMP_OUTPUT_PREFIX: str = '.pfsense-redactor-'
+TEMP_OUTPUT_SUFFIX: str = '.tmp'
+
+
+def _stat_or_none(file_path: str) -> os.stat_result | None:
+    """os.stat, or None when the path does not exist or cannot be read"""
+    try:
+        return os.stat(file_path)
+    except (OSError, ValueError):
+        return None
+
+
+def _realpath_or_abspath(file_path: str) -> str:
+    """Absolute, symlink-resolved form, tolerating a path that does not exist"""
+    try:
+        return os.path.realpath(file_path)
+    except (OSError, ValueError):  # pragma: no cover - realpath rarely raises
+        return os.path.abspath(file_path)
+
+
+def paths_identify_same_file(first: str, second: str) -> bool:
+    """Whether two path strings reach the same file
+
+    Compared on device and inode via os.path.samestat rather than on the
+    strings, because 'config.xml' and './config.xml' are the same file, and so
+    are a path, a symlink to it and a hard link to it. String equality catches
+    none of those, and a case-insensitive filesystem catches none of them
+    either - but a stat of both names does.
+
+    When one of the paths does not exist there is nothing to stat, so the
+    resolved forms are compared instead. That is the weaker comparison, and it
+    is only reachable when the output does not exist yet - in which case
+    writing it cannot destroy the input.
+    """
+    first_stat = _stat_or_none(first)
+    second_stat = _stat_or_none(second)
+
+    if first_stat is not None and second_stat is not None:
+        return os.path.samestat(first_stat, second_stat)
+
+    return _realpath_or_abspath(first) == _realpath_or_abspath(second)
+
+
+def _has_multiple_names(file_path: str) -> bool:
+    """Whether a file is reachable under more than one name
+
+    st_nlink is not available meaningfully on every platform; where it reports
+    0 or 1 this returns False and the caller proceeds, which is the same
+    behaviour as before hard links were considered at all.
+    """
+    stat_result = _stat_or_none(file_path)
+    if stat_result is None:
+        return False
+    return getattr(stat_result, 'st_nlink', 1) > 1
+
+
+def output_path_refusal(input_file: str, output_file: str) -> str | None:
+    """Why writing to this output path is unsafe, or None if it is acceptable
+
+    Three refusals. Each is a case where the write destroys data, or leaves
+    data the operator believes was redacted sitting somewhere they will not
+    look.
+
+    1. The output reaches the input. That is --inplace by accident: without
+       --inplace's symlink guard, without its consent, and with no warning that
+       the only copy of the secrets is being consumed.
+
+    2. The output is a symbolic link. The write would follow it to a file the
+       operator did not name, and the atomic replacement would then remove the
+       link itself - so the destination is both wrong and gone.
+
+    3. The output has more than one name. Atomic replacement puts a *new inode*
+       at the destination, so every other name keeps pointing at the old
+       content. For a file being redacted, the old content is the unredacted
+       config, and it now sits under a name nobody is going to check.
+
+    Returns a message rather than raising, so the caller decides how to report
+    it - and so this function can be tested without a CLI.
+    """
+    if paths_identify_same_file(input_file, output_file):
+        return (f"output '{output_file}' is the input file. Redacting a file "
+                f"over itself destroys the only copy of the secrets; use "
+                f"--inplace --force if that is genuinely what you want.")
+
+    if os.path.islink(output_file):
+        return (f"output '{output_file}' is a symbolic link. Writing would "
+                f"follow it to a file you did not name.")
+
+    if _has_multiple_names(output_file):
+        return (f"output '{output_file}' has more than one name (hard link). "
+                f"Output is written by atomic replacement, so the other "
+                f"name(s) would keep the previous, unredacted content.")
+
+    return None
+
+
+def inplace_path_refusal(input_file: str) -> str | None:
+    """Why --inplace on this file is unsafe, or None if it is acceptable
+
+    The symlink case is refused earlier, by _resolve_input_path. What is left
+    is the hard link, and it is refused for the reason above: the replacement
+    creates a new inode, so the other name would still hold the unredacted
+    configuration while the operator believes the file has been redacted.
+
+    Before atomic writes this case worked - the write went through the link and
+    every name saw the redacted content - so this is a deliberate behaviour
+    change, made because the alternative is a silent stale copy.
+    """
+    if _has_multiple_names(input_file):
+        return (f"'{input_file}' has more than one name (hard link). In-place "
+                f"output is written by atomic replacement, so the other "
+                f"name(s) would keep the previous, unredacted content. Write "
+                f"to a new file instead.")
+    return None
+
+
+def _remove_quietly(file_path: str) -> None:
+    """Delete a file, ignoring the case where it is already gone
+
+    Used only on failure paths, where the original error is the one worth
+    reporting and a second failure while cleaning up would hide it.
+    """
+    try:
+        os.unlink(file_path)
+    except OSError:
+        pass
+
+
+def _fsync_directory(directory: str) -> None:
+    """Fsync a directory so a completed rename survives power loss
+
+    Not supported everywhere - Windows has no directory file descriptor to
+    sync - so failure here is not a failed write and is not reported as one.
+    The data itself was already fsynced before the rename.
+    """
+    try:
+        handle = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+
+    try:
+        os.fsync(handle)
+    except OSError:
+        pass
+    finally:
+        os.close(handle)
+
+
+def write_bytes_atomically(target: str, payload: bytes) -> None:
+    """Write `payload` to `target` atomically, at OUTPUT_FILE_MODE
+
+    The sequence, and why each step is there:
+
+        temp file in the destination directory   same filesystem, so the
+                                                 rename below is atomic
+        0600 before any bytes are written        the window where a partial
+                                                 secret file is readable by
+                                                 others never opens
+        write, flush, fsync                      the bytes are on the device,
+                                                 not in a buffer
+        close, os.replace                        the destination changes from
+                                                 old content to new content in
+                                                 one step, with no moment at
+                                                 which it is neither
+        fsync the directory                      the rename survives power loss
+
+    On any failure - including KeyboardInterrupt - the temporary file is
+    removed and the exception is re-raised. The destination is left holding
+    either its previous content or the complete new content. It is never a
+    truncated mixture of the two, which is what tree.write() produced: that
+    opens the target for writing, truncating it, and only then starts
+    serialising.
+    """
+    directory = os.path.dirname(os.path.abspath(target)) or os.curdir
+    handle, temp_path = tempfile.mkstemp(
+        prefix=TEMP_OUTPUT_PREFIX, suffix=TEMP_OUTPUT_SUFFIX, dir=directory
+    )
+
+    try:
+        _write_and_sync(handle, temp_path, payload)
+        os.replace(temp_path, target)
+    except BaseException:
+        _remove_quietly(temp_path)
+        raise
+
+    _fsync_directory(directory)
+
+
+def _write_and_sync(handle: int, temp_path: str, payload: bytes) -> None:
+    """Fill the temporary file, set its mode, and get it onto the device
+
+    mkstemp already creates at 0600 on POSIX. The explicit chmod is for
+    platforms where it does not, and is a no-op where it does. On Windows it
+    only clears the read-only bit, because permissions there are ACLs; the
+    restrictive-permissions guarantee is POSIX-only and documented as such.
+    """
+    with os.fdopen(handle, 'wb') as stream:
+        os.chmod(temp_path, OUTPUT_FILE_MODE)
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
 def _resolve_for_validation(file_path: str, path: Path) -> tuple[Path, bool]:
     """Resolve a path to absolute form. Returns (resolved, was_absolute)
 
@@ -3927,7 +4222,7 @@ def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--stdout', action='store_true',
                         help='Write redacted XML to stdout')
     parser.add_argument('--inplace', action='store_true',
-                        help='Overwrite input file with redacted output')
+                        help='Overwrite input file with redacted output. Requires --force: this destroys the only unredacted copy of the configuration.')
     parser.add_argument('--force', action='store_true',
                         help='Overwrite output file if it exists')
     parser.add_argument('--aggressive', action='store_true',
@@ -4028,6 +4323,36 @@ def _would_overwrite_without_force(args: argparse.Namespace, resolved: Path) -> 
     return resolved.exists()
 
 
+def _writes_a_file(args: argparse.Namespace) -> bool:
+    """Whether this invocation will actually create or replace a file
+
+    --dry-run and --stdout write nothing, so the destination checks below have
+    nothing to protect in those modes.
+    """
+    if args.dry_run:
+        return False
+    return bool(args.inplace or (args.output and not args.stdout))
+
+
+def _refuse_unsafe_destination(args: argparse.Namespace, logger: logging.Logger) -> None:
+    """Exit if the destination would destroy the input or strand stale content
+
+    Kept separate from validate_file_path, which asks where a path points.
+    This asks what writing there would do to files that already exist, which is
+    a different question with different answers.
+    """
+    if not _writes_a_file(args):
+        return
+
+    refusal = (inplace_path_refusal(args.input) if args.inplace
+               else output_path_refusal(args.input, args.output))
+    if refusal is None:
+        return
+
+    logger.error("[!] Error: %s", refusal)
+    sys.exit(1)
+
+
 def _resolve_output_path(
     args: argparse.Namespace, sensitive_dirs: frozenset[str], logger: logging.Logger
 ) -> None:
@@ -4051,6 +4376,8 @@ def _resolve_output_path(
             args.input, args, sensitive_dirs, logger,
             "[!] Error: Cannot use --inplace with this file: %s"
         )
+
+    _refuse_unsafe_destination(args, logger)
 
 
 def _validate_as_output_target(
@@ -4186,6 +4513,26 @@ def _handle_early_exit_flags(args: argparse.Namespace, parser: argparse.Argument
 
     if args.quiet and args.verbose:
         parser.error("--quiet and --verbose are mutually exclusive")
+
+    _require_consent_for_inplace(args, parser)
+
+
+def _require_consent_for_inplace(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> None:
+    """Refuse --inplace without --force
+
+    The help epilogue has shown '--inplace --force' since the flag existed and
+    docs/security.md describes them together, but nothing enforced it: the
+    overwrite guard is reached only when args.output is set, and --inplace
+    leaves it None. A single mistyped flag rewrote the operator's only
+    unredacted copy with no confirmation.
+    """
+    if args.inplace and not args.force:
+        parser.error(
+            "--inplace overwrites the input file, destroying the only "
+            "unredacted copy of the configuration. Add --force to confirm."
+        )
 
 
 def _configure_logging_from_args(args: argparse.Namespace) -> None:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -3331,7 +3331,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                   -> verify candidate -> decide -> write
 
         Nothing is written to a file or to stdout before the verdict. Before
-        1.5.0 the write happened first and the verdict was returned afterwards,
+        1.3.0 the write happened first and the verdict was returned afterwards,
         so `--fail-on-warn` reported the problem and still left the artefact on
         disk for someone to share.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.2.2"
+version = "1.3.0"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/adversarial/test_assurance_signals.py
+++ b/tests/adversarial/test_assurance_signals.py
@@ -30,12 +30,6 @@ class TestFailClosed:
             "exit 0 on output containing a private key certifies the leak"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-22: --fail-on-warn reports failure only after the "
-               "output has already been written, so the gate does not prevent "
-               "the unsafe artefact from existing",
-    )
     def test_fail_on_warn_writes_no_output(self, adversarial_canary, run_redactor, tmp_path):
         """The gate must prevent the artefact, not just report on it"""
         out = tmp_path / "out.xml"
@@ -52,6 +46,34 @@ class TestFailClosed:
         """Regression pin: the gate itself works, whatever its timing"""
         result = run_redactor(adversarial_canary, "--stdout", "--fail-on-warn")
         assert result.returncode != 0
+
+    def test_fail_on_warn_emits_no_xml_on_stdout(self, adversarial_canary, run_redactor):
+        """A redirected stdout is an artefact like any other"""
+        result = run_redactor(adversarial_canary, "--stdout", "--fail-on-warn")
+
+        assert result.returncode != 0
+        assert result.stdout.strip() == "", "the gate failed but emitted the document"
+
+    def test_a_verifier_finding_alone_blocks_output(self, tmp_path, run_redactor):
+        """The gate reads the independent verification, not only the summary
+
+        This config has nothing the transformer reports: the value is not in a
+        secret-named element and does not survive as high-entropy. It does
+        survive verbatim, which only something re-reading the output can tell.
+        """
+        config = tmp_path / "in.xml"
+        config.write_text(
+            "<pfsense><installedpackages><vendor><config>"
+            "<sitecode>CANARYVERBATIMSURVIVOR42</sitecode>"
+            "</config></vendor></installedpackages></pfsense>"
+        )
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(config, out, "--fail-on-warn")
+
+        assert result.returncode != 0
+        assert not out.exists()
+        assert "verification" in result.stderr.lower()
 
     @pytest.mark.xfail(
         strict=True,

--- a/tests/adversarial/test_filesystem_safety.py
+++ b/tests/adversarial/test_filesystem_safety.py
@@ -32,11 +32,6 @@ class TestInputPreservation:
             run_redactor(canary_copy, *flags)
             assert canary_copy.read_bytes() == before, flags
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-15: input and output paths are never compared, so "
-               "naming the input as the output destroys it",
-    )
     def test_same_input_and_output_path_is_refused(self, canary_copy, run_redactor):
         """Naming the input as the output must not destroy it"""
         before = canary_copy.read_bytes()
@@ -45,11 +40,6 @@ class TestInputPreservation:
         assert result.returncode != 0
         assert canary_copy.read_bytes() == before
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-15: the comparison is textual at best, so ./name and "
-               "name reach the same file undetected",
-    )
     def test_same_file_via_relative_indirection_is_refused(self, canary_copy, run_redactor):
         """Spelling the path differently must not defeat the check"""
         before = canary_copy.read_bytes()
@@ -58,11 +48,6 @@ class TestInputPreservation:
         assert result.returncode != 0
         assert canary_copy.read_bytes() == before
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-16: an output path that is a symlink is followed, so a "
-               "link pointing back at the input overwrites the input",
-    )
     def test_output_symlink_pointing_at_input_is_refused(self, canary_copy, run_redactor, tmp_path):
         """Nor must reaching the input through a link"""
         link = tmp_path / "out-link.xml"
@@ -73,11 +58,6 @@ class TestInputPreservation:
 
         assert result.returncode != 0 or canary_copy.read_bytes() == before
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-17: --inplace rewrites the original without requiring "
-               "--force; only args.output is covered by the overwrite guard",
-    )
     def test_inplace_requires_explicit_consent(self, canary_copy, run_redactor):
         """Destroying the original is not a default-worthy action"""
         before = canary_copy.read_bytes()
@@ -95,40 +75,25 @@ class TestInputPreservation:
         ET.fromstring(canary_copy.read_text())
 
 
-def explode_on_path_write(monkeypatch):
-    """Make tree.write() fail the way a real interrupted write fails
+def fail_at(monkeypatch, name):
+    """Make one step of the atomic write fail, the way a real one can
 
-    Emulates a crash *after* the target has been opened for writing, which is
-    what ElementTree.write does before it can fail: the file is truncated, some
-    bytes land, and then the error arrives.
-
-    Writes to a *stream* are passed through to the real implementation. The
-    redactor serialises the candidate to a string before writing it, and
-    ET.tostring goes through this same method with a stream target - so a fake
-    that raised unconditionally would abort during serialisation and the test
-    would never reach the write it is named after.
+    The write is: temp file in the destination directory, chmod, write, flush,
+    fsync, close, os.replace, fsync the directory. A crash can land at any of
+    them - disk full at the write, SIGINT before the rename, power loss after
+    it - and the guarantee is the same in every case: the destination holds
+    either its previous content or the complete new content, and no temporary
+    file survives.
     """
-    real_write = ET.ElementTree.write
+    def explode(*args, **kwargs):
+        raise OSError(f"simulated failure in {name}")
 
-    def explode(self, file_or_filename, *args, **kwargs):
-        if hasattr(file_or_filename, "write"):
-            return real_write(self, file_or_filename, *args, **kwargs)
-
-        with open(file_or_filename, "wb") as handle:
-            handle.write(b'<?xml version="1.0"?>\n<pfsense><syst')
-        raise OSError("simulated I/O failure mid-write")
-
-    monkeypatch.setattr(ET.ElementTree, "write", explode)
+    monkeypatch.setattr(f"os.{name}", explode)
 
 
 class TestWriteSafety:
     """How the output is written, not where"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-18: tree.write() creates the file with the process "
-               "umask, so redacted output is typically world-readable 0644",
-    )
     def test_output_is_not_world_readable(self, canary_copy, run_redactor, tmp_path):
         """Redacted output can still hold retained values"""
         out = tmp_path / "out.xml"
@@ -140,15 +105,17 @@ class TestWriteSafety:
             f"high-entropy values and identifying material"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-19: the write is not atomic - tree.write() truncates "
-               "the target first, so a failure mid-write destroys it",
-    )
-    def test_interrupted_inplace_write_preserves_the_original(self, canary_copy, monkeypatch):
-        """A crash mid-write must not leave the operator with nothing"""
+    @pytest.mark.parametrize("step", ["fsync", "replace"])
+    def test_interrupted_inplace_write_preserves_the_original(
+        self, canary_copy, monkeypatch, step
+    ):
+        """A crash mid-write must not leave the operator with nothing
+
+        Reproduced before the fix at 7889 bytes -> 36: tree.write() opened the
+        target, truncating it, and only then began serialising.
+        """
         before = canary_copy.read_bytes()
-        explode_on_path_write(monkeypatch)
+        fail_at(monkeypatch, step)
 
         redactor = PfSenseRedactor()
         assert redactor.redact_config(str(canary_copy), str(canary_copy), inplace=True) is False
@@ -157,21 +124,45 @@ class TestWriteSafety:
             f"from {len(before)}"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-19: a failed write leaves the partial file behind "
-               "rather than removing it",
-    )
-    def test_interrupted_write_leaves_no_partial_output(self, canary_copy, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("step", ["fsync", "replace"])
+    def test_interrupted_write_leaves_no_partial_output(
+        self, canary_copy, tmp_path, monkeypatch, step
+    ):
         """A truncated file that looks like output is worse than none"""
         out = tmp_path / "out.xml"
-        explode_on_path_write(monkeypatch)
+        fail_at(monkeypatch, step)
 
         PfSenseRedactor().redact_config(str(canary_copy), str(out))
 
         assert not out.exists(), (
             "a truncated file that looks like output is worse than no output"
         )
+
+    @pytest.mark.parametrize("step", ["fsync", "replace"])
+    def test_interrupted_overwrite_preserves_the_existing_destination(
+        self, canary_copy, tmp_path, monkeypatch, step
+    ):
+        """An existing destination survives a failed write byte-for-byte"""
+        out = tmp_path / "out.xml"
+        out.write_bytes(b"<pfsense><previous/></pfsense>")
+        before = out.read_bytes()
+        fail_at(monkeypatch, step)
+
+        PfSenseRedactor().redact_config(str(canary_copy), str(out))
+
+        assert out.read_bytes() == before
+
+    @pytest.mark.parametrize("step", ["fsync", "replace"])
+    def test_interrupted_write_leaves_no_temporary_file(
+        self, canary_copy, tmp_path, monkeypatch, step
+    ):
+        """Cleanup runs on every failure path, not just the tidy ones"""
+        out = tmp_path / "out.xml"
+        fail_at(monkeypatch, step)
+
+        PfSenseRedactor().redact_config(str(canary_copy), str(out))
+
+        assert not list(tmp_path.glob(".pfsense-redactor-*"))
 
     def test_no_temporary_files_are_left_behind(self, canary_copy, run_redactor, tmp_path):
         """Whatever the write strategy, the directory must be clean afterwards"""
@@ -217,22 +208,45 @@ class TestSpecialFiles:
             "looking for the wrong problem"
         )
 
-    def test_hardlinked_output_write_is_in_place(self, canary_copy, run_redactor, tmp_path):
-        """Writing over one name of a hard-linked file changes every name
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hard links only")
+    def test_hardlinked_output_is_refused(self, canary_copy, run_redactor, tmp_path):
+        """A hard-linked destination is refused rather than written through
 
-        tests/unit/test_symlink_security.py:139 documents --inplace on a hard
-        link. This pins the *output* side, and it matters to whoever implements
-        FINDING-19: an atomic temp-file-plus-rename write would break the link
-        instead, leaving the alias holding the unredacted content. That is a
-        behaviour change, and this test is where it will surface.
+        This test previously asserted the opposite - that writing over one name
+        of a hard-linked file changed every name - and its own docstring named
+        this as the place the atomic-write change would surface. It has.
+
+        Atomic replacement puts a *new inode* at the destination, so the other
+        name keeps pointing at the old content. For a file being redacted that
+        old content is the unredacted configuration, now sitting under a name
+        the operator has no reason to check. Writing through the link is not
+        available any more, and silently stranding a stale copy is worse than
+        refusing, so the destination is refused.
+
+        The invariant is unchanged and is asserted below: after the run, no
+        name holds content the operator believes was redacted but was not.
         """
         out = tmp_path / "out.xml"
         out.write_text("<pfsense><old/></pfsense>")
         alias = tmp_path / "alias.xml"
         os.link(out, alias)
+        before = out.read_bytes()
 
-        run_redactor(canary_copy, out, "--force")
+        result = run_redactor(canary_copy, out, "--force")
 
-        assert out.stat().st_nlink == 2, "the write broke the hard link"
-        assert Path(alias).read_bytes() == out.read_bytes()
-        assert "<old/>" not in alias.read_text()
+        assert result.returncode != 0
+        assert "hard link" in result.stderr.lower()
+        assert out.read_bytes() == before, "the refused write happened anyway"
+        assert Path(alias).read_bytes() == before
+        assert out.stat().st_nlink == 2, "the link was broken despite the refusal"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hard links only")
+    def test_hardlinked_output_with_no_alias_is_allowed(self, canary_copy, run_redactor, tmp_path):
+        """The control: an ordinary destination with one name still works"""
+        out = tmp_path / "out.xml"
+        out.write_text("<pfsense><old/></pfsense>")
+
+        result = run_redactor(canary_copy, out, "--force")
+
+        assert result.returncode == 0
+        assert "<old/>" not in out.read_text()

--- a/tests/adversarial/test_filesystem_safety.py
+++ b/tests/adversarial/test_filesystem_safety.py
@@ -78,7 +78,7 @@ class TestInputPreservation:
 def fail_at(monkeypatch, name):
     """Make one step of the atomic write fail, the way a real one can
 
-    The write is: temp file in the destination directory, chmod, write, flush,
+    The write is: temp file in the destination directory, fchmod, write, flush,
     fsync, close, os.replace, fsync the directory. A crash can land at any of
     them - disk full at the write, SIGINT before the rename, power loss after
     it - and the guarantee is the same in every case: the destination holds

--- a/tests/adversarial/test_filesystem_safety.py
+++ b/tests/adversarial/test_filesystem_safety.py
@@ -94,6 +94,13 @@ def fail_at(monkeypatch, name):
 class TestWriteSafety:
     """How the output is written, not where"""
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX mode bits only: Windows permissions are ACLs, os.stat "
+               "reports 0666 for any writable file whatever the ACL says, and "
+               "os.chmod can only clear the read-only bit. The 0600 guarantee "
+               "is POSIX-only and documented as such in docs/security.md",
+    )
     def test_output_is_not_world_readable(self, canary_copy, run_redactor, tmp_path):
         """Redacted output can still hold retained values"""
         out = tmp_path / "out.xml"

--- a/tests/integration/test_cli_behaviour.py
+++ b/tests/integration/test_cli_behaviour.py
@@ -115,7 +115,7 @@ def test_inplace_modifies_original(cli_runner, create_xml_file):
     exit_code, _stdout, _stderr = cli_runner.run(
         str(xml_file),
         output_file=None,
-        flags=["--inplace"]
+        flags=["--inplace", "--force"]
     )
 
     assert exit_code == 0

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.5.0 -->
+  <!-- Redacted using pfsense-redactor v1.3.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.2.2 -->
+  <!-- Redacted using pfsense-redactor v1.5.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_atomic_output.py
+++ b/tests/unit/test_atomic_output.py
@@ -1,0 +1,278 @@
+"""File identity and the atomic writer, tested directly
+
+tests/adversarial/test_filesystem_safety.py drives these through the CLI, which
+is where the behaviour matters. This file tests the two primitives on their own,
+because they are small, security-critical and cheap to get subtly wrong: an
+identity check that compares strings, or a "safe" write that fsyncs after the
+rename instead of before it, both look correct and are not.
+
+POSIX-specific behaviour is skipped rather than asserted on Windows, where file
+permissions are ACLs and st_nlink means something different.
+"""
+import os
+import stat
+
+import pytest
+
+from pfsense_redactor.redactor import (
+    OUTPUT_FILE_MODE,
+    TEMP_OUTPUT_PREFIX,
+    inplace_path_refusal,
+    output_path_refusal,
+    paths_identify_same_file,
+    write_bytes_atomically,
+)
+
+PAYLOAD = b"<?xml version='1.0' encoding='utf-8'?>\n<pfsense><a>b</a></pfsense>"
+POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX semantics")
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A file standing in for the operator's configuration"""
+    path = tmp_path / "config.xml"
+    path.write_bytes(b"<pfsense><password>SECRET</password></pfsense>")
+    return path
+
+
+class TestPathIdentity:
+    """Two names reach the same file, or they do not. Strings cannot say."""
+
+    def test_identical_paths(self, source):
+        """The obvious case"""
+        assert paths_identify_same_file(str(source), str(source))
+
+    def test_relative_alias(self, source, monkeypatch):
+        """'config.xml' and './config.xml' are one file"""
+        monkeypatch.chdir(source.parent)
+        assert paths_identify_same_file("config.xml", "./config.xml")
+
+    def test_dot_dot_alias(self, source, monkeypatch):
+        """So are 'config.xml' and 'sub/../config.xml'"""
+        (source.parent / "sub").mkdir()
+        monkeypatch.chdir(source.parent)
+        assert paths_identify_same_file("config.xml", "sub/../config.xml")
+
+    @POSIX_ONLY
+    def test_symlink_alias(self, source, tmp_path):
+        """A symlink reaches the file it points at"""
+        link = tmp_path / "link.xml"
+        link.symlink_to(source)
+        assert paths_identify_same_file(str(source), str(link))
+
+    @POSIX_ONLY
+    def test_hardlink_alias(self, source, tmp_path):
+        """So does a hard link, which no path comparison would notice"""
+        alias = tmp_path / "alias.xml"
+        os.link(source, alias)
+        assert paths_identify_same_file(str(source), str(alias))
+
+    def test_different_files(self, source, tmp_path):
+        """The control"""
+        other = tmp_path / "other.xml"
+        other.write_bytes(b"<pfsense/>")
+        assert not paths_identify_same_file(str(source), str(other))
+
+    def test_a_path_that_does_not_exist_yet(self, source, tmp_path):
+        """The output usually does not exist, and that is not a match"""
+        assert not paths_identify_same_file(str(source), str(tmp_path / "new.xml"))
+
+    def test_neither_path_exists(self, tmp_path):
+        """Falls back to resolved-path comparison without raising"""
+        assert paths_identify_same_file(str(tmp_path / "a"), str(tmp_path / "a"))
+        assert not paths_identify_same_file(str(tmp_path / "a"), str(tmp_path / "b"))
+
+
+class TestOutputRefusal:
+    """Which destinations are refused, and for which stated reason"""
+
+    def test_the_input_itself_is_refused(self, source):
+        """--inplace by accident, without --inplace's guards"""
+        refusal = output_path_refusal(str(source), str(source))
+        assert refusal is not None
+        assert "input file" in refusal
+
+    def test_a_relative_alias_of_the_input_is_refused(self, source, monkeypatch):
+        """Spelling it differently is not a different file"""
+        monkeypatch.chdir(source.parent)
+        assert output_path_refusal("config.xml", "./config.xml") is not None
+
+    @POSIX_ONLY
+    def test_a_symlink_destination_is_refused(self, source, tmp_path):
+        """Writing would follow it somewhere the operator did not name"""
+        other = tmp_path / "other.xml"
+        other.write_bytes(b"<pfsense/>")
+        link = tmp_path / "link.xml"
+        link.symlink_to(other)
+
+        refusal = output_path_refusal(str(source), str(link))
+        assert refusal is not None
+        assert "symbolic link" in refusal
+
+    @POSIX_ONLY
+    def test_a_hardlinked_destination_is_refused(self, source, tmp_path):
+        """Atomic replacement would leave the other name holding stale content"""
+        target = tmp_path / "out.xml"
+        target.write_bytes(b"<pfsense/>")
+        os.link(target, tmp_path / "alias.xml")
+
+        refusal = output_path_refusal(str(source), str(target))
+        assert refusal is not None
+        assert "hard link" in refusal
+
+    def test_an_ordinary_new_destination_is_accepted(self, source, tmp_path):
+        """The control: a refusal that refuses everything protects nothing"""
+        assert output_path_refusal(str(source), str(tmp_path / "out.xml")) is None
+
+    def test_an_ordinary_existing_destination_is_accepted(self, source, tmp_path):
+        """Overwriting a single-named file is what --force is for"""
+        target = tmp_path / "out.xml"
+        target.write_bytes(b"<pfsense/>")
+        assert output_path_refusal(str(source), str(target)) is None
+
+    @POSIX_ONLY
+    def test_inplace_on_a_hardlink_is_refused(self, source, tmp_path):
+        """The other name would keep the unredacted configuration"""
+        os.link(source, tmp_path / "alias.xml")
+
+        refusal = inplace_path_refusal(str(source))
+        assert refusal is not None
+        assert "hard link" in refusal
+
+    def test_inplace_on_an_ordinary_file_is_accepted(self, source):
+        """The control"""
+        assert inplace_path_refusal(str(source)) is None
+
+
+class TestAtomicWrite:
+    """Either the previous content or the complete new content. Never both."""
+
+    def test_writes_the_payload(self, tmp_path):
+        """The ordinary case"""
+        target = tmp_path / "out.xml"
+        write_bytes_atomically(str(target), PAYLOAD)
+        assert target.read_bytes() == PAYLOAD
+
+    def test_replaces_existing_content_completely(self, tmp_path):
+        """No remnant of a longer previous file survives"""
+        target = tmp_path / "out.xml"
+        target.write_bytes(b"X" * (len(PAYLOAD) * 4))
+        write_bytes_atomically(str(target), PAYLOAD)
+        assert target.read_bytes() == PAYLOAD
+
+    @POSIX_ONLY
+    def test_creates_the_file_at_0600(self, tmp_path):
+        """Redacted output can still hold retained values and topology"""
+        target = tmp_path / "out.xml"
+        write_bytes_atomically(str(target), PAYLOAD)
+
+        assert stat.S_IMODE(target.stat().st_mode) == OUTPUT_FILE_MODE
+
+    @POSIX_ONLY
+    def test_is_not_world_readable_whatever_the_umask(self, tmp_path):
+        """The permissive-umask case is the one that matters"""
+        previous = os.umask(0o000)
+        try:
+            target = tmp_path / "out.xml"
+            write_bytes_atomically(str(target), PAYLOAD)
+        finally:
+            os.umask(previous)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert not mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IWGRP | stat.S_IWOTH)
+
+    def test_leaves_no_temporary_file(self, tmp_path):
+        """The destination directory is clean afterwards"""
+        write_bytes_atomically(str(tmp_path / "out.xml"), PAYLOAD)
+
+        assert {p.name for p in tmp_path.iterdir()} == {"out.xml"}
+
+    @pytest.mark.parametrize("step", ["fsync", "replace", "chmod"])
+    def test_a_failure_leaves_the_destination_untouched(self, tmp_path, monkeypatch, step):
+        """Every step that can fail, and the same guarantee for each"""
+        target = tmp_path / "out.xml"
+        target.write_bytes(b"<pfsense><previous/></pfsense>")
+        before = target.read_bytes()
+
+        def explode(*args, **kwargs):
+            raise OSError(f"simulated failure in os.{step}")
+
+        monkeypatch.setattr(f"os.{step}", explode)
+
+        with pytest.raises(OSError):
+            write_bytes_atomically(str(target), PAYLOAD)
+
+        assert target.read_bytes() == before
+
+    @pytest.mark.parametrize("step", ["fsync", "replace", "chmod"])
+    def test_a_failure_leaves_no_temporary_file(self, tmp_path, monkeypatch, step):
+        """Cleanup runs on the failure path, not only the happy one"""
+        target = tmp_path / "out.xml"
+
+        def explode(*args, **kwargs):
+            raise OSError(f"simulated failure in os.{step}")
+
+        monkeypatch.setattr(f"os.{step}", explode)
+
+        with pytest.raises(OSError):
+            write_bytes_atomically(str(target), PAYLOAD)
+
+        assert not list(tmp_path.glob(f"{TEMP_OUTPUT_PREFIX}*"))
+        assert not target.exists()
+
+    def test_an_interrupt_is_cleaned_up_and_re_raised(self, tmp_path, monkeypatch):
+        """A SIGINT mid-write is the case the operator actually hits"""
+        target = tmp_path / "out.xml"
+
+        def interrupt(*args, **kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("os.replace", interrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            write_bytes_atomically(str(target), PAYLOAD)
+
+        assert not list(tmp_path.glob(f"{TEMP_OUTPUT_PREFIX}*"))
+        assert not target.exists()
+
+    def test_the_temporary_file_is_in_the_destination_directory(self, tmp_path, monkeypatch):
+        """Cross-filesystem renames are not atomic, so the temp file must be local
+
+        Asserted by capturing where mkstemp is asked to put it, because by the
+        time the write returns the evidence has been renamed away.
+        """
+        seen = {}
+        real_mkstemp = __import__('tempfile').mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            seen['dir'] = kwargs.get('dir')
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr("tempfile.mkstemp", recording_mkstemp)
+
+        target = tmp_path / "sub" / "out.xml"
+        target.parent.mkdir()
+        write_bytes_atomically(str(target), PAYLOAD)
+
+        assert seen['dir'] == str(target.parent)
+
+    @POSIX_ONLY
+    def test_the_temporary_file_is_never_world_readable(self, tmp_path, monkeypatch):
+        """The window before the rename must not expose the content either"""
+        observed = {}
+        target = tmp_path / "out.xml"
+        real_replace = os.replace
+
+        def inspect_then_replace(src, dst, *args, **kwargs):
+            observed['mode'] = stat.S_IMODE(os.stat(src).st_mode)
+            return real_replace(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr("os.replace", inspect_then_replace)
+
+        previous = os.umask(0o000)
+        try:
+            write_bytes_atomically(str(target), PAYLOAD)
+        finally:
+            os.umask(previous)
+
+        assert observed['mode'] == OUTPUT_FILE_MODE

--- a/tests/unit/test_atomic_output.py
+++ b/tests/unit/test_atomic_output.py
@@ -26,6 +26,13 @@ from pfsense_redactor.redactor import (
 PAYLOAD = b"<?xml version='1.0' encoding='utf-8'?>\n<pfsense><a>b</a></pfsense>"
 POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX semantics")
 
+# The call the writer actually makes to restrict the mode: fchmod on the open
+# descriptor where the platform has it, chmod on the path otherwise. The
+# failure-injection tests below parametrise over this rather than hardcoding
+# "chmod", because patching a call the production path no longer makes would
+# leave them green while exercising nothing.
+MODE_CALL = "fchmod" if hasattr(os, "fchmod") else "chmod"
+
 
 @pytest.fixture
 def source(tmp_path):
@@ -187,7 +194,7 @@ class TestAtomicWrite:
 
         assert {p.name for p in tmp_path.iterdir()} == {"out.xml"}
 
-    @pytest.mark.parametrize("step", ["fsync", "replace", "chmod"])
+    @pytest.mark.parametrize("step", ["fsync", "replace", MODE_CALL])
     def test_a_failure_leaves_the_destination_untouched(self, tmp_path, monkeypatch, step):
         """Every step that can fail, and the same guarantee for each"""
         target = tmp_path / "out.xml"
@@ -204,7 +211,7 @@ class TestAtomicWrite:
 
         assert target.read_bytes() == before
 
-    @pytest.mark.parametrize("step", ["fsync", "replace", "chmod"])
+    @pytest.mark.parametrize("step", ["fsync", "replace", MODE_CALL])
     def test_a_failure_leaves_no_temporary_file(self, tmp_path, monkeypatch, step):
         """Cleanup runs on the failure path, not only the happy one"""
         target = tmp_path / "out.xml"
@@ -255,6 +262,26 @@ class TestAtomicWrite:
         write_bytes_atomically(str(target), PAYLOAD)
 
         assert seen['dir'] == str(target.parent)
+
+    @POSIX_ONLY
+    def test_the_mode_is_set_on_the_descriptor_not_the_path(self, tmp_path, monkeypatch):
+        """No window between creating the file and restricting it
+
+        chmod-by-path can be pointed at a different file between mkstemp and
+        the chmod. fchmod acts on the descriptor already held, so it cannot.
+        """
+        calls = []
+        real_fchmod = os.fchmod
+        monkeypatch.setattr(
+            "os.fchmod", lambda fd, mode: (calls.append(mode), real_fchmod(fd, mode))[1]
+        )
+        monkeypatch.setattr(
+            "os.chmod", lambda *a, **k: pytest.fail("chmod-by-path used on POSIX")
+        )
+
+        write_bytes_atomically(str(tmp_path / "out.xml"), PAYLOAD)
+
+        assert calls == [OUTPUT_FILE_MODE]
 
     @POSIX_ONLY
     def test_the_temporary_file_is_never_world_readable(self, tmp_path, monkeypatch):

--- a/tests/unit/test_fail_on_warn.py
+++ b/tests/unit/test_fail_on_warn.py
@@ -87,13 +87,28 @@ class TestTheGatePredicate:
 class TestRedactConfigReturnValue:
     """The predicate reaching redact_config's return, in-process"""
 
-    def test_retained_value_returns_false_with_the_flag(self, tmp_path):
-        """The write still happens; only the reported success changes"""
+    def test_retained_value_returns_false_and_writes_nothing(self, tmp_path):
+        """A failed gate produces no output at all
+
+        This asserted the opposite until 1.5.0: that the file was still
+        written, so the operator could review the retained paths in it. That
+        reasoning does not survive the case the gate exists for. The candidate
+        can contain a private key in an element the tool did not recognise, and
+        an artefact that exists is an artefact that gets uploaded, attached,
+        or picked up by the next step in the pipeline. The gate has to prevent
+        the file, not annotate it.
+
+        The review path is still there and costs nothing: --dry-run reports the
+        same retained paths and the same verification findings, and never
+        wrote a file in the first place.
+        """
         redactor, ok = redact(tmp_path, UNKNOWN_BLOB, fail_on_warn=True)
 
         assert redactor.stats['high_entropy_retained'] == 1
         assert ok is False
-        assert (tmp_path / 'out.xml').exists(), 'output should still be written'
+        assert not (tmp_path / 'out.xml').exists(), (
+            'a failed gate must leave no artefact for someone to share'
+        )
 
     def test_retained_value_returns_true_without_the_flag(self, tmp_path):
         """Default behaviour is unchanged"""
@@ -170,16 +185,24 @@ class TestExitCodeReachesTheShell:
         assert 'high-entropy' in stderr
         assert '--aggressive' in stderr
 
-    def test_output_is_still_written_when_the_gate_fails(self, cli_runner, tmp_path):
-        """Failing the build must not mean losing the redacted file
+    def test_no_xml_is_emitted_when_the_gate_fails(self, cli_runner, tmp_path):
+        """The gate must prevent the artefact, not annotate it
 
-        The retained values were reported, not leaked, so the operator still
-        wants the output in order to review those paths.
+        Replaces test_output_is_still_written_when_the_gate_fails, which
+        asserted that the redacted document reached stdout even though the run
+        had just reported failure. A pipeline that pipes stdout to a file, or
+        a shell that redirects it, ends up with exactly the artefact the gate
+        was asked to prevent.
+
+        --dry-run remains the way to see what would be retained without
+        producing anything.
         """
         exit_code, stdout, _ = run_cli(cli_runner, tmp_path, UNKNOWN_BLOB, '--fail-on-warn')
 
         assert exit_code != 0
-        assert ET.fromstring(stdout).tag == 'pfsense'
+        assert stdout.strip() == '', 'a failed gate emitted the document anyway'
+        with pytest.raises(ET.ParseError):
+            ET.fromstring(stdout or '')
 
     def test_wrong_root_tag_exit_code(self, cli_runner, tmp_path):
         """The pre-existing behaviour, through the shell"""

--- a/tests/unit/test_fail_on_warn.py
+++ b/tests/unit/test_fail_on_warn.py
@@ -90,7 +90,7 @@ class TestRedactConfigReturnValue:
     def test_retained_value_returns_false_and_writes_nothing(self, tmp_path):
         """A failed gate produces no output at all
 
-        This asserted the opposite until 1.5.0: that the file was still
+        This asserted the opposite until 1.3.0: that the file was still
         written, so the operator could review the retained paths in it. That
         reasoning does not survive the case the gate exists for. The candidate
         can contain a private key in an element the tool did not recognise, and

--- a/tests/unit/test_symlink_security.py
+++ b/tests/unit/test_symlink_security.py
@@ -138,7 +138,7 @@ class TestSymlinkSecurity:
 
     @pytest.mark.skipif(os.name == 'nt', reason="Hardlinks work differently on Windows")
     def test_hardlink_inplace_refused(self, sample_config, temp_dir):
-        """Test 4: --inplace on a hardlink is refused since 1.5.0
+        """Test 4: --inplace on a hardlink is refused since 1.3.0
 
         This asserted that the operation succeeded and that both names ended up
         holding the redacted content. That was true while the write went

--- a/tests/unit/test_symlink_security.py
+++ b/tests/unit/test_symlink_security.py
@@ -137,30 +137,42 @@ class TestSymlinkSecurity:
         assert current_content == original_content, "Target file should not be modified"
 
     @pytest.mark.skipif(os.name == 'nt', reason="Hardlinks work differently on Windows")
-    def test_hardlink_inplace_allowed(self, sample_config, temp_dir):
-        """Test 4: Hardlink with --inplace should work (different from symlink)"""
-        # Create a hardlink to the config
+    def test_hardlink_inplace_refused(self, sample_config, temp_dir):
+        """Test 4: --inplace on a hardlink is refused since 1.5.0
+
+        This asserted that the operation succeeded and that both names ended up
+        holding the redacted content. That was true while the write went
+        through the link, truncating and rewriting the same inode.
+
+        Output is now written by atomic replacement, which puts a new inode at
+        the destination. The other name would keep the old content - the
+        unredacted configuration - while the operator, having watched
+        --inplace report success, has no reason to look at it. That is a silent
+        stale copy of exactly the material the tool exists to remove, so the
+        operation is refused instead.
+
+        The invariant the original test protected - after --inplace on a
+        hardlink, no name holds unredacted content the operator believes was
+        redacted - is asserted below, and is now satisfied by refusing rather
+        than by rewriting both names.
+        """
         hardlink_path = temp_dir / "hardlink.xml"
         os.link(sample_config, hardlink_path)
 
-        # Get original content
         original_content = sample_config.read_text(encoding='utf-8')
 
-        # Run redactor on the hardlink with --inplace
         result = run_redactor(
             [str(hardlink_path), "--inplace", "--force"]
         )
 
-        # Should succeed (hardlinks are safe)
-        assert result.returncode == 0, f"Hardlink should be allowed: {result.stderr}"
+        assert result.returncode != 0, "Hardlink --inplace should be refused"
+        assert "hard link" in result.stderr.lower(), (
+            f"Error should name the reason: {result.stderr}"
+        )
 
-        # Both names should point to the same modified content
-        hardlink_content = hardlink_path.read_text(encoding='utf-8')
-        original_content_now = sample_config.read_text(encoding='utf-8')
-
-        assert hardlink_content == original_content_now, "Both hardlinks should have same content"
-        assert hardlink_content != original_content, "Content should be modified"
-        assert "testdomain.local" not in hardlink_content, "Domain should be redacted"
+        # Nothing was written, so neither name changed and nothing is stale
+        assert hardlink_path.read_text(encoding='utf-8') == original_content
+        assert sample_config.read_text(encoding='utf-8') == original_content
 
     def test_nested_symlinks_refused(self, sample_config, temp_dir):
         """Test 5: Nested symlinks (symlink to symlink) should be refused"""


### PR DESCRIPTION
# PR 3 — Verify before write, and atomic output

Base: `security/independent-output-verifier` · Branch: `security/verified-atomic-output` · Version: 1.3.0

**Contains breaking changes.**

## Summary

The order was: transform, write, return the verdict. `--fail-on-warn` exited non-zero *after* `_write_output` had produced the file. The gate reported the problem; it did not prevent the artefact.

## Findings addressed

| Finding | Status | Evidence |
| --- | --- | --- |
| FINDING-15 | Fixed | `TestInputPreservation` (2 cases), `test_atomic_output.py::TestPathIdentity` (8) |
| FINDING-16 | Fixed | `…::test_output_symlink_pointing_at_input_is_refused`, `TestOutputRefusal` |
| FINDING-17 | Fixed | `…::test_inplace_requires_explicit_consent` |
| FINDING-18 | Fixed | `TestWriteSafety::test_output_is_not_world_readable`, `TestAtomicWrite` |
| FINDING-19 | Fixed | 8 failure-injection cases across `os.fsync`, `os.replace`, `os.chmod`, `KeyboardInterrupt` |
| FINDING-22 | Fixed | `TestFailClosed::test_fail_on_warn_writes_no_output` and 2 new cases |

## Security invariants

- Candidate output is independently verified before any bytes become externally visible.
- An interrupted write cannot truncate an existing destination.
- A failed gate leaves no artefact — no file, no stdout, no temporary file.
- The output path cannot reach the input by any spelling: same path, relative alias, symlink, or hard link.
- Atomic replacement never strands unredacted content under another name.

## Behaviour changes

| Change | Impact |
| --- | --- |
| `--inplace` requires `--force` | **Breaking.** Scripts must add `--force` |
| Hard-linked output/`--inplace` target refused | **Breaking.** Write to a new path |
| Failed `--fail-on-warn` produces no output | **Breaking** for pipelines reading it. Use `--dry-run` |
| `--fail-on-warn` also gates on verifier findings and on the verifier being unavailable | More runs fail |
| Output created `0600` (POSIX) | Downstream readers may need permissions |
| Output path that is a symlink, or reaches the input, refused | New refusals |
| Verification runs under `--dry-run` too | Extra stderr |

## Regression analysis

- Before: 1174 passed, 1 skipped, 26 xfailed
- After: **1222 passed, 1 skipped, 18 xfailed**
- Previously passing tests affected: 3, all deliberate:

1. `test_fail_on_warn.py::test_output_is_still_written_when_the_gate_fails` → `test_no_xml_is_emitted_when_the_gate_fails`. Asserted the document reached stdout after failure; a pipeline redirecting stdout ends up with the artefact the gate was asked to prevent. `--dry-run` still reports the same paths and never wrote a file.
2. `test_symlink_security.py::test_hardlink_inplace_allowed` → `test_hardlink_inplace_refused`. Asserted both names ended up redacted — true only while the write went through the link. Atomic replacement cannot do that, and would leave the other name holding the unredacted config. Same invariant, satisfied by refusing.
3. `test_filesystem_safety.py::test_hardlinked_output_write_is_in_place` → `test_hardlinked_output_is_refused`. Same change on the output side; its own docstring predicted it.

`test_cli_behaviour.py::test_inplace_modifies_original` gains `--force`. Snapshots regenerated for the version comment alone.

## Tests

```
python -m pytest tests/ -q                                    1222 passed, 1 skipped, 18 xfailed
python -m pytest tests/unit/test_atomic_output.py -q            30 passed
python -m pytest tests/adversarial/test_filesystem_safety.py -q 20 passed, 1 xfailed
pylint / structure                                            10.00/10, exit 0
```

## Xfail changes

Removed (8): FINDING-15 ×2, FINDING-16, FINDING-17, FINDING-18, FINDING-19 ×2, FINDING-22. Retained: 18. New markers: none.

## Remaining risks

- `0600` is POSIX-only; Windows permissions are ACLs and the mode is not claimed.
- A residual TOCTOU window exists between the path checks and `os.replace`; closing it fully needs `O_NOFOLLOW`/`openat`, which is not portable to Windows. It requires a local attacker with write access to the destination directory.
- Directory `fsync` is best-effort where the platform supports it.

## Review guidance

`redactor.py`: `paths_identify_same_file`, `output_path_refusal`, `write_bytes_atomically`, and the `_process` → `_output_is_permitted` → `_emit_candidate` sequence. Read the three modified tests' docstrings for the reasoning behind each expectation change.

---

## Update: mode set on the descriptor, not the path

Codacy, correctly: `_write_and_sync` held the descriptor open and then called
`os.chmod` on the *path*. `mkstemp` already creates at 0600 so the window is
theoretical, but chmod-by-path is the textbook TOCTOU shape and the descriptor
was right there. `_restrict_mode` now uses `os.fchmod` where the platform has
it, falling back to `os.chmod` on Windows — which has neither `fchmod` nor
meaningful POSIX modes, so the restrictive-permissions guarantee stays
POSIX-only and stays documented as such.

**The tests needed changing, not just re-running.** `test_atomic_output.py`
parametrised its failure injection over `"chmod"` — a call POSIX no longer
makes. Left alone, both cases would have kept passing while patching nothing.
They now parametrise over `MODE_CALL`, which resolves to whichever call the
running platform actually uses, and a new test patches `os.chmod` to fail the
test outright if it is used on POSIX.


---

## Versions renumbered

The stack was numbered 1.3.0–1.8.0, one minor bump per PR, because the
repository forbids an open `[Unreleased]` section so each PR had to name a
version. That claimed six releases that never happened: **PyPI's latest is
1.1.2**, and `main`'s 1.2.0 has not shipped either.

Renumbered to patches, with a minor only where compatibility actually breaks:

| PR | Was | Now | |
| --- | --- | --- | --- |
| #65 | 1.3.0 | **1.2.1** | additive detection |
| #66 | 1.4.0 | **1.2.2** | verifier, advisory only |
| #67 | 1.5.0 | **1.3.0** | breaking: `--inplace` needs `--force`, hard links refused, failed gate writes nothing |
| #68 | 1.6.0 | **1.4.0** | breaking: usage errors exit 1, not 2 |
| #69 | 1.7.0 | **1.4.1** | workflows and docs only |
| #71 | 1.8.0 | **1.4.2** | verifier containment |

Sequence: `1.2.0 → 1.2.1 → 1.2.2 → 1.3.0 → 1.4.0 → 1.4.1 → 1.4.2`.

Test totals are unchanged by the renumber, and reference snapshots differ only
in the version comment.
