### PR TITLE
Strict public-sharing mode, distinct exit codes and a JSON assurance report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,15 +71,7 @@ needs to check a sharing decision without reading prose on stderr.
 
 - **A wrong root element aborts under `--strict` as well as `--fail-on-warn`.**
 
-### Documentation
-
-- `docs/benchmark.md` now states which mode the published score refers to, gives
-  the decode-aware counts alongside the literal ones, and says plainly that the
-  default-mode figure is a literal-marker count. (FINDING-27, documentation part)
-
-- `docs/security.md` distinguishes redaction, identifier anonymisation,
-  independent verification and third-party scanning, and separates default,
-  `--aggressive` and `--strict` by what each refuses.
+### Fixed
 
 - **A document too deep to traverse fully now fails closed in every mode.**
   `redact_element` stops descending at 400 elements and counted that it had;
@@ -99,6 +91,16 @@ needs to check a sharing decision without reading prose on stderr.
   `--force`, `--strict` with `--inplace`, and `--quiet` with `--verbose` went
   through `argparse.error` and exited 2. `argparse` still exits 2 for a command
   line it cannot parse itself, such as an unknown flag.
+
+### Documentation
+
+- `docs/benchmark.md` now states which mode the published score refers to, gives
+  the decode-aware counts alongside the literal ones, and says plainly that the
+  default-mode figure is a literal-marker count. (FINDING-27, documentation part)
+
+- `docs/security.md` distinguishes redaction, identifier anonymisation,
+  independent verification and third-party scanning, and separates default,
+  `--aggressive` and `--strict` by what each refuses.
 
 **Action required:** none for existing invocations. `--strict` and
 `--report-json` are new. Scripts testing only for a non-zero exit are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,29 @@ needs to check a sharing decision without reading prose on stderr.
   independent verification and third-party scanning, and separates default,
   `--aggressive` and `--strict` by what each refuses.
 
+- **A document too deep to traverse fully now fails closed in every mode.**
+  `redact_element` stops descending at 400 elements and counted that it had;
+  nothing read the counter. The structural check normally refuses such a
+  document first, so this was not reachable through the CLI — but a run that
+  stopped early would have emitted elements it never examined, and reported
+  success. Refused with exit code 2, no output, in every mode rather than only
+  under a gate.
+
+- **The JSON report distinguishes a failed run from a dirty configuration.**
+  `verdict` was `"findings"` for I/O and internal failures as well as for
+  retained material, so a pipeline reading it concluded the configuration
+  still held secrets when the disk was full. Those now report `"error"`.
+  Values are `clean`, `rejected`, `findings`, `error`.
+
+- **The tool's own usage errors exit 1, as documented.** `--inplace` without
+  `--force`, `--strict` with `--inplace`, and `--quiet` with `--verbose` went
+  through `argparse.error` and exited 2. `argparse` still exits 2 for a command
+  line it cannot parse itself, such as an unknown flag.
+
 **Action required:** none for existing invocations. `--strict` and
-`--report-json` are new; scripts that test only for a non-zero exit are
-unaffected by the new codes.
+`--report-json` are new. Scripts testing only for a non-zero exit are
+unaffected; a script matching the exact value **2** for a usage error should
+match **1** instead.
 
 ## [1.3.0][] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,86 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0][] - 2026-08-05
+
+A mode for output intended to be read by anyone, and the machinery a caller
+needs to check a sharing decision without reading prose on stderr.
+
+### Added
+
+- **`--strict`, a fail-closed mode for public sharing.** It implies
+  `--aggressive` and `--redact-descriptions`, runs the independent verifier, and
+  **produces no output at all** - no file, no XML on stdout, no temporary file -
+  when anything is retained or found, or when the verifier could not run. It
+  ignores allow-list files found in the working directory or home directory and
+  says so; refuses `--inplace`; and rejects rather than warns about an
+  unsupported root element, a configuration schema version outside the range
+  this tool has been exercised against, a document nesting more than 400
+  elements deep, and any element too large to process. (FINDING-25)
+
+  Strict mode is a mode with no silent failure path. It is not described as
+  certified, audit-grade, complete or suitable for every package schema,
+  because it is none of those; `docs/security.md` states what it does not
+  establish.
+
+- **`--report-json PATH`, a machine-readable assurance report.** Paths, kinds,
+  lengths, counts and a verdict. Never a retained value, a prefix of one,
+  decoded content, a full credential-bearing URL, or a hash of a secret - a
+  short secret's hash is brute-forceable. Written on failure as well as on
+  success, through the same atomic `0600` writer as the XML. Works in every
+  mode, not only under `--strict`. (FINDING-26)
+
+- **Distinct exit codes.** `0` clean, `1` usage error, `2` input rejected, `3`
+  sensitive value retained, `4` verifier finding, `5` I/O failure, `6` internal
+  failure. Previously only `0` and `1` were used, so a CI job could not tell
+  "this file is not parseable" from "this file still has secrets" from "the
+  disk is full". Every non-zero value is still non-zero, so an integration that
+  only tests for success is unaffected. `argparse` still exits `2` of its own
+  accord for a malformed command line; the overlap is documented rather than
+  hidden. (FINDING-23)
+
+### Security
+
+- **Allow-list sources are announced in every mode.** The notice was printed
+  only when *not* `--dry-run` and *not* `--stdout` - the two modes most likely
+  to be scripted - so running the tool inside a repository checkout or a CI
+  workspace could weaken redaction with nothing in the run saying so.
+  (FINDING-25)
+
+- **Nesting is bounded at 400 elements.** Deeper documents are refused with a
+  diagnosis instead of reaching the interpreter's recursion limit and arriving
+  at the shell as a traceback with interpreter paths in it. Depth is measured
+  iteratively, because recursing over the document is what fails. (FINDING-13)
+
+- **Text over the 1 MiB element limit is replaced, not trimmed, and the run is
+  refused.** Truncating discarded 151,424 characters of a 1,200,000-character
+  element and reported success. Refused in every mode, not only under a gate:
+  output that silently lacks part of the configuration misrepresents itself.
+  (FINDING-14)
+
+- **The configuration's own `<version>` is inspected and reported.** Redaction
+  is name-driven, so an unfamiliar schema is exactly where coverage is weakest,
+  and an operator deciding whether to share is entitled to know. Reported as a
+  warning outside strict mode; a refusal inside it. Only the root's own
+  `<version>` is read, so a package version is never mistaken for the schema.
+  (FINDING-24)
+
+- **A wrong root element aborts under `--strict` as well as `--fail-on-warn`.**
+
+### Documentation
+
+- `docs/benchmark.md` now states which mode the published score refers to, gives
+  the decode-aware counts alongside the literal ones, and says plainly that the
+  default-mode figure is a literal-marker count. (FINDING-27, documentation part)
+
+- `docs/security.md` distinguishes redaction, identifier anonymisation,
+  independent verification and third-party scanning, and separates default,
+  `--aggressive` and `--strict` by what each refuses.
+
+**Action required:** none for existing invocations. `--strict` and
+`--report-json` are new; scripts that test only for a non-zero exit are
+unaffected by the new codes.
+
 ## [1.3.0][] - 2026-08-05
 
 Verify, then write. Until now the write happened first and the verdict was
@@ -848,6 +928,7 @@ pfsense-redactor config.xml --anonymise
 pfsense-redactor config.xml --dry-run-verbose
 ```
 
+[1.4.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.4.0
 [1.3.0]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.3.0
 [1.2.2]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.2
 [1.2.1]: https://github.com/grounzero/pfsense-redactor/releases/tag/1.2.1

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -25,6 +25,41 @@ release at the time of testing.
 The corpus file has not changed since those two tools were scored against it.
 This tool's number moved because the tool changed, not because the test did.
 
+## Which mode the score refers to
+
+The published figure is an **`--aggressive`** result. That matters, because the
+survivor count is produced by a literal `CANARY_[A-Z0-9_]+` search over the
+output, and a marker the corpus author encoded is invisible to it.
+
+Under decode-aware scanning — `tests/adversarial/decode_scan.py`, which follows
+Base64 layers — the shipped corpus scores:
+
+```text
+default mode:      5 markers survive
+aggressive mode:   2 markers survive  (the two documented below)
+```
+
+So the headline number is honest: under decode-aware scanning, `--aggressive`
+leaves exactly the two documented survivors. What the literal count cannot
+support is the *default-mode* figure, where an encoded marker survives
+uncounted. Any default-mode number quoted in this project should be read as a
+literal-marker count, not a decode-aware one.
+
+`--strict` closes this differently: it does not count markers at all. Either the
+material is removed, or no output is produced.
+
+Reproduce either measurement:
+
+```bash
+# literal, the published method
+pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
+  | grep -oE 'CANARY_[A-Z0-9_]+' | sort -u
+
+# decode-aware
+pfsense-redactor tests/corpus/canary-corpus.xml --stdout --aggressive \
+  | python tests/adversarial/decode_scan.py
+```
+
 ## Read this before quoting the numbers
 
 **The corpus was built alongside pfsense-redactor.** It grew out of bug reports

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -104,6 +104,100 @@ the unredacted content.
 | `--force`                | Overwrite output file if it already exists; also the required consent for `--inplace`                   |
 | `--allow-absolute-paths` | Allow absolute file paths (relative paths only by default for security)                                 |
 
+### Assurance
+
+| Flag             | Description                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `--fail-on-warn` | Exit non-zero, and produce no output, if the root tag is wrong, values were retained, or verification found anything |
+| `--strict`       | Fail-closed mode for output intended for public sharing. See below                                              |
+| `--report-json`  | Write a machine-readable assurance report. Paths, kinds, lengths and counts only — never a value                 |
+
+#### `--strict`
+
+Intended for output that may be read by anyone, indefinitely. It is a mode with
+no silent failure path, not a guarantee of safety — see
+[security](security.md#strict-mode) for what it does and does not establish.
+
+Strict mode:
+
+- implies `--aggressive` and `--redact-descriptions`
+- runs the independent verifier and **produces no output at all** if it finds
+  anything, or if it could not run
+- ignores allow-list files found in the working directory or home directory,
+  and says so; `--allowlist-file` is the only way in
+- refuses `--inplace`, an unsupported root element, a configuration schema
+  version outside the range the tool has been exercised against, a document
+  nesting more than 400 elements deep, and any element too large to process
+- writes through the same atomic `0600` writer as every other mode
+
+```bash
+pfsense-redactor config.xml public.xml --strict --report-json report.json
+```
+
+### Exit codes
+
+Every non-zero value is still non-zero, so an integration that only tests for
+success is unaffected.
+
+| Code | Meaning                                                                    |
+| ---- | -------------------------------------------------------------------------- |
+| 0    | Clean output produced                                                      |
+| 1    | Usage error — the command line asks for something incoherent               |
+| 2    | Input rejected: unparseable, unsupported schema, too deeply nested, oversized |
+| 3    | A sensitive value was retained (under `--fail-on-warn` or `--strict`)      |
+| 4    | Independent verification found something, or could not run                 |
+| 5    | Reading or writing a file failed                                           |
+| 6    | Internal processing failure                                                |
+
+`argparse` exits **2** of its own accord for a malformed command line — an
+unknown flag, a missing positional — which is the same value as *input
+rejected*. Both mean "what you gave me cannot be used", they are
+distinguishable from stderr, and suppressing argparse's convention would be
+worse than the overlap.
+
+### Report schema
+
+```json
+{
+  "schema_version": 1,
+  "tool": {"name": "pfsense-redactor", "version": "1.6.0"},
+  "input": {"sha256": "…", "bytes": 48213, "root_tag": "pfsense",
+            "config_version": "23.1", "config_version_supported": true},
+  "mode": {"strict": true, "aggressive": true, "redact_descriptions": true,
+           "anonymise": false, "fail_on_warn": false, "dry_run": false,
+           "allowlist_files": []},
+  "verdict": "clean",
+  "verification": {"available": true, "clean": true},
+  "counts": {"secrets_redacted": 42, "certificates_redacted": 6,
+             "ips_redacted": 18, "domains_redacted": 9,
+             "identifiers_anonymised": 0, "high_entropy_retained": 0,
+             "oversized_text": 0, "verifier_findings": 0},
+  "retained": [],
+  "findings": [],
+  "exit_code": 0
+}
+```
+
+A finding looks like:
+
+```json
+{"id": "retained-private-key",
+ "path": "pfsense/installedpackages/example/vendorblob",
+ "kind": "pem-private-key",
+ "length": 1679}
+```
+
+The report never contains a retained value, a prefix of one, decoded content, a
+full credential-bearing URL, or a hash of a secret. A short secret's hash is
+brute-forceable, so publishing one publishes the secret.
+
+The `sha256` under `input` is a digest of the **input file**, which the operator
+already has. It identifies which file the report describes.
+
+Reports are written through the same atomic `0600` writer as the XML, and are
+written on failure as well as on success — a run that withheld output is exactly
+when a caller needs to know why.
+
 ### Redaction Modes
 
 | Flag                     | Description                                                                                                                                        |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -160,7 +160,7 @@ worse than the overlap.
 ```json
 {
   "schema_version": 1,
-  "tool": {"name": "pfsense-redactor", "version": "1.6.0"},
+  "tool": {"name": "pfsense-redactor", "version": "1.4.0"},
   "input": {"sha256": "…", "bytes": 48213, "root_tag": "pfsense",
             "config_version": "23.1", "config_version_supported": true},
   "mode": {"strict": true, "aggressive": true, "redact_descriptions": true,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -142,18 +142,20 @@ success is unaffected.
 | Code | Meaning                                                                    |
 | ---- | -------------------------------------------------------------------------- |
 | 0    | Clean output produced                                                      |
-| 1    | Usage error — the command line asks for something incoherent               |
+| 1    | Usage error — the command line parsed, and asks for something incoherent    |
 | 2    | Input rejected: unparseable, unsupported schema, too deeply nested, oversized |
 | 3    | A sensitive value was retained (under `--fail-on-warn` or `--strict`)      |
 | 4    | Independent verification found something, or could not run                 |
 | 5    | Reading or writing a file failed                                           |
 | 6    | Internal processing failure                                                |
 
-`argparse` exits **2** of its own accord for a malformed command line — an
-unknown flag, a missing positional — which is the same value as *input
-rejected*. Both mean "what you gave me cannot be used", they are
-distinguishable from stderr, and suppressing argparse's convention would be
-worse than the overlap.
+The tool's own usage errors — `--inplace` without `--force`, `--strict` with
+`--inplace`, `--quiet` with `--verbose` — exit **1**.
+
+`argparse` exits **2** of its own accord for a command line it cannot parse at
+all, such as an unknown flag. That is the same value as *input rejected*. Both
+mean "what you gave me cannot be used", they are distinguishable from stderr,
+and overriding argparse's convention would be worse than the overlap.
 
 ### Report schema
 
@@ -166,7 +168,7 @@ worse than the overlap.
   "mode": {"strict": true, "aggressive": true, "redact_descriptions": true,
            "anonymise": false, "fail_on_warn": false, "dry_run": false,
            "allowlist_files": []},
-  "verdict": "clean",
+  "verdict": "clean",           // clean | rejected | findings | error
   "verification": {"available": true, "clean": true},
   "counts": {"secrets_redacted": 42, "certificates_redacted": 6,
              "ips_redacted": 18, "domains_redacted": 9,
@@ -186,6 +188,18 @@ A finding looks like:
  "kind": "pem-private-key",
  "length": 1679}
 ```
+
+`verdict` distinguishes what the run concluded from how it ended:
+
+| Verdict | Means |
+| --- | --- |
+| `clean` | Output was produced and nothing was withheld |
+| `rejected` | The input was unsupported or structurally unsafe (exit 2) |
+| `findings` | Something sensitive was retained or detected **in the configuration** (exit 3 or 4) |
+| `error` | The **run** failed — I/O or an internal fault (exit 5 or 6). Says nothing about the configuration |
+
+The distinction matters to a pipeline: reading `findings` when the disk was
+full would report the configuration as still holding secrets.
 
 The report never contains a retained value, a prefix of one, decoded content, a
 full credential-bearing URL, or a hash of a secret. A short secret's hash is

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -47,7 +47,7 @@ That is the number each pull request below is compared against.
 | 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
 | 2 | 1106 passed, 1 skipped, 26 xfailed | 0 | 26 |
 | 3 | 1153 passed, 1 skipped, 18 xfailed | 8 | 18 |
-| 4 | (measured below) | 9 | 9 |
+| 4 | 1205 passed, 1 skipped, 9 xfailed | 9 | 9 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/security-remediation-tracker.md
+++ b/docs/security-remediation-tracker.md
@@ -47,6 +47,7 @@ That is the number each pull request below is compared against.
 | 1 | 1059 passed, 1 skipped, 26 xfailed | 31 | 26 |
 | 2 | 1106 passed, 1 skipped, 26 xfailed | 0 | 26 |
 | 3 | 1153 passed, 1 skipped, 18 xfailed | 8 | 18 |
+| 4 | (measured below) | 9 | 9 |
 
 Every confirmed gap carries a `xfail(strict=True)` marker naming its finding id,
 so closing one turns its test into a failure until the marker is removed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -202,6 +202,68 @@ Redacted output is for **analysis only**, because:
 
 Always keep the **original secure copy**.
 
+## Modes
+
+Four things the documentation deliberately keeps apart, because conflating them
+is how a file gets shared that should not have been:
+
+| | What it does |
+| --- | --- |
+| **Redaction** | Removing secrets: passwords, keys, tokens, certificates |
+| **Identifier anonymisation** | Replacing addresses and hostnames with consistent aliases, so topology survives and the real values do not (`--anonymise`) |
+| **Independent verification** | A separate component re-reading the output for material that should not be in it |
+| **Gitleaks and similar** | A third-party scanner that fails differently. Useful, and not a certificate — see [verifying output](verifying-output.md#a-clean-scan-is-not-a-clean-file) |
+
+And three modes, in increasing order of what they will refuse:
+
+| Mode | Intended for | Behaviour on a finding |
+| --- | --- | --- |
+| Default | Private troubleshooting, where you keep the output | Reported; output is still produced |
+| `--aggressive` | Controlled sharing with a named recipient | More is redacted; findings still reported, output still produced |
+| `--strict` | Public sharing, where the output may be read by anyone indefinitely | **No output at all**, and a distinct non-zero exit code |
+
+### Strict mode
+
+`--strict` implies `--aggressive` and `--redact-descriptions`, then adds a
+policy: this run has no silent failure path.
+
+- The independent verifier runs, and **any** finding means no output — no file,
+  no XML on stdout, no temporary file. A verifier that could not be imported
+  counts as a finding, because nothing checked is not nothing found.
+- Any high-entropy value the transformer chose to retain means no output.
+- Allow-list files found in the working directory or the home directory are
+  **ignored**, and the refusal is announced. An allow-list weakens redaction,
+  and one picked up from wherever the tool happened to run means the output
+  depends on the working directory — which is not a property output intended
+  for public sharing can have. `--allowlist-file` is the only way in, and every
+  source that took effect is announced on stderr and recorded in the report.
+- `--inplace` is a usage error. Strict mode withholds output when it finds
+  something, and in-place operation has nowhere to withhold it to.
+- Input is **rejected** rather than warned about: a root element that is not
+  `pfsense`, a configuration schema version outside the range this tool has been
+  exercised against, a document nesting more than 400 elements deep, and any
+  element too large to process.
+
+#### What strict mode does not establish
+
+It is a mode with no silent failure path. It is not a guarantee, and the
+following are all still true under it:
+
+- **Unknown encodings exist.** Base64 and Base64URL are decoded to a depth of
+  three. A value encoded some other way — a vendor's own scheme, compression,
+  encryption — is opaque to both the transformer and the verifier.
+- **Unsupported packages exist.** pfSense packages invent element names freely.
+  Coverage of a package this project has never seen rests on the value-shape
+  rules and on the retention comparison, not on knowing what the field means.
+- **Independent verification does not eliminate false negatives.** It reduces
+  correlated failure — the transformer and the verifier can be wrong about
+  different things — and that is all it does.
+- **Passing the included corpus is not certification.** The corpus was written
+  alongside this tool, which biases it; see [the benchmark](benchmark.md).
+
+Strict mode is not described as certified, audit-grade, complete, or suitable
+for every package schema, because it is none of those.
+
 ## Output safety
 
 Where the output goes, and how it gets there. Separate from path safety below,

--- a/pfsense_redactor/__init__.py
+++ b/pfsense_redactor/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 9):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 # pylint: disable=wrong-import-position
 from .redactor import PfSenseRedactor, main, parse_allowlist_file

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -50,6 +50,8 @@ import xml.etree.ElementTree as ET
 import argparse
 import base64
 import binascii
+import hashlib
+import json
 import math
 import re
 import sys
@@ -159,6 +161,59 @@ def setup_logging(level: int = logging.INFO, use_stderr: bool = False) -> loggin
     return logger
 
 
+# ==========================================================================
+# Exit codes
+# ==========================================================================
+class ExitCode:
+    """Process exit statuses, so a caller can tell failures apart
+
+    Before 1.6.0 only 0 and 1 were used, and a CI job could not distinguish
+    "this file is not parseable" from "this file still has secrets" from "the
+    disk is full". Every non-zero value below is still non-zero, so a caller
+    that only tests for success is unaffected.
+
+    One overlap is worth stating rather than hiding: argparse exits 2 of its
+    own accord for a malformed command line (an unknown flag, a missing
+    positional). That is the same value as INPUT_REJECTED. Both mean "what you
+    gave me cannot be used", they are distinguishable from stderr, and
+    suppressing argparse's convention would be worse than the overlap.
+    """
+
+    CLEAN = 0             # Output produced, and nothing was withheld
+    USAGE = 1             # The command line asks for something incoherent
+    INPUT_REJECTED = 2    # The input is unsupported or structurally unsafe
+    RETAINED_VALUE = 3    # Sensitive material was left in the candidate
+    VERIFIER_FINDING = 4  # Independent verification found something
+    IO_FAILURE = 5        # Reading or writing a file failed
+    INTERNAL_FAILURE = 6  # A defect in this program
+
+
+# ==========================================================================
+# Input limits
+# ==========================================================================
+# Nesting bound. redact_element, ET.indent and the verifier's value walk each
+# recurse once per level, so an unbounded document reaches the interpreter's
+# recursion limit and arrives at the shell as a traceback with interpreter
+# paths in it. 400 is comfortably above anything pfSense emits - real configs
+# are a handful of levels deep, and the deepest in this project's corpus is 9 -
+# and comfortably below the frame budget of the three recursive passes.
+MAX_XML_DEPTH: int = 400
+
+# Config schema versions this tool has been exercised against. Expressed as a
+# bound on the leading component rather than an enumeration, because pfSense
+# has written every value from 1.x to 23.x and enumerating them would refuse
+# every future release. 99.9 is not a version pfSense has ever written.
+MIN_CONFIG_VERSION_MAJOR: int = 1
+MAX_CONFIG_VERSION_MAJOR: int = 30
+CONFIG_VERSION_RE = re.compile(r'\A(\d+)\.(\d+)')
+
+# Written in place of a text element that exceeds MAX_TEXT_CHUNK. Truncating
+# it instead discarded the excess while reporting success - a 1,200,000
+# character element became 1,048,576, losing 151,424 characters of the
+# operator's configuration with a warning and exit 0.
+OVERSIZED_TEXT_PLACEHOLDER: str = '[REDACTED_OVERSIZED]'
+
+
 # Module-level constants (immutable for safety)
 # ==========================================================================
 # 2. CONSTANTS - element sets, secret/cert tag patterns, deny-list
@@ -242,7 +297,7 @@ CERT_TAG_PATTERN = re.compile(r'cert(?:ificate)?s?$|ssloffload', re.IGNORECASE)
 # '[REDACTED_CERT_OR_KEY]' fails to resolve as a certificate reference on a
 # second pass and degrades to the less informative '[REDACTED]'.
 REDACTION_PLACEHOLDERS: frozenset[str] = frozenset({
-    '[REDACTED]', '[REDACTED_CERT_OR_KEY]',
+    '[REDACTED]', '[REDACTED_CERT_OR_KEY]', OVERSIZED_TEXT_PLACEHOLDER,
 })
 
 # Tags that match SECRET_TAG_PATTERN but are not secrets.
@@ -757,6 +812,40 @@ def _has_mixed_character_classes(compact: str, hex_only: bool) -> bool:
     return has_digit + has_upper + has_lower >= 2
 
 
+def _document_depth(root: ET.Element, limit: int) -> int:
+    """Depth of the deepest element, stopping once `limit` is exceeded
+
+    Iterative on purpose. This exists because recursing over the document is
+    what fails, so measuring it by recursion would fail in the same way.
+    Returns as soon as the answer is "deeper than the limit", so a pathological
+    document costs the limit rather than its own size.
+    """
+    stack = [(root, 1)]
+    deepest = 0
+
+    while stack:
+        element, depth = stack.pop()
+        deepest = max(deepest, depth)
+        if deepest > limit:
+            return deepest
+        stack.extend((child, depth + 1) for child in element)
+
+    return deepest
+
+
+def _config_version_is_supported(version: str) -> bool:
+    """Whether a configuration schema version is one this tool has seen
+
+    A bound on the leading component rather than an enumeration: pfSense has
+    written every value from 1.x to 23.x, and enumerating them would refuse
+    every future release the day it shipped.
+    """
+    match = CONFIG_VERSION_RE.match(version)
+    if match is None:
+        return False
+    return MIN_CONFIG_VERSION_MAJOR <= int(match.group(1)) <= MAX_CONFIG_VERSION_MAJOR
+
+
 def is_rfc_documentation_ip(ip: IPAddress) -> bool:
     """Check whether an address is in a reserved documentation range
 
@@ -1174,15 +1263,28 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         allowlist_networks: list[IPNetwork] | None = None,
         dry_run_verbose: bool = False,
         redact_url_usernames: bool = False,
-        redact_descriptions: bool = False
+        redact_descriptions: bool = False,
+        strict: bool = False
     ) -> None:
         self.keep_private_ips = keep_private_ips
         self.anonymise = anonymise
-        self.aggressive = aggressive
+        self.strict = strict
+        # Strict mode is for output that may be read by anyone, indefinitely,
+        # so it turns on the strongest scanning the tool has rather than
+        # leaving it to the operator to remember two more flags.
+        self.aggressive = aggressive or strict
         self.fail_on_warn = fail_on_warn
         self.dry_run_verbose = dry_run_verbose
         self.redact_url_usernames = redact_url_usernames
-        self.redact_descriptions = redact_descriptions
+        self.redact_descriptions = redact_descriptions or strict
+
+        # Set by _load_config_tree, read by --strict and --report-json.
+        self.config_version: str | None = None
+        self.config_version_supported: bool = True
+
+        # The process status this run should end with. Raised, never lowered,
+        # by _fail_with; see ExitCode for what each value means.
+        self.exit_code: int = ExitCode.CLEAN
 
         # Element paths of high-entropy values retained (not redacted) so they
         # can be surfaced in the summary for manual review
@@ -2448,11 +2550,21 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if not text:
             return text
 
-        # ReDoS protection - reject absurdly long text chunks
+        # ReDoS protection - a text chunk this long is refused, not trimmed.
+        #
+        # Truncating was worse than the bound it enforced: 151,424 characters
+        # of the operator's configuration were discarded and the run reported
+        # success. The whole value is replaced instead, which at least does not
+        # misrepresent what is left, and the run is failed by
+        # _oversized_text_refusal so the loss cannot pass unnoticed.
         if len(text) > self.MAX_TEXT_CHUNK:
-            # Log warning and truncate
-            self.logger.warning("[!] Warning: Text chunk too long (%d chars), truncating", len(text))
-            text = text[:self.MAX_TEXT_CHUNK]
+            self.logger.warning(
+                "[!] Warning: Text chunk too long (%d chars, limit %d). The "
+                "whole value has been replaced rather than trimmed.",
+                len(text), self.MAX_TEXT_CHUNK
+            )
+            self.stats['oversized_text'] += 1
+            return OVERSIZED_TEXT_PLACEHOLDER
 
         result = text
 
@@ -3111,7 +3223,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         return handled
 
     def redact_element(self, element: ET.Element) -> None:
-        """Recursively redact sensitive information from XML element"""
+        """Recursively redact sensitive information from XML element
+
+        Bounded by MAX_XML_DEPTH. redact_config refuses an over-deep document
+        before it gets here, but this method is also called directly - by the
+        tests, and by anyone importing the class - and unbounded recursion on
+        attacker-supplied XML reached the shell as a traceback with interpreter
+        paths in it.
+        """
+        if len(self._path_stack) >= MAX_XML_DEPTH:
+            self.stats['depth_limit_hits'] += 1
+            return
 
         # Normalise tag name to handle namespaced exports
         tag = self._normalise_tag(element.tag)
@@ -3162,13 +3284,16 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
     def _check_root_tag(self, root: ET.Element) -> bool:
         """Warn if this does not look like a pfSense config. False means abort
 
-        Namespace-robust. Only --fail-on-warn turns the warning into an abort.
+        Namespace-robust. A gate - --fail-on-warn or --strict - turns the
+        warning into an abort: a document that is not a pfSense configuration
+        is one whose element names mean something else, and every redaction
+        decision this tool makes rests on those names.
         """
         if root.tag.rsplit('}', 1)[-1].lower() == 'pfsense':
             return True
 
         msg = f"[!] Warning: Root tag is '{root.tag}', expected 'pfsense'."
-        if self.fail_on_warn:
+        if self._gate_is_active:
             self.logger.error("%s Exiting.", msg)
             return False
 
@@ -3201,10 +3326,70 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # line or the one directly below, so it cannot be parked above a
         # comment block like this one.
         tree = ET.parse(input_file)  # nosemgrep  # nosec
-        if not self._check_root_tag(tree.getroot()):
+        root = tree.getroot()
+
+        if not self._check_root_tag(root):
+            self.exit_code = ExitCode.INPUT_REJECTED
             return None
 
+        if not self._check_structural_limits(root):
+            self.exit_code = ExitCode.INPUT_REJECTED
+            return None
+
+        self._check_config_version(root)
         return tree
+
+    def _check_structural_limits(self, root: ET.Element) -> bool:
+        """Refuse a document too deep to process. False means abort
+
+        Measured iteratively rather than by recursing, because the whole point
+        is that recursing over this document is what fails.
+        """
+        depth = _document_depth(root, MAX_XML_DEPTH)
+        if depth <= MAX_XML_DEPTH:
+            return True
+
+        self.logger.error(
+            "[!] Refusing to process this file because it nests more than %d "
+            "elements deep. pfSense configurations are a handful of levels "
+            "deep, and processing this one would exhaust the interpreter's "
+            "recursion limit rather than produce output.", MAX_XML_DEPTH
+        )
+        return False
+
+    def _check_config_version(self, root: ET.Element) -> None:
+        """Report a configuration schema version this tool has not seen
+
+        Not fatal outside strict mode. Redaction is name-driven, so an
+        unrecognised schema is exactly the case where coverage is weakest, and
+        an operator deciding whether to share the output is entitled to know
+        that. Recorded on self so --strict and --report-json can act on it.
+
+        Only the root's own <version> is read. Package configs carry their own,
+        and reading one of those would report a package version as the schema.
+        """
+        element = root.find('version')
+        self.config_version = (element.text or '').strip() if element is not None else None
+
+        if self.config_version is None:
+            self.logger.warning(
+                "[!] Warning: no <version> element; the configuration schema "
+                "is unknown, so redaction coverage cannot be judged."
+            )
+            self.config_version_supported = False
+            return
+
+        self.config_version_supported = _config_version_is_supported(self.config_version)
+        if self.config_version_supported:
+            return
+
+        self.logger.warning(
+            "[!] Warning: configuration schema version '%s' is outside the "
+            "range this tool has been exercised against (%d.x to %d.x). "
+            "Redaction is driven by element names, so an unfamiliar schema is "
+            "where coverage is weakest.",
+            self.config_version, MIN_CONFIG_VERSION_MAJOR, MAX_CONFIG_VERSION_MAJOR
+        )
 
     @staticmethod
     def serialise_tree(tree: ET.ElementTree) -> str:
@@ -3346,14 +3531,28 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 input_file, output_file, dry_run, stdout_mode, inplace
             )
         except ET.ParseError as e:
-            self.logger.error("[!] Error parsing XML: %s", e)
-            return False
+            return self._fail_with(
+                ExitCode.INPUT_REJECTED, "[!] Error parsing XML: %s", e
+            )
+        except RecursionError:
+            # Reached only by a caller driving redact_element directly past the
+            # depth guard; _check_structural_limits refuses such a document
+            # first. Caught anyway, because a traceback with interpreter paths
+            # in it is not a diagnosis.
+            return self._fail_with(
+                ExitCode.INPUT_REJECTED,
+                "[!] Refusing to process this file: it nests too deeply to "
+                "traverse without exhausting the interpreter's recursion limit."
+            )
         except (IOError, OSError) as e:
-            self.logger.error("[!] Error reading/writing file: %s", e)
-            return False
+            return self._fail_with(
+                ExitCode.IO_FAILURE, "[!] Error reading/writing file: %s", e
+            )
         except (ValueError, TypeError) as e:
-            self.logger.error("[!] Error processing configuration: %s", e)
-            return False
+            return self._fail_with(
+                ExitCode.INTERNAL_FAILURE,
+                "[!] Error processing configuration: %s", e
+            )
 
     def _process(
         self,
@@ -3423,16 +3622,87 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         ET.indent(tree, space="  ")
         return self.serialise_tree(tree)
 
+    def _fail_with(self, code: int, message: str, *args) -> bool:
+        """Record a non-zero outcome and say why. Always returns False
+
+        Only the *first* reason is recorded. _output_is_permitted runs its
+        checks in order of specificity - input rejected, data discarded,
+        value retained, verifier finding - so the first one to fire is the one
+        that tells the operator most. A run that trips three of them still
+        logs all three; it just exits with the code for the first.
+        """
+        if self.exit_code == ExitCode.CLEAN:
+            self.exit_code = code
+        self.logger.error(message, *args)
+        return False
+
+    @property
+    def _gate_is_active(self) -> bool:
+        """Whether this run refuses to produce output when something is found
+
+        Without a gate, findings are reported and the output is still produced:
+        an operator troubleshooting privately needs the file, and the
+        retained-value warning has always been advisory. --fail-on-warn and
+        --strict both exist precisely to stop the artefact.
+        """
+        return bool(self.fail_on_warn or self.strict)
+
     def _output_is_permitted(self) -> bool:
         """Whether policy allows this candidate to become externally visible
 
-        Two gates, both of which only bite under --fail-on-warn. Without a
-        gate, findings are reported and the output is still produced: an
-        operator troubleshooting privately needs the file, and the
-        retained-value warning has always been advisory. The gate exists
-        precisely to stop the artefact, so under it a finding means no output.
+        Every branch is evaluated rather than short-circuited, so a run that
+        fails three checks reports three reasons instead of the first one. The
+        exit code is the most severe of them.
         """
-        return self._retained_values_are_acceptable() and self._verification_permits_output()
+        checks = (
+            self._input_is_supported(),
+            self._no_data_was_discarded(),
+            self._retained_values_are_acceptable(),
+            self._verification_permits_output(),
+        )
+        return all(checks)
+
+    def _input_is_supported(self) -> bool:
+        """Whether strict mode accepts this configuration's schema
+
+        Outside strict mode an unrecognised schema is a warning: the tool will
+        do its best and has said so. Strict mode is for output that may be read
+        by anyone indefinitely, and "we have never seen this schema" is not a
+        basis for that claim.
+        """
+        if not self.strict:
+            return True
+        if self.config_version_supported:
+            return True
+
+        return self._fail_with(
+            ExitCode.INPUT_REJECTED,
+            "[!] Strict mode refuses this file: its configuration schema "
+            "version (%s) is outside the range this tool has been exercised "
+            "against. Redaction is name-driven, so coverage on an unfamiliar "
+            "schema cannot be claimed.",
+            self.config_version or 'absent'
+        )
+
+    def _no_data_was_discarded(self) -> bool:
+        """Whether any element was too large to process
+
+        Refused in every mode, not only under a gate. The alternative is
+        producing a file that silently lacks part of the operator's
+        configuration while reporting success, which misrepresents the output
+        rather than redacting it.
+        """
+        if not self.stats['oversized_text']:
+            return True
+
+        return self._fail_with(
+            ExitCode.INPUT_REJECTED,
+            "[!] Refusing to produce output: %d text element(s) exceeded the "
+            "%d character limit and were replaced wholesale. The output would "
+            "be missing part of the configuration, which is not something to "
+            "report as success.",
+            self.stats['oversized_text'], self.MAX_TEXT_CHUNK
+        )
 
     def _verification_permits_output(self) -> bool:
         """Whether the independent verification allows output, under a gate
@@ -3441,25 +3711,26 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         "nothing found", and a gate that passes because its check did not run
         is not a gate.
         """
-        if not self.fail_on_warn:
+        if not self._gate_is_active:
             return True
 
         if self.last_verification is None:
-            self.logger.error(
-                "[!] Failing because --fail-on-warn is set and independent "
-                "verification could not run: verifier.py is not importable."
+            return self._fail_with(
+                ExitCode.VERIFIER_FINDING,
+                "[!] Failing because independent verification could not run: "
+                "verifier.py is not importable. Nothing checked is not "
+                "nothing found."
             )
-            return False
 
         if self.last_verification.clean:
             return True
 
-        self.logger.error(
-            "[!] Failing because --fail-on-warn is set and independent "
-            "verification reported %d finding(s) in the candidate output.",
+        return self._fail_with(
+            ExitCode.VERIFIER_FINDING,
+            "[!] Failing because independent verification reported %d "
+            "finding(s) in the candidate output.",
             self.last_verification.count
         )
-        return False
 
     def _retained_values_are_acceptable(self) -> bool:
         """Whether the run should be treated as successful
@@ -3471,18 +3742,18 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         could pass on a file the tool had just told the operator to review
         before sharing. A gate that cannot fail is not a gate.
         """
-        if not self.fail_on_warn:
+        if not self._gate_is_active:
             return True
         if not self.stats['high_entropy_retained']:
             return True
 
-        self.logger.error(
-            "[!] Failing because --fail-on-warn is set and %d high-entropy "
-            "value(s) were retained. Re-run with --aggressive to redact them, "
-            "or review the paths listed above.",
+        return self._fail_with(
+            ExitCode.RETAINED_VALUE,
+            "[!] Failing because %d high-entropy value(s) were retained. "
+            "Re-run with --aggressive to redact them, or review the paths "
+            "listed above.",
             self.stats['high_entropy_retained']
         )
-        return False
 
     def _print_stats(self) -> None:
         """Print redaction statistics using logger"""
@@ -4183,6 +4454,16 @@ Examples:
   %(prog)s config.xml config-redacted.xml --aggressive
   %(prog)s config.xml config-redacted.xml --allowlist-ip 8.8.8.8 --allowlist-domain time.nist.gov
   %(prog)s config.xml config-redacted.xml --allowlist-file allowlist.txt
+  %(prog)s config.xml config-public.xml --strict --report-json report.json
+
+Exit codes:
+  0  clean output produced
+  1  usage error (argparse itself also uses 2 for a malformed command line)
+  2  input rejected: unparseable, unsupported schema, too deep, oversized
+  3  sensitive value retained (under --fail-on-warn or --strict)
+  4  independent verification found something
+  5  file or I/O failure
+  6  internal processing failure
 
 Allow-list file format (one item per line):
   # Public DNS servers
@@ -4245,7 +4526,11 @@ def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='Show detailed debug information')
     parser.add_argument('--fail-on-warn', action='store_true',
-                        help='Exit with non-zero code if root tag is not pfsense (useful in CI)')
+                        help='Exit non-zero, and produce no output, if the root tag is not pfsense, if high-entropy values were retained, or if independent verification found anything (useful in CI)')
+    parser.add_argument('--strict', action='store_true',
+                        help='Fail-closed mode for output intended for public sharing. Implies --aggressive and --redact-descriptions; ignores allow-list files found in the working directory or home directory; refuses --inplace, unsupported configuration schemas, over-deep documents and oversized elements; and produces no output at all when anything is retained or found. Not a guarantee of safety - see docs/security.md.')
+    parser.add_argument('--report-json', metavar='PATH', dest='report_json',
+                        help='Write a machine-readable assurance report to PATH. Contains paths, kinds, lengths and counts only - never a value, a prefix of one, or a hash of one.')
 
 def _add_allowlist_arguments(parser: argparse.ArgumentParser) -> None:
     """Allow-list sources and the remaining opt-in redaction flags"""
@@ -4449,14 +4734,17 @@ def _merge_allowlist(target: Allowlists, parsed: Allowlists) -> None:
 def _load_default_allowlists(
     args: argparse.Namespace, logger: logging.Logger, target: Allowlists
 ) -> None:
-    """Merge every default allow-list file found on disk, unless disabled"""
-    if getattr(args, 'no_default_allowlist', False):
-        return
+    """Merge every default allow-list file found on disk, unless disabled
 
-    for default_file in find_default_allowlist_files():
+    Announced in every mode, including --dry-run and --stdout. The notice used
+    to be suppressed in exactly those two - the ones most likely to be
+    scripted - so redaction could be weakened by a file in the working
+    directory with nothing in the run saying so.
+    """
+    for default_file in _implicit_allowlist_files(args, logger):
         _merge_allowlist(target, parse_allowlist_file(default_file, silent_if_missing=True))
-        if not args.dry_run and not args.stdout:
-            logger.info("[+] Loaded default allow-list: %s", default_file)
+        logger.warning("[+] Loaded default allow-list: %s", default_file)
+        args.allowlist_sources.append(str(default_file))
 
 
 def _collect_allowlists(
@@ -4473,6 +4761,8 @@ def _collect_allowlists(
 
     if args.allowlist_file:
         _merge_allowlist(collected, parse_allowlist_file(args.allowlist_file, silent_if_missing=False))
+        logger.warning("[+] Loaded allow-list: %s", args.allowlist_file)
+        args.allowlist_sources.append(str(args.allowlist_file))
 
     allowlist_ips, allowlist_networks, allowlist_domains = collected
 
@@ -4484,6 +4774,33 @@ def _collect_allowlists(
         allowlist_domains.add(domain.lower())
 
     return allowlist_ips, allowlist_networks, allowlist_domains
+
+
+def _implicit_allowlist_files(
+    args: argparse.Namespace, logger: logging.Logger
+) -> list[Path]:
+    """Default allow-list files to load, honouring the opt-outs
+
+    Strict mode loads none of them. An allow-list weakens redaction, and one
+    picked up from the working directory or the home directory means the output
+    depends on where the tool was run - which is not a property output intended
+    for public sharing can have. The refusal is announced rather than silent,
+    so an operator who was relying on the file finds out.
+    """
+    if getattr(args, 'no_default_allowlist', False):
+        return []
+
+    found = find_default_allowlist_files()
+
+    if not args.strict:
+        return found
+
+    for ignored in found:
+        logger.warning(
+            "[!] Strict mode is ignoring the allow-list found at %s. Pass "
+            "--allowlist-file to use it deliberately.", ignored
+        )
+    return []
 
 
 def _add_cli_allowlist_ip(
@@ -4528,6 +4845,7 @@ def _handle_early_exit_flags(args: argparse.Namespace, parser: argparse.Argument
         parser.error("--quiet and --verbose are mutually exclusive")
 
     _require_consent_for_inplace(args, parser)
+    _reject_strict_inplace(args, parser)
 
 
 def _require_consent_for_inplace(
@@ -4545,6 +4863,25 @@ def _require_consent_for_inplace(
         parser.error(
             "--inplace overwrites the input file, destroying the only "
             "unredacted copy of the configuration. Add --force to confirm."
+        )
+
+
+def _reject_strict_inplace(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> None:
+    """Refuse --strict --inplace
+
+    Strict mode withholds output when it finds anything, and in-place operation
+    has nowhere to withhold it to: the destination is the source. Producing
+    nothing would leave the original in place - which looks identical to a
+    successful run that changed nothing - so the combination is a usage error
+    rather than a mode with a subtle failure.
+    """
+    if args.strict and args.inplace:
+        parser.error(
+            "--strict cannot be combined with --inplace. Strict mode "
+            "withholds output when it finds anything, and in-place operation "
+            "has nowhere to withhold it to. Write to a separate file."
         )
 
 
@@ -4579,6 +4916,10 @@ def _needs_generated_output_name(args: argparse.Namespace) -> bool:
 
 def _apply_argument_defaults(args: argparse.Namespace) -> None:
     """Fill in values implied by other flags, before any validation"""
+    # Every allow-list source that took effect, for the JSON report. Populated
+    # by _collect_allowlists.
+    args.allowlist_sources = []
+
     # --dry-run-verbose is a louder --dry-run
     if args.dry_run_verbose:
         args.dry_run = True
@@ -4627,7 +4968,8 @@ def main() -> None:
         allowlist_networks=allowlist_networks,
         dry_run_verbose=args.dry_run_verbose,
         redact_url_usernames=args.redact_url_usernames,
-        redact_descriptions=args.redact_descriptions
+        redact_descriptions=args.redact_descriptions,
+        strict=args.strict
     )
 
     success = redactor.redact_config(
@@ -4640,7 +4982,152 @@ def main() -> None:
         inplace=args.inplace
     )
 
-    sys.exit(0 if success else 1)
+    exit_code = _resolve_exit_code(redactor, success)
+    _write_report_if_requested(args, redactor, exit_code, logger)
+    sys.exit(exit_code)
+
+
+REPORT_SCHEMA_VERSION: int = 1
+
+
+def _report_verdict(exit_code: int) -> str:
+    """One word for what happened, for a caller that does not want the codes"""
+    if exit_code == ExitCode.CLEAN:
+        return 'clean'
+    if exit_code == ExitCode.INPUT_REJECTED:
+        return 'rejected'
+    return 'findings'
+
+
+def _input_digest(input_file: str) -> dict:
+    """Size and SHA-256 of the input, so a report can be tied to a file
+
+    The digest is of the *input*, which is the file the operator already has.
+    It identifies which file a report describes; it is not a digest of any
+    secret, and there is nothing here to brute-force.
+    """
+    try:
+        data = Path(input_file).read_bytes()
+    except (OSError, ValueError):  # pragma: no cover - the run already read it
+        return {'sha256': None, 'bytes': None}
+    return {'sha256': hashlib.sha256(data).hexdigest(), 'bytes': len(data)}
+
+
+def _report_findings(redactor: PfSenseRedactor) -> list[dict]:
+    """Verifier findings as plain data
+
+    Metadata only, by construction: VerificationFinding has no field that could
+    hold a value, a prefix or a hash, and this copies its fields rather than
+    reaching for anything else.
+    """
+    result = redactor.last_verification
+    if result is None:
+        return []
+    return [
+        {'id': finding.finding_id, 'path': finding.path,
+         'kind': finding.kind, 'length': finding.length}
+        for finding in result.findings
+    ]
+
+
+def build_report(
+    args: argparse.Namespace, redactor: PfSenseRedactor, exit_code: int
+) -> dict:
+    """The machine-readable assurance report
+
+    What it deliberately does not contain: any retained value, any prefix of
+    one, any decoded content, any full credential-bearing URL, and any hash of
+    a secret - a short secret's hash is brute-forceable, so publishing one
+    publishes the secret to anyone willing to spend an afternoon.
+
+    What it does contain is enough to make a sharing decision without a human
+    reading prose on stderr: where the questionable values are, what kind they
+    are, how long they are, and what the run concluded.
+    """
+    return {
+        'schema_version': REPORT_SCHEMA_VERSION,
+        'tool': {'name': 'pfsense-redactor', 'version': resolve_version()},
+        'input': {
+            **_input_digest(args.input),
+            'root_tag': 'pfsense',
+            'config_version': redactor.config_version,
+            'config_version_supported': redactor.config_version_supported,
+        },
+        'mode': {
+            'strict': bool(args.strict),
+            'aggressive': bool(redactor.aggressive),
+            'redact_descriptions': bool(redactor.redact_descriptions),
+            'anonymise': bool(args.anonymise),
+            'fail_on_warn': bool(args.fail_on_warn),
+            'dry_run': bool(args.dry_run),
+            'allowlist_files': list(args.allowlist_sources),
+        },
+        'verdict': _report_verdict(exit_code),
+        'verification': {
+            'available': verification_is_available(),
+            'clean': None if redactor.last_verification is None
+                     else redactor.last_verification.clean,
+        },
+        'counts': {
+            'secrets_redacted': redactor.stats['secrets_redacted'],
+            'certificates_redacted': redactor.stats['certs_redacted'],
+            'ips_redacted': redactor.stats['ips_redacted'],
+            'domains_redacted': redactor.stats['domains_redacted'],
+            'identifiers_anonymised': len(redactor.ip_aliases) + len(redactor.domain_aliases),
+            'high_entropy_retained': redactor.stats['high_entropy_retained'],
+            'oversized_text': redactor.stats['oversized_text'],
+            'verifier_findings': 0 if redactor.last_verification is None
+                                 else redactor.last_verification.count,
+        },
+        'retained': [
+            {'path': path, 'kind': 'high-entropy'}
+            for path in redactor.high_entropy_paths
+        ],
+        'findings': _report_findings(redactor),
+        'exit_code': exit_code,
+    }
+
+
+def _write_report_if_requested(
+    args: argparse.Namespace, redactor: PfSenseRedactor, exit_code: int,
+    logger: logging.Logger
+) -> None:
+    """Write the JSON report, if one was asked for
+
+    Written on failure as well as on success - a run that withheld output is
+    exactly when a caller needs to know why - and written through the same
+    atomic 0600 writer as the XML, because it names the paths of everything
+    the tool decided to keep.
+
+    A failure to write the report does not change the run's own verdict. It is
+    reported and the exit code stands: the report is a description of what
+    happened, not part of it.
+    """
+    if not getattr(args, 'report_json', None):
+        return
+
+    try:
+        payload = json.dumps(build_report(args, redactor, exit_code), indent=2)
+        write_bytes_atomically(args.report_json, (payload + '\n').encode('utf-8'))
+    except (OSError, ValueError, TypeError) as error:
+        logger.error("[!] Could not write the report to %s: %s", args.report_json, error)
+        return
+
+    logger.info("[+] Assurance report written to: %s", args.report_json)
+
+
+def _resolve_exit_code(redactor: PfSenseRedactor, success: bool) -> int:
+    """The status this run ends with
+
+    redact_config records the specific reason on the redactor. This reconciles
+    it with the boolean, so a failure that somehow left the code at CLEAN still
+    exits non-zero rather than reporting success.
+    """
+    if success:
+        return ExitCode.CLEAN
+    if redactor.exit_code != ExitCode.CLEAN:
+        return redactor.exit_code
+    return ExitCode.INTERNAL_FAILURE
 
 
 if __name__ == '__main__':

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -4718,6 +4718,19 @@ def _resolve_keep_private_ips(args: argparse.Namespace) -> bool:
 Allowlists = tuple[set[str], list[IPNetwork], set[str]]
 
 
+def _record_allowlist_source(args: argparse.Namespace, source) -> None:
+    """Remember an allow-list source so --report-json can name it
+
+    Every source that weakened redaction has to be recoverable from the report,
+    not only from stderr. Created on demand for the same reason the reads above
+    use getattr: this path is exercised directly by tests with a hand-built
+    Namespace.
+    """
+    if not hasattr(args, 'allowlist_sources'):
+        args.allowlist_sources = []
+    args.allowlist_sources.append(str(source))
+
+
 def _merge_allowlist(target: Allowlists, parsed: Allowlists) -> None:
     """Fold one parsed (ips, networks, domains) triple into the accumulators
 
@@ -4744,7 +4757,7 @@ def _load_default_allowlists(
     for default_file in _implicit_allowlist_files(args, logger):
         _merge_allowlist(target, parse_allowlist_file(default_file, silent_if_missing=True))
         logger.warning("[+] Loaded default allow-list: %s", default_file)
-        args.allowlist_sources.append(str(default_file))
+        _record_allowlist_source(args, default_file)
 
 
 def _collect_allowlists(
@@ -4762,7 +4775,7 @@ def _collect_allowlists(
     if args.allowlist_file:
         _merge_allowlist(collected, parse_allowlist_file(args.allowlist_file, silent_if_missing=False))
         logger.warning("[+] Loaded allow-list: %s", args.allowlist_file)
-        args.allowlist_sources.append(str(args.allowlist_file))
+        _record_allowlist_source(args, args.allowlist_file)
 
     allowlist_ips, allowlist_networks, allowlist_domains = collected
 
@@ -4792,7 +4805,10 @@ def _implicit_allowlist_files(
 
     found = find_default_allowlist_files()
 
-    if not args.strict:
+    # getattr, matching how no_default_allowlist is read above: this function
+    # is called directly by tests with a hand-built Namespace, not only from
+    # main() where argparse guarantees every attribute.
+    if not getattr(args, 'strict', False):
         return found
 
     for ignored in found:

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -167,7 +167,7 @@ def setup_logging(level: int = logging.INFO, use_stderr: bool = False) -> loggin
 class ExitCode:
     """Process exit statuses, so a caller can tell failures apart
 
-    Before 1.6.0 only 0 and 1 were used, and a CI job could not distinguish
+    Before 1.4.0 only 0 and 1 were used, and a CI job could not distinguish
     "this file is not parseable" from "this file still has secrets" from "the
     disk is full". Every non-zero value below is still non-zero, so a caller
     that only tests for success is unaffected.

--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -3685,13 +3685,21 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         )
 
     def _no_data_was_discarded(self) -> bool:
-        """Whether any element was too large to process
+        """Whether the whole document was actually processed
 
-        Refused in every mode, not only under a gate. The alternative is
-        producing a file that silently lacks part of the operator's
-        configuration while reporting success, which misrepresents the output
-        rather than redacting it.
+        Two ways it might not have been: an element too large to scan, and a
+        subtree too deep to reach. Both are refused in every mode, not only
+        under a gate, because the alternative is producing a file that silently
+        lacks part of the operator's configuration - or worse, silently lacks
+        part of the *redaction* - while reporting success.
+
+        Not short-circuited: a document that trips both is told about both.
         """
+        checks = (self._all_text_was_scanned(), self._whole_tree_was_traversed())
+        return all(checks)
+
+    def _all_text_was_scanned(self) -> bool:
+        """Whether every text element was small enough to process"""
         if not self.stats['oversized_text']:
             return True
 
@@ -3702,6 +3710,29 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             "be missing part of the configuration, which is not something to "
             "report as success.",
             self.stats['oversized_text'], self.MAX_TEXT_CHUNK
+        )
+
+    def _whole_tree_was_traversed(self) -> bool:
+        """Whether the traversal reached every element
+
+        redact_element stops descending at MAX_XML_DEPTH. _check_structural_limits
+        normally refuses such a document before the traversal starts, so this
+        should be unreachable through the CLI - but "should be unreachable" is
+        not a property to rest output on when the two limits could ever
+        disagree, and redact_element is also callable directly.
+
+        The elements below the cut were never examined. Anything in them is
+        unredacted, and the run knows only that it stopped, not what it missed.
+        """
+        if not self.stats['depth_limit_hits']:
+            return True
+
+        return self._fail_with(
+            ExitCode.INPUT_REJECTED,
+            "[!] Refusing to produce output: the traversal stopped at %d "
+            "element(s) nested deeper than %d, so their contents were never "
+            "examined and would be emitted unredacted.",
+            self.stats['depth_limit_hits'], MAX_XML_DEPTH
         )
 
     def _verification_permits_output(self) -> bool:
@@ -4845,10 +4876,28 @@ def _add_cli_allowlist_ip(
     sys.exit(1)
 
 
+def _exit_usage(parser: argparse.ArgumentParser, message: str) -> NoReturn:
+    """Report a usage error and exit with ExitCode.USAGE
+
+    argparse's own parser.error exits 2, which is its convention for a command
+    line it could not parse. This tool's usage errors are different: the
+    command line parsed fine and asks for something incoherent. They exit 1,
+    which is what the documented scheme has always said and what the path
+    validation in _resolve_input_path already did.
+
+    argparse still exits 2 for what it rejects before this code runs - an
+    unknown flag, a missing positional it handles itself - and that overlap
+    with INPUT_REJECTED is documented rather than papered over.
+    """
+    parser.print_usage(sys.stderr)
+    logging.getLogger('pfsense_redactor').error("[!] Error: %s", message)
+    sys.exit(ExitCode.USAGE)
+
+
 def _handle_early_exit_flags(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     """Handle argument combinations that exit before any redaction happens"""
     if not args.check_version and not args.input:
-        parser.error("the following arguments are required: input")
+        _exit_usage(parser, "the following arguments are required: input")
 
     if args.check_version:
         from .version_checker import print_version_check  # pylint: disable=import-outside-toplevel
@@ -4858,7 +4907,7 @@ def _handle_early_exit_flags(args: argparse.Namespace, parser: argparse.Argument
         sys.exit(0 if success else 1)
 
     if args.quiet and args.verbose:
-        parser.error("--quiet and --verbose are mutually exclusive")
+        _exit_usage(parser, "--quiet and --verbose are mutually exclusive")
 
     _require_consent_for_inplace(args, parser)
     _reject_strict_inplace(args, parser)
@@ -4876,7 +4925,8 @@ def _require_consent_for_inplace(
     unredacted copy with no confirmation.
     """
     if args.inplace and not args.force:
-        parser.error(
+        _exit_usage(
+            parser,
             "--inplace overwrites the input file, destroying the only "
             "unredacted copy of the configuration. Add --force to confirm."
         )
@@ -4894,7 +4944,8 @@ def _reject_strict_inplace(
     rather than a mode with a subtle failure.
     """
     if args.strict and args.inplace:
-        parser.error(
+        _exit_usage(
+            parser,
             "--strict cannot be combined with --inplace. Strict mode "
             "withholds output when it finds anything, and in-place operation "
             "has nowhere to withhold it to. Write to a separate file."
@@ -5007,11 +5058,19 @@ REPORT_SCHEMA_VERSION: int = 1
 
 
 def _report_verdict(exit_code: int) -> str:
-    """One word for what happened, for a caller that does not want the codes"""
+    """One word for what happened, for a caller that does not want the codes
+
+    'findings' is a statement about the configuration: something sensitive was
+    retained or detected in it. An I/O or internal failure is a statement about
+    the run, and reporting it as 'findings' tells a pipeline the config still
+    holds secrets when actually the disk was full. Those get 'error'.
+    """
     if exit_code == ExitCode.CLEAN:
         return 'clean'
     if exit_code == ExitCode.INPUT_REJECTED:
         return 'rejected'
+    if exit_code in (ExitCode.IO_FAILURE, ExitCode.INTERNAL_FAILURE):
+        return 'error'
     return 'findings'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pfsense-redactor"
-version = "1.3.0"
+version = "1.4.0"
 description = "Enterprise-grade tool to redact secrets and anonymise identifiers in pfSense/Netgate config.xml exports. Preserves network topology while removing passwords, VPN keys, certificates, public IPs, domains, and MACs for safe sharing with support teams, consultants, AI tools, and forums."
 readme = "README.md"
 authors = [

--- a/tests/adversarial/test_assurance_signals.py
+++ b/tests/adversarial/test_assurance_signals.py
@@ -16,19 +16,41 @@ from .decode_scan import find_key_material
 class TestFailClosed:
     """Unsafe output must not be distributable"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-21: retained high-entropy values warn but do not fail, "
-               "so a run that left a private key in the output exits 0",
-    )
-    def test_retained_key_material_fails_the_run(self, adversarial_canary, run_redactor):
-        """Output holding a private key must not exit 0"""
+    def test_key_material_no_longer_survives_at_all(self, adversarial_canary, run_redactor):
+        """The premise of the finding is gone, which is the better outcome
+
+        This asserted that the fixture still leaked a private key and that the
+        run nevertheless exited 0 - the leak being certified by the success.
+        Both halves are now false: nothing survives to certify. The stronger
+        statement is asserted directly here, and the exit-code half of the
+        original is asserted by test_a_verifier_finding_alone_blocks_output,
+        which uses material that does still survive.
+        """
         result = run_redactor(adversarial_canary, "--stdout")
 
-        assert find_key_material(result.stdout), "fixture no longer leaks - update the test"
-        assert result.returncode != 0, (
-            "exit 0 on output containing a private key certifies the leak"
+        assert not find_key_material(result.stdout)
+        assert result.returncode == 0, (
+            "nothing was retained that should fail the run"
         )
+
+    def test_output_holding_key_material_could_not_exit_zero(self, tmp_path, run_redactor):
+        """The invariant the finding was about, on a run that can reach it
+
+        Independent verification is what makes this assertable at all: the
+        value below is not in a secret-named element and is not shaped like key
+        material, so the transformer has nothing to report about it.
+        """
+        config = tmp_path / "in.xml"
+        config.write_text(
+            "<pfsense><installedpackages><vendor><config>"
+            "<mqtt_login_string>CANARYUNKNOWNFIELDSECRET42</mqtt_login_string>"
+            "</config></vendor></installedpackages></pfsense>"
+        )
+
+        result = run_redactor(config, tmp_path / "out.xml", "--strict")
+
+        assert result.returncode != 0
+        assert not (tmp_path / "out.xml").exists()
 
     def test_fail_on_warn_writes_no_output(self, adversarial_canary, run_redactor, tmp_path):
         """The gate must prevent the artefact, not just report on it"""
@@ -75,11 +97,6 @@ class TestFailClosed:
         assert not out.exists()
         assert "verification" in result.stderr.lower()
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-23: only 0 and 1 are used, so a caller cannot tell a "
-               "refused input from a retained secret from a write failure",
-    )
     def test_exit_codes_distinguish_failure_kinds(self, tmp_path, run_redactor,
                                                   adversarial_canary):
         """A CI job needs to tell apart why a run failed"""
@@ -114,11 +131,6 @@ class TestUnsupportedInput:
         result = run_redactor(config, "--stdout", "--fail-on-warn")
         assert result.returncode != 0
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-24: the config's own <version> is never inspected, so "
-               "a schema the tool has never seen is accepted silently",
-    )
     def test_unsupported_config_version_is_reported(self, tmp_path, run_redactor):
         """An unrecognised schema version is named, not ignored"""
         config = tmp_path / "future.xml"
@@ -157,12 +169,6 @@ class TestImplicitConfiguration:
 
         assert with_list != without, "the implicit allow-list had no effect"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-25: the 'Loaded default allow-list' notice is "
-               "suppressed under --stdout and --dry-run, the two modes most "
-               "likely to be scripted",
-    )
     def test_implicit_allowlist_is_announced_in_stdout_mode(self, workdir_with_allowlist,
                                                             run_redactor):
         """Weakened redaction must never be silent"""
@@ -172,10 +178,6 @@ class TestImplicitConfiguration:
             "the run never said so"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-25: same suppression under --dry-run",
-    )
     def test_implicit_allowlist_is_announced_in_dry_run(self, workdir_with_allowlist,
                                                         run_redactor):
         """Same requirement in the mode used to decide about sharing"""
@@ -195,11 +197,6 @@ class TestImplicitConfiguration:
 class TestMachineReadableAssurance:
     """A sharing decision should be checkable by something other than a human"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-26: there is no machine-readable report; the retained "
-               "paths and counts exist only as prose on stderr",
-    )
     def test_a_structured_report_is_available(self, adversarial_canary, run_redactor, tmp_path):
         """A sharing gate needs something other than prose to read"""
         import json  # pylint: disable=import-outside-toplevel

--- a/tests/adversarial/test_encoded_canary_scoring.py
+++ b/tests/adversarial/test_encoded_canary_scoring.py
@@ -98,6 +98,25 @@ class TestCorpusScoringIsIncomplete:
             f"markers recoverable only by decoding: {sorted(decoded - literal)}"
         )
 
+    def test_strict_mode_leaves_no_encoded_marker(self, corpus, run_redactor, tmp_path):
+        """Strict mode is where the encoded survivor is actually accounted for
+
+        The default-mode gap above stands: the corpus score counts literal
+        markers, and the base64 canary is not in its denominator. What strict
+        mode adds is that the same marker cannot reach output at all - either
+        it is redacted, or the run produces nothing.
+        """
+        out = tmp_path / "out.xml"
+        result = run_redactor(corpus, out, "--strict")
+
+        if result.returncode != 0:
+            assert not out.exists()
+            return
+
+        literal = find_markers(out.read_text(), max_depth=0)
+        decoded = find_markers(out.read_text())
+        assert not (decoded - literal), sorted(decoded - literal)
+
     def test_aggressive_mode_clears_the_encoded_marker(self, corpus, run_redactor):
         """Pins the escape hatch, and scopes the finding to default mode"""
         result = run_redactor(corpus, "--stdout", "--aggressive")

--- a/tests/adversarial/test_parser_limits.py
+++ b/tests/adversarial/test_parser_limits.py
@@ -27,12 +27,6 @@ class TestRecursionBounds:
         root = ET.fromstring(nested_config(200))
         PfSenseRedactor().redact_element(root)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-13: redact_element has no depth bound, so nesting past "
-               "the interpreter recursion limit raises RecursionError, which "
-               "redact_config does not catch",
-    )
     def test_deep_nesting_is_refused_not_crashed(self):
         """Nesting past the recursion limit must be handled, not fatal"""
         root = ET.fromstring(nested_config(2000))
@@ -42,11 +36,6 @@ class TestRecursionBounds:
         except RecursionError:
             pytest.fail("RecursionError escaped redact_element")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-13: the RecursionError reaches the shell as an "
-               "unhandled traceback rather than a diagnosed refusal",
-    )
     def test_deep_nesting_reports_cleanly_through_the_cli(self, tmp_path, run_redactor):
         """And must reach the shell as a diagnosis"""
         deep = tmp_path / "deep.xml"
@@ -72,13 +61,15 @@ class TestTextSizeBounds:
         assert time.monotonic() - started < 30
         assert len(result) <= redactor.MAX_TEXT_CHUNK
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="FINDING-14: text over MAX_TEXT_CHUNK is truncated, so the "
-               "output silently loses config data while the run reports success",
-    )
     def test_oversized_text_is_not_silently_truncated(self, tmp_path, run_redactor):
-        """Discarding config data is not a successful run"""
+        """Discarding config data is not a successful run
+
+        The return code is checked before the output is parsed, because the
+        correct outcome is now that there is no output to parse. The invariant
+        is unchanged: either the whole value survives, or the run fails. What
+        is no longer permitted is the third option it used to take - discard
+        151,424 characters of the operator's configuration and exit 0.
+        """
         oversized = "A" * 1_200_000
         config = tmp_path / "big.xml"
         config.write_text(
@@ -86,13 +77,25 @@ class TestTextSizeBounds:
         )
 
         result = run_redactor(config, "--stdout")
+
+        if result.returncode != 0:
+            assert result.stdout.strip() == "", "refused, but emitted a document anyway"
+            return
+
         root = ET.fromstring(result.stdout)
         kept = root.find("system/hostname").text or ""
-
-        assert len(kept) == len(oversized) or result.returncode != 0, (
+        assert len(kept) == len(oversized), (
             f"{len(oversized) - len(kept)} characters discarded, exit code "
             f"{result.returncode}"
         )
+
+    def test_oversized_text_is_replaced_rather_than_trimmed(self):
+        """What is left in place of an oversized value says what happened"""
+        redactor = PfSenseRedactor()
+        result = redactor.redact_text("A" * (redactor.MAX_TEXT_CHUNK + 200_000))
+
+        assert result == "[REDACTED_OVERSIZED]"
+        assert redactor.stats["oversized_text"] == 1
 
 
 class TestPathologicalPatterns:

--- a/tests/adversarial/test_strict_mode.py
+++ b/tests/adversarial/test_strict_mode.py
@@ -24,7 +24,7 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
-from pfsense_redactor.redactor import ExitCode, MAX_XML_DEPTH
+from pfsense_redactor.redactor import ExitCode, MAX_XML_DEPTH, PfSenseRedactor
 
 PEM = (
     "-----BEGIN RSA PRIVATE KEY-----\n"
@@ -304,6 +304,76 @@ class TestStrictModeRejectsInput:
         assert not out.exists()
 
 
+class TestIncompleteTraversalFailsClosed:
+    """A subtree the traversal never reached is unredacted, not clean
+
+    redact_element stops descending at MAX_XML_DEPTH and counts it.
+    _check_structural_limits normally refuses such a document first, so this
+    should be unreachable through the CLI - but nothing was reading the
+    counter, so if the two limits ever disagreed the run would emit a document
+    containing elements it had never examined, and report success.
+
+    Refused in every mode, not only under a gate: the elements below the cut
+    were not redacted, and the run knows only that it stopped.
+    """
+
+    @pytest.fixture
+    def too_deep(self, tmp_path):
+        """A document past MAX_XML_DEPTH"""
+        depth = MAX_XML_DEPTH + 50
+        return write(
+            tmp_path,
+            f"<pfsense><version>23.1</version>{'<a>' * depth}"
+            f"CANARYBELOWTHECUT42{'</a>' * depth}</pfsense>"
+        )
+
+    def test_the_traversal_records_that_it_stopped(self, too_deep):
+        """The premise: the counter this now gates on is actually set"""
+        redactor = PfSenseRedactor()
+        redactor.redact_element(ET.parse(too_deep).getroot())
+
+        assert redactor.stats['depth_limit_hits'] > 0
+
+    @pytest.mark.parametrize("flags", [[], ["--aggressive"], ["--strict"]],
+                             ids=["default", "aggressive", "strict"])
+    def test_it_is_refused_with_input_rejected(self, too_deep, tmp_path, run_redactor, flags):
+        """Non-zero, and the same code in every mode"""
+        result = run_redactor(too_deep, tmp_path / "out.xml", *flags)
+
+        assert result.returncode == ExitCode.INPUT_REJECTED, result.stderr
+
+    def test_it_creates_no_output(self, too_deep, tmp_path, run_redactor):
+        """Nothing to find and share"""
+        out = tmp_path / "out.xml"
+        run_redactor(too_deep, out)
+
+        assert not out.exists()
+
+    def test_it_preserves_an_existing_output(self, too_deep, tmp_path, run_redactor):
+        """And does not destroy what was already there"""
+        out = tmp_path / "out.xml"
+        out.write_bytes(b"<pfsense><previous/></pfsense>")
+        before = out.read_bytes()
+
+        run_redactor(too_deep, out, "--force")
+
+        assert out.read_bytes() == before
+
+    def test_it_emits_no_xml_to_stdout(self, too_deep, run_redactor):
+        """A redirected stdout is an artefact like any other"""
+        result = run_redactor(too_deep, "--stdout")
+
+        assert result.returncode != 0
+        assert result.stdout.strip() == ""
+        assert "CANARYBELOWTHECUT42" not in result.stdout
+
+    def test_the_reason_names_the_depth(self, too_deep, tmp_path, run_redactor):
+        """An operator has to be able to tell this from any other refusal"""
+        result = run_redactor(too_deep, tmp_path / "out.xml")
+
+        assert "nested deeper" in result.stderr or "nests more than" in result.stderr
+
+
 class TestStrictModeHasNoImplicitConfiguration:
     """Output must not depend on where the tool was run"""
 
@@ -393,6 +463,36 @@ class TestExitCodes:
         source = write(tmp_path, wrap(SURVIVOR))
         result = run_redactor(source, tmp_path / "o.xml", "--strict")
         assert result.returncode == ExitCode.VERIFIER_FINDING
+
+    @pytest.mark.parametrize(
+        "flags,why",
+        [
+            (["--inplace"], "--inplace without --force"),
+            (["--strict", "--inplace", "--force"], "--strict with --inplace"),
+            (["--quiet", "--verbose"], "mutually exclusive verbosity"),
+        ],
+    )
+    def test_usage_errors_exit_one(self, tmp_path, run_redactor, flags, why):
+        """1, not argparse's 2
+
+        The documented scheme has always said 1 means a usage error, and
+        nothing produced it: every one of these went through parser.error,
+        which exits 2. argparse still exits 2 for a command line it rejects
+        itself - an unknown flag - and that overlap is documented.
+        """
+        source = write(tmp_path, CLEAN_CONFIG)
+
+        result = run_redactor(source, *flags)
+
+        assert result.returncode == ExitCode.USAGE, f"{why}: {result.stderr[:200]}"
+
+    def test_an_unknown_flag_still_exits_two(self, tmp_path, run_redactor):
+        """argparse's own convention, left alone and documented"""
+        source = write(tmp_path, CLEAN_CONFIG)
+
+        result = run_redactor(source, "--no-such-flag")
+
+        assert result.returncode == 2
 
     def test_the_codes_are_distinct(self, tmp_path, run_redactor):
         """The property the finding was about"""
@@ -513,6 +613,49 @@ class TestJsonReport:
                      "--allowlist-file", allowlist, "--report-json", path)
 
         assert str(allowlist) in json.loads(path.read_text())['mode']['allowlist_files']
+
+    @pytest.mark.parametrize(
+        "verdict,setup",
+        [
+            ('clean', 'clean'),
+            ('rejected', 'unparseable'),
+            ('findings', 'survivor'),
+            ('error', 'unwritable'),
+        ],
+    )
+    def test_every_verdict_is_reachable_and_distinct(
+        self, tmp_path, run_redactor, verdict, setup
+    ):
+        """All four mappings, each from a run that really produces that code
+
+        'findings' is a statement about the configuration. An I/O or internal
+        failure is a statement about the run, and reporting it as 'findings'
+        tells a pipeline the config still holds secrets when the disk was
+        actually full - which is why 'error' exists.
+        """
+        report = tmp_path / "report.json"
+
+        if setup == 'clean':
+            source = write(tmp_path, CLEAN_CONFIG)
+        elif setup == 'unparseable':
+            source = write(tmp_path, "<pfsense><unclosed></pfsense>")
+        elif setup == 'survivor':
+            source = write(tmp_path, wrap(SURVIVOR))
+        else:
+            source = write(tmp_path, CLEAN_CONFIG)
+
+        target = tmp_path / "out.xml"
+        if setup == 'unwritable':
+            # A destination whose parent directory does not exist. The
+            # candidate is produced and verified, and the failure lands in the
+            # atomic writer - which is an I/O failure, not a finding about the
+            # configuration. A directory would not do: it has more than one
+            # name, so it is refused by the hard-link guard before any of this.
+            target = tmp_path / "no-such-directory" / "out.xml"
+
+        run_redactor(source, target, "--strict", "--force", "--report-json", report)
+
+        assert json.loads(report.read_text())['verdict'] == verdict
 
     def test_it_works_outside_strict_mode(self, adversarial_canary, run_redactor, tmp_path):
         """--report-json is not strict-only; --dry-run is the usual pairing"""

--- a/tests/adversarial/test_strict_mode.py
+++ b/tests/adversarial/test_strict_mode.py
@@ -1,0 +1,525 @@
+"""Phase 8: --strict, the fail-closed mode
+
+Strict mode exists for output that may be read by anyone, indefinitely. Its
+whole value is that it has no silent failure path, so these tests are mostly
+about what it refuses and what it does *not* leave behind when it refuses.
+
+The two properties every case below asserts together:
+
+    non-zero exit  AND  no artefact
+
+Either on its own is the failure mode this mode was built to remove. A gate
+that reports a problem and still writes the file is what --fail-on-warn used to
+be; a run that writes nothing and exits 0 is worse.
+
+Every value here is synthetic.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import ExitCode, MAX_XML_DEPTH
+
+PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIVATEKEYCANARYPRIV0123\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJDQU5BUllfSldUIn0"
+    ".dBjftJeZ4CVPmB92K27uhbUJU1p1r6wW1gFWFOEjXk"
+)
+
+# Nothing in here is a secret, nothing survives verbatim, and the schema
+# version is one the tool knows. Strict mode must produce output for it, or the
+# mode is a refusal generator rather than a gate.
+CLEAN_CONFIG = (
+    "<pfsense><version>23.1</version>"
+    "<system><hostname>fw</hostname>"
+    "<user><name>admin</name><password>hunter2</password></user></system>"
+    "<interfaces><wan><if>igb0</if><ipaddr>dhcp</ipaddr></wan></interfaces>"
+    "</pfsense>"
+)
+
+
+def write(tmp_path, xml, name="config.xml"):
+    """Put `xml` in a file and return its path"""
+    path = tmp_path / name
+    path.write_text(xml, encoding="utf-8")
+    return path
+
+
+def wrap(inner, version="23.1"):
+    """A package config carrying `inner`"""
+    return (f"<pfsense><version>{version}</version><installedpackages>"
+            f"<vendorpkg><config>{inner}</config></vendorpkg>"
+            f"</installedpackages></pfsense>")
+
+
+class TestStrictModeProducesOutputWhenItCan:
+    """The control. A mode that always refuses protects nothing."""
+
+    def test_a_clean_config_succeeds(self, tmp_path, run_redactor):
+        """Strict mode is a gate, not a wall"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.CLEAN, result.stderr
+        assert out.exists()
+        ET.fromstring(out.read_text())
+
+    def test_the_output_is_not_world_readable(self, tmp_path, run_redactor):
+        """Strict output is still a redacted configuration"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        out = tmp_path / "out.xml"
+        run_redactor(source, out, "--strict")
+
+        mode = stat.S_IMODE(out.stat().st_mode)
+        assert not mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IWGRP | stat.S_IWOTH)
+
+    def test_strict_implies_the_strongest_scanning(self, tmp_path, run_redactor):
+        """--aggressive and --redact-descriptions are on, without asking"""
+        source = write(tmp_path, wrap(
+            "<syslogtarget>198.18.51.77</syslogtarget>"
+            "<descr>CEO Jane Doe personal laptop</descr>"
+        ))
+        out = tmp_path / "out.xml"
+        run_redactor(source, out, "--strict")
+
+        if out.exists():
+            text = out.read_text()
+            assert "198.18.51.77" not in text
+            assert "Jane Doe" not in text
+
+
+# A value that no rule in the transformer recognises: not a secret-named
+# element, not a key shape, not high-entropy enough to report. It survives the
+# transformation intact, and only re-reading the output can tell. This is what
+# strict mode has to refuse.
+SURVIVOR = "<mqtt_login_string>CANARYUNKNOWNFIELDSECRET42</mqtt_login_string>"
+
+
+class TestStrictModeRemovesKeyMaterial:
+    """Classes that are removed rather than refused
+
+    Strict mode is not a refusal generator. Where the transformer can remove
+    the material, it does, and the output is produced - the mode's value is in
+    what happens when it *cannot*.
+    """
+
+    @pytest.mark.parametrize(
+        "inner,absent",
+        [
+            (f"<vendorblob>{PEM}</vendorblob>", "CANARYPRIVATEKEY"),
+            (f'<endpoint blob="{PEM}"/>', "CANARYPRIVATEKEY"),
+            (f"<payload>{base64.b64encode(PEM.encode()).decode()}</payload>",
+             "LS0tLS1CRUdJTiBSU0Eg"),
+            (f"<blob>{base64.b64encode(base64.b64encode(PEM.encode())).decode()}</blob>",
+             "TFMwdExTMUNSVWRK"),
+            (f"<apitoken>{JWT}</apitoken>", "eyJhbGciOiJIUzI1NiIs"),
+            ("<sitekey>deadbeefdeadbeefdeadbeefcafefeedcafefeed</sitekey>",
+             "deadbeefdeadbeef"),
+        ],
+        ids=["pem-element", "pem-attribute", "base64-pem", "double-base64-pem",
+             "jwt", "hex-only"],
+    )
+    def test_the_material_is_gone_and_output_is_produced(
+        self, tmp_path, run_redactor, inner, absent
+    ):
+        """Removed, verified clean, and written"""
+        source = write(tmp_path, wrap(inner))
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.CLEAN, result.stderr
+        assert out.exists()
+        assert absent not in out.read_text()
+
+
+class TestStrictModeWithholdsOutput:
+    """Non-zero exit and no artefact, when something survives"""
+
+    def test_a_surviving_value_means_no_output(self, tmp_path, run_redactor):
+        """The case no shape rule covers, and the reason the mode exists"""
+        source = write(tmp_path, wrap(SURVIVOR))
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.VERIFIER_FINDING
+        assert not out.exists(), "strict mode produced an artefact"
+
+    def test_an_existing_destination_is_left_alone(self, tmp_path, run_redactor):
+        """A refusal must not destroy what was already there"""
+        source = write(tmp_path, wrap(SURVIVOR))
+        out = tmp_path / "out.xml"
+        out.write_bytes(b"<pfsense><previous/></pfsense>")
+        before = out.read_bytes()
+
+        result = run_redactor(source, out, "--strict", "--force")
+
+        assert result.returncode != 0
+        assert out.read_bytes() == before
+
+    def test_no_xml_reaches_stdout(self, tmp_path, run_redactor):
+        """A redirected stdout is an artefact like any other"""
+        source = write(tmp_path, wrap(SURVIVOR))
+
+        result = run_redactor(source, "--stdout", "--strict")
+
+        assert result.returncode != 0
+        assert result.stdout.strip() == ""
+
+    def test_no_temporary_files_are_left_behind(self, tmp_path, run_redactor):
+        """Not even the ones a partial write would have created"""
+        source = write(tmp_path, wrap(SURVIVOR))
+        run_redactor(source, tmp_path / "out.xml", "--strict")
+
+        leftovers = {p.name for p in tmp_path.iterdir()} - {"config.xml"}
+        assert not leftovers, leftovers
+
+    def test_the_input_is_untouched(self, tmp_path, run_redactor):
+        """A refusal reads the input and nothing else"""
+        source = write(tmp_path, wrap(SURVIVOR))
+        before = source.read_bytes()
+
+        run_redactor(source, tmp_path / "out.xml", "--strict")
+
+        assert source.read_bytes() == before
+
+    def test_a_transformer_defect_is_caught_by_the_verifier(self, tmp_path, run_redactor):
+        """The assurance the mode rests on, stated as a property
+
+        SURVIVOR is a defect in the transformer's coverage rather than an
+        injected one: nothing in its rules recognises the element or the value.
+        The run is refused anyway, because something other than the transformer
+        looked at the output.
+        """
+        source = write(tmp_path, wrap(SURVIVOR))
+        result = run_redactor(source, tmp_path / "out.xml", "--strict")
+
+        assert "verification" in result.stderr.lower()
+        assert "CANARYUNKNOWNFIELDSECRET42" not in result.stderr
+
+
+class TestStrictModeRejectsInput:
+    """Structures and schemas there is no basis for processing"""
+
+    def test_an_unsupported_root_is_rejected(self, tmp_path, run_redactor):
+        """Every redaction decision rests on element names meaning what we think"""
+        source = write(tmp_path, "<opnsense><system><password>x</password></system></opnsense>")
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.INPUT_REJECTED
+        assert not out.exists()
+
+    def test_an_unsupported_schema_version_is_rejected(self, tmp_path, run_redactor):
+        """An unfamiliar schema is where name-driven coverage is weakest"""
+        source = write(tmp_path, wrap("<a>b</a>", version="99.9"))
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.INPUT_REJECTED
+        assert "99.9" in result.stderr
+        assert not out.exists()
+
+    def test_a_supported_schema_version_is_accepted(self, tmp_path, run_redactor):
+        """The control, across the range the tool claims"""
+        for version in ("2.9", "18.2", "23.09.1"):
+            source = write(tmp_path, CLEAN_CONFIG.replace("23.1", version))
+            result = run_redactor(source, tmp_path / f"out-{version}.xml", "--strict")
+            assert result.returncode == ExitCode.CLEAN, f"{version}: {result.stderr}"
+
+    def test_excessive_nesting_is_rejected(self, tmp_path, run_redactor):
+        """Refused, rather than traversed until the interpreter gives up"""
+        depth = MAX_XML_DEPTH + 50
+        source = write(
+            tmp_path,
+            f"<pfsense><version>23.1</version>{'<a>' * depth}x{'</a>' * depth}</pfsense>"
+        )
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.INPUT_REJECTED
+        assert "Traceback" not in result.stderr
+        assert not out.exists()
+
+    def test_oversized_text_is_rejected(self, tmp_path, run_redactor):
+        """Discarding part of the configuration is not a successful run
+
+        Free text rather than a run of one character, so the value is not
+        redacted as a blob before the size bound is reached - the bound is what
+        this is about.
+        """
+        oversized = "the quick brown fox jumps over the lazy dog " * 28_000
+        source = write(
+            tmp_path,
+            f"<pfsense><version>23.1</version><installedpackages><vendor>"
+            f"<config><vendornotes>{oversized}</vendornotes></config>"
+            "</vendor></installedpackages></pfsense>"
+        )
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out, "--strict")
+
+        assert result.returncode == ExitCode.INPUT_REJECTED
+        assert not out.exists()
+
+    def test_oversized_text_is_rejected_outside_strict_mode_too(
+        self, tmp_path, run_redactor
+    ):
+        """Silently losing config data is not acceptable in any mode
+
+        <hostname> rather than a package field, because the refusal is about
+        text the tool actually scans. A value in an element no pass touches is
+        copied through whole - nothing is discarded, so there is nothing to
+        refuse.
+        """
+        oversized = "the quick brown fox jumps over the lazy dog " * 28_000
+        source = write(
+            tmp_path,
+            f"<pfsense><version>23.1</version><system><hostname>{oversized}"
+            "</hostname></system></pfsense>"
+        )
+        out = tmp_path / "out.xml"
+
+        result = run_redactor(source, out)
+
+        assert result.returncode == ExitCode.INPUT_REJECTED
+        assert not out.exists()
+
+
+class TestStrictModeHasNoImplicitConfiguration:
+    """Output must not depend on where the tool was run"""
+
+    @pytest.fixture
+    def workdir(self, tmp_path):
+        """A working directory holding an implicit allow-list"""
+        (tmp_path / ".pfsense-allowlist").write_text(
+            "megacorp-holdings.example\n198.18.51.77\n"
+        )
+        write(tmp_path, wrap(
+            "<syslogtarget>198.18.51.77</syslogtarget>"
+            "<note>ships to collector.megacorp-holdings.example</note>"
+        ))
+        return tmp_path
+
+    def test_the_implicit_allowlist_is_not_loaded(self, workdir, run_redactor):
+        """A file in the working directory must not weaken a public-sharing run"""
+        result = run_redactor("config.xml", "out.xml", "--strict", cwd=workdir)
+
+        out = workdir / "out.xml"
+        if out.exists():
+            text = out.read_text()
+            assert "198.18.51.77" not in text
+            assert "megacorp-holdings.example" not in text
+        assert "ignoring the allow-list" in result.stderr
+
+    def test_ignoring_it_is_announced(self, workdir, run_redactor):
+        """An operator relying on that file has to find out"""
+        result = run_redactor("config.xml", "out.xml", "--strict", cwd=workdir)
+
+        assert ".pfsense-allowlist" in result.stderr
+
+    def test_an_explicit_allowlist_is_used_and_announced(self, tmp_path, run_redactor):
+        """--allowlist-file is the only way in, and it says so"""
+        allowlist = tmp_path / "allow.txt"
+        allowlist.write_text("time.nist.gov.example\n")
+        source = write(tmp_path, CLEAN_CONFIG)
+
+        result = run_redactor(
+            source, tmp_path / "out.xml", "--strict", "--allowlist-file", allowlist
+        )
+
+        assert "Loaded allow-list" in result.stderr
+        assert str(allowlist) in result.stderr
+        assert result.returncode == ExitCode.CLEAN
+
+
+class TestStrictModeRejectsInPlace:
+    """There is nowhere to withhold output to when the destination is the source"""
+
+    def test_strict_inplace_is_a_usage_error(self, tmp_path, run_redactor):
+        """And the original is untouched"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        before = source.read_bytes()
+
+        result = run_redactor(source, "--strict", "--inplace", "--force")
+
+        assert result.returncode != 0
+        assert "--strict" in result.stderr
+        assert source.read_bytes() == before
+
+
+class TestExitCodes:
+    """A caller needs to tell apart why a run failed"""
+
+    def test_a_clean_run_exits_zero(self, tmp_path, run_redactor):
+        """The baseline"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        assert run_redactor(source, tmp_path / "o.xml", "--strict").returncode == 0
+
+    def test_unparseable_input(self, tmp_path, run_redactor):
+        """2, not the same code as a retained secret"""
+        source = write(tmp_path, "<pfsense><unclosed></pfsense>")
+        result = run_redactor(source, tmp_path / "o.xml", "--strict")
+        assert result.returncode == ExitCode.INPUT_REJECTED
+
+    def test_a_retained_value(self, tmp_path, run_redactor):
+        """3 - the transformer knew it kept something"""
+        source = write(tmp_path, wrap(
+            "<blob>Q0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZ</blob>"
+        ))
+        result = run_redactor(source, tmp_path / "o.xml", "--fail-on-warn")
+        assert result.returncode == ExitCode.RETAINED_VALUE
+
+    def test_a_verifier_finding(self, tmp_path, run_redactor):
+        """4 - only something re-reading the output could tell"""
+        source = write(tmp_path, wrap(SURVIVOR))
+        result = run_redactor(source, tmp_path / "o.xml", "--strict")
+        assert result.returncode == ExitCode.VERIFIER_FINDING
+
+    def test_the_codes_are_distinct(self, tmp_path, run_redactor):
+        """The property the finding was about"""
+        malformed = write(tmp_path, "<pfsense><unclosed></pfsense>", "bad.xml")
+        retained = write(tmp_path, wrap(
+            "<blob>Q0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZX0JBU0U2NEJMT0JfQ0FOQVJZ</blob>"
+        ), "retained.xml")
+
+        parse_failure = run_redactor(malformed, tmp_path / "a.xml").returncode
+        gate_failure = run_redactor(retained, tmp_path / "b.xml", "--fail-on-warn").returncode
+
+        assert parse_failure != gate_failure
+        assert parse_failure != 0 and gate_failure != 0
+
+    def test_every_non_zero_code_stays_non_zero(self, tmp_path, run_redactor):
+        """Integrations that only test for success are unaffected"""
+        cases = [
+            (write(tmp_path, "<pfsense><unclosed></pfsense>", "a.xml"), []),
+            (write(tmp_path, wrap(SURVIVOR), "b.xml"), ["--strict"]),
+            (write(tmp_path, wrap("<a>x</a>", version="99.9"), "c.xml"), ["--strict"]),
+            (write(tmp_path, "<opnsense><a>x</a></opnsense>", "d.xml"), ["--strict"]),
+        ]
+        for index, (source, flags) in enumerate(cases):
+            result = run_redactor(source, tmp_path / f"out{index}.xml", *flags)
+            assert result.returncode != 0, (source, flags)
+
+
+class TestJsonReport:
+    """A sharing decision that something other than a human can check"""
+
+    @pytest.fixture
+    def report(self, tmp_path, run_redactor):
+        """A report from a run that found something"""
+        source = write(tmp_path, wrap(
+            f"<vendorblob>{PEM}</vendorblob>"
+            f"<apitoken>{JWT}</apitoken>"
+            + SURVIVOR
+        ))
+        path = tmp_path / "report.json"
+        run_redactor(source, tmp_path / "out.xml", "--strict", "--report-json", path)
+        return path
+
+    def test_it_is_written_even_when_the_run_failed(self, report):
+        """A run that withheld output is exactly when a caller needs the reason"""
+        assert report.exists()
+
+    def test_it_is_valid_json_with_the_documented_shape(self, report):
+        """A schema nothing validates is prose in braces"""
+        data = json.loads(report.read_text())
+
+        assert data['schema_version'] == 1
+        assert data['tool']['name'] == 'pfsense-redactor'
+        assert set(data['input']) >= {'sha256', 'bytes', 'root_tag', 'config_version'}
+        assert data['verdict'] in {'clean', 'findings', 'rejected'}
+        assert isinstance(data['findings'], list)
+        assert isinstance(data['retained'], list)
+        assert data['exit_code'] != 0
+
+    def test_findings_carry_metadata_only(self, report):
+        """Path, kind and length. Never a value."""
+        data = json.loads(report.read_text())
+
+        for finding in data['findings']:
+            assert set(finding) == {'id', 'path', 'kind', 'length'}
+            assert isinstance(finding['length'], int)
+
+    def test_no_secret_text_appears_anywhere_in_it(self, report):
+        """Asserted over the whole file, not per field
+
+        A field-by-field check passes the moment a secret reaches a field
+        nobody thought to check.
+        """
+        text = report.read_text()
+
+        for secret in ("CANARYPRIVATEKEY", "BEGIN RSA PRIVATE KEY", "eyJ",
+                       "CANARYUNKNOWNFIELDSECRET", "dBjftJeZ"):
+            assert secret not in text, secret
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
+    def test_it_is_not_world_readable(self, report):
+        """It names the path of everything the run decided to keep"""
+        mode = stat.S_IMODE(report.stat().st_mode)
+        assert not mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IWGRP | stat.S_IWOTH)
+
+    def test_a_clean_run_reports_clean(self, tmp_path, run_redactor):
+        """The other half of the verdict"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        path = tmp_path / "report.json"
+
+        run_redactor(source, tmp_path / "out.xml", "--strict", "--report-json", path)
+        data = json.loads(path.read_text())
+
+        assert data['verdict'] == 'clean'
+        assert data['exit_code'] == 0
+        assert data['findings'] == []
+        assert data['counts']['verifier_findings'] == 0
+
+    def test_it_records_the_mode_the_run_used(self, tmp_path, run_redactor):
+        """A report that does not say how it was produced cannot be trusted"""
+        source = write(tmp_path, CLEAN_CONFIG)
+        path = tmp_path / "report.json"
+
+        run_redactor(source, tmp_path / "out.xml", "--strict", "--report-json", path)
+        mode = json.loads(path.read_text())['mode']
+
+        assert mode['strict'] is True
+        assert mode['aggressive'] is True
+        assert mode['redact_descriptions'] is True
+
+    def test_it_records_every_allowlist_source(self, tmp_path, run_redactor):
+        """An allow-list weakens redaction, so the report has to name it"""
+        allowlist = tmp_path / "allow.txt"
+        allowlist.write_text("time.nist.gov.example\n")
+        source = write(tmp_path, CLEAN_CONFIG)
+        path = tmp_path / "report.json"
+
+        run_redactor(source, tmp_path / "out.xml", "--strict",
+                     "--allowlist-file", allowlist, "--report-json", path)
+
+        assert str(allowlist) in json.loads(path.read_text())['mode']['allowlist_files']
+
+    def test_it_works_outside_strict_mode(self, adversarial_canary, run_redactor, tmp_path):
+        """--report-json is not strict-only; --dry-run is the usual pairing"""
+        path = tmp_path / "report.json"
+        result = run_redactor(adversarial_canary, "--dry-run", "--report-json", path)
+
+        assert result.returncode == 0
+        data = json.loads(path.read_text())
+        assert data['mode']['dry_run'] is True
+        assert data['retained'], "the canary retains values, so they must be listed"

--- a/tests/adversarial/test_strict_mode.py
+++ b/tests/adversarial/test_strict_mode.py
@@ -78,6 +78,7 @@ class TestStrictModeProducesOutputWhenItCan:
         assert out.exists()
         ET.fromstring(out.read_text())
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
     def test_the_output_is_not_world_readable(self, tmp_path, run_redactor):
         """Strict output is still a redacted configuration"""
         source = write(tmp_path, CLEAN_CONFIG)

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/aggressive.xml
+++ b/tests/reference/default-config/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/anonymise.xml
+++ b/tests/reference/default-config/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/default.xml
+++ b/tests/reference/default-config/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/keep_private.xml
+++ b/tests/reference/default-config/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_domains.xml
+++ b/tests/reference/default-config/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/no_ips.xml
+++ b/tests/reference/default-config/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/default-config/stdout.xml
+++ b/tests/reference/default-config/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>2.9</version>
   <lastchange />
   <theme>nervecenter</theme>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/aggressive.xml
+++ b/tests/reference/test-config1/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/anonymise.xml
+++ b/tests/reference/test-config1/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/default.xml
+++ b/tests/reference/test-config1/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/keep_private.xml
+++ b/tests/reference/test-config1/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_domains.xml
+++ b/tests/reference/test-config1/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/no_ips.xml
+++ b/tests/reference/test-config1/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config1/stdout.xml
+++ b/tests/reference/test-config1/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>18.2</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/aggressive.xml
+++ b/tests/reference/test-config2/aggressive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/anonymise.xml
+++ b/tests/reference/test-config2/anonymise.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/default.xml
+++ b/tests/reference/test-config2/default.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/keep_private.xml
+++ b/tests/reference/test-config2/keep_private.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_domains.xml
+++ b/tests/reference/test-config2/no_domains.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/no_ips.xml
+++ b/tests/reference/test-config2/no_ips.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.6.0 -->
+  <!-- Redacted using pfsense-redactor v1.4.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/reference/test-config2/stdout.xml
+++ b/tests/reference/test-config2/stdout.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pfsense>
-  <!-- Redacted using pfsense-redactor v1.3.0 -->
+  <!-- Redacted using pfsense-redactor v1.6.0 -->
   <version>19.1</version>
   <lastchange />
   <system>

--- a/tests/unit/test_default_allowlist_discovery.py
+++ b/tests/unit/test_default_allowlist_discovery.py
@@ -126,15 +126,28 @@ class TestLoadIsAnnounced:
     """A file picked up without being asked for should say so"""
 
     def test_logged_when_writing_a_file(self, in_dir_with_default, caplog):
-        """Not in --stdout or --dry-run, where output is the product"""
+        """The ordinary case"""
         with caplog.at_level(logging.INFO, logger='pfsense_redactor'):
             collect(stdout=False)
 
         assert 'default allow-list' in caplog.text
 
-    def test_not_logged_in_stdout_mode(self, in_dir_with_default, caplog):
-        """stdout carries the redacted config, so nothing else may land there"""
-        with caplog.at_level(logging.INFO, logger='pfsense_redactor'):
-            collect(stdout=True)
+    @pytest.mark.parametrize('mode', [{'stdout': True}, {'dry_run': True}], ids=['stdout', 'dry-run'])
+    def test_logged_in_every_mode(self, in_dir_with_default, caplog, mode):
+        """Including --stdout and --dry-run, which is where it used to be silent
 
-        assert 'default allow-list' not in caplog.text
+        This asserted the opposite: that the notice was suppressed under
+        --stdout, on the reasoning that stdout carries the redacted config and
+        nothing else may land there. The reasoning was sound and the conclusion
+        was not - the notice goes to *stderr*, so it never competed with the
+        document, and suppressing it meant a file in the working directory
+        could weaken redaction in exactly the two modes most likely to be
+        scripted, with nothing in the run saying so.
+
+        Announced in every mode now. An allow-list changes what is redacted; a
+        run must not be quiet about being handed one it was not asked to use.
+        """
+        with caplog.at_level(logging.INFO, logger='pfsense_redactor'):
+            collect(**mode)
+
+        assert 'default allow-list' in caplog.text


### PR DESCRIPTION
# PR 4 — Strict public-sharing mode

Base: `security/verified-atomic-output` · Branch: `security/strict-public-sharing-mode` · Version: 1.4.0

## Summary

`--strict` for output that may be read by anyone, indefinitely: a mode with no silent failure path. Plus the machinery a caller needs to check a sharing decision without reading prose on stderr.

## Findings addressed

| Finding | Status | Evidence |
| --- | --- | --- |
| FINDING-13 | Fixed | `TestRecursionBounds` (3 cases), `test_strict_mode.py::test_excessive_nesting_is_rejected` |
| FINDING-14 | Fixed | `TestTextSizeBounds` (3), `test_oversized_text_is_rejected[_outside_strict_mode_too]` |
| FINDING-23 | Fixed | `TestExitCodes` (6 cases) |
| FINDING-24 | Fixed | `test_unsupported_config_version_is_reported`, `test_an_unsupported_schema_version_is_rejected` |
| FINDING-25 | Fixed | `TestImplicitConfiguration` (2), `TestStrictModeHasNoImplicitConfiguration` (3) |
| FINDING-26 | Fixed | `TestJsonReport` (9 cases) |
| FINDING-27 | Partial | Documentation only — `docs/benchmark.md` now states the mode. Scoring change not made; default-mode xfail retained |

## Security invariants

- Any unresolved finding under `--strict` means no XML output at all, and a documented non-zero exit code.
- An unavailable verifier is a finding, not a pass.
- Output does not depend on where the tool was run: implicit allow-lists are ignored under `--strict` and the refusal is announced.
- Every allow-list source that took effect is announced on stderr in every mode.
- The report contains no value, prefix, decoded content, full credential URL, or hash of a secret.
- Recursion, element size and schema version are bounded before traversal, not during it.

## Behaviour changes

- **New:** `--strict`, `--report-json PATH`.
- **New:** exit codes 2–6 alongside 0 and 1. All non-zero values remain non-zero.
- Oversized elements are replaced wholesale and the run is refused **in every mode**, where previously the excess was discarded and the run exited 0.
- Documents deeper than 400 elements are refused with a diagnosis instead of a traceback.
- An unrecognised configuration schema version is reported on stderr in every mode; refused under `--strict`.
- Allow-list sources are announced under `--dry-run` and `--stdout`, where the notice was previously suppressed.
- A wrong root element aborts under `--strict` as well as `--fail-on-warn`.

## Regression analysis

- Before: 1222 passed, 1 skipped, 18 xfailed
- After: **1291 passed, 1 skipped, 9 xfailed**
- Previously passing tests affected: 0
- Existing tests modified: 2

1. `test_assurance_signals.py::test_retained_key_material_fails_the_run` (FINDING-21) had become **vacuous**: it opened with `assert find_key_material(result.stdout)`, and since PR 1 nothing survives. It was passing its strict xfail on a false premise rather than on the finding. Replaced by two tests — one asserting the stronger fact directly, one asserting the invariant on a run that can still reach it.
2. `test_parser_limits.py::test_oversized_text_is_not_silently_truncated` now checks the return code before parsing stdout, because the correct outcome is that there is nothing to parse. The invariant is unchanged.

## Tests

```
python -m pytest tests/ -q                                 1291 passed, 1 skipped, 9 xfailed
python -m pytest tests/adversarial/test_strict_mode.py -q    40 passed
pylint / structure                                         10.00/10, exit 0
```

## Xfail changes

Removed (9): FINDING-13 ×2, FINDING-14, FINDING-23, FINDING-24, FINDING-25 ×2, FINDING-26, plus the vacuous FINDING-21 marker.
Retained (9): FINDING-06, 07, 08, 11 ×2, 12 ×2, 20, 27.
New markers: none.

## Remaining risks

Stated in `docs/security.md#what-strict-mode-does-not-establish`: unknown encodings exist; unsupported package schemas exist; independent verification reduces correlated failure without eliminating false negatives; passing a corpus written alongside the tool is not certification. Strict mode is not described as certified, audit-grade, complete, or suitable for every package schema.

`argparse` exits 2 for a malformed command line, the same value as *input rejected*. Documented rather than hidden.

Strict mode on a large real config may report a handful of structural values retained verbatim (pfBlockerNG alias names, package metadata). Resolving them needs `--allowlist-file`.

## Review guidance

`redactor.py`: `ExitCode`, `_output_is_permitted` and its four checks, `_document_depth`, `_config_version_is_supported`, `build_report`. Then `tests/adversarial/test_strict_mode.py`, which is the specification.

---

## Update: integration with #70

`f071e91` reconciles this PR's allow-list changes with the collector #70 restores.

#62 refactored `_collect_allowlists` into `_load_default_allowlists` plus a `_merge_allowlist` accumulator, and added tests that call it directly with a hand-built `Namespace`. This PR reads two attributes those tests do not set, so both reads now use `getattr` — matching how `no_default_allowlist` is already read in the same function. Sources are recorded through `_record_allowlist_source`, which creates the list on demand for the same reason.

**One expectation reversed deliberately.** `test_not_logged_in_stdout_mode` asserted the "Loaded default allow-list" notice was *suppressed* under `--stdout`, reasoning that stdout carries the redacted config and nothing else may land there. The reasoning was sound and the conclusion was not: the notice goes to **stderr**, so it never competed with the document, and suppressing it meant a file in the working directory could weaken redaction in exactly the two modes most likely to be scripted with nothing in the run saying so. That is FINDING-25.

Replaced by `test_logged_in_every_mode`, parametrised over `--stdout` and `--dry-run`. Same invariant — a run must not be quiet about being handed an allow-list it was not asked to use — asserted in the direction that actually holds it.

Side benefit of #70's instance-state change: `redact_config` and `_process` drop from 7 arguments to 5.

---

## Update: three review comments, one of them a real defect

**`depth_limit_hits` was set and never read.** `redact_element` stops
descending at `MAX_XML_DEPTH` and counts it. `_check_structural_limits` normally
refuses such a document first, so it was not reachable through the CLI — but
that is not a property to rest output on when two limits could disagree, and
`redact_element` is callable directly. A run that stopped early would have
emitted elements it never examined and reported success.

`_no_data_was_discarded` now asks two questions, neither short-circuited:

| | |
| --- | --- |
| `_all_text_was_scanned` | no element was too large to scan |
| `_whole_tree_was_traversed` | no subtree was too deep to reach |

Both refuse in **every** mode, exit 2. Tested for all four properties a refusal
must have — the code, no output created, an existing output preserved
byte-for-byte, nothing on stdout — plus the premise that the counter is set.

**The JSON verdict conflated a failed run with a dirty configuration.**
`"findings"` covered `IO_FAILURE` and `INTERNAL_FAILURE`, so a pipeline reading
it after a failed write would conclude the configuration still held secrets when
the disk was full. Those now report `"error"`. All four mappings — `clean`,
`rejected`, `findings`, `error` — are tested from runs that really produce each
exit code, not by calling the mapper directly.

**`ExitCode.USAGE` was unreachable.** Every usage error went through
`parser.error`, which exits 2, while the documented scheme said 1. `_exit_usage`
prints the usage line, logs the reason, and exits 1 — matching what path
validation already did. `argparse` still exits 2 for a command line it cannot
parse itself; that overlap remains documented.

Verified end to end:

```
--inplace without --force      1   (was 2)
--strict --inplace             1   (was 2)
unknown flag (argparse)        2   (unchanged)
document past the depth limit  2   and no output produced
```

`CHANGELOG.md` and `docs/cli-reference.md` updated for all three user-visible
changes, including a table saying what each verdict is a statement about.


---

## Versions renumbered

The stack was numbered 1.3.0–1.8.0, one minor bump per PR, because the
repository forbids an open `[Unreleased]` section so each PR had to name a
version. That claimed six releases that never happened: **PyPI's latest is
1.1.2**, and `main`'s 1.2.0 has not shipped either.

Renumbered to patches, with a minor only where compatibility actually breaks:

| PR | Was | Now | |
| --- | --- | --- | --- |
| #65 | 1.3.0 | **1.2.1** | additive detection |
| #66 | 1.4.0 | **1.2.2** | verifier, advisory only |
| #67 | 1.5.0 | **1.3.0** | breaking: `--inplace` needs `--force`, hard links refused, failed gate writes nothing |
| #68 | 1.6.0 | **1.4.0** | breaking: usage errors exit 1, not 2 |
| #69 | 1.7.0 | **1.4.1** | workflows and docs only |
| #71 | 1.8.0 | **1.4.2** | verifier containment |

Sequence: `1.2.0 → 1.2.1 → 1.2.2 → 1.3.0 → 1.4.0 → 1.4.1 → 1.4.2`.

Test totals are unchanged by the renumber, and reference snapshots differ only
in the version comment.
