### PR TITLE
Restore PR #62: CodeScene structural fixes that never reached main

### DIFF
--- a/pfsense_redactor/redactor.py
+++ b/pfsense_redactor/redactor.py
@@ -310,6 +310,15 @@ FILE_EXTENSIONS: frozenset[str] = frozenset({
 # content, so a placeholder can only ever be one this module wrote.
 URL_PLACEHOLDER_RE = re.compile(r'\x00URL(\d+)\x00')
 
+# What a redacted address looks like in the output. Named because they are
+# also matched on the way back *in*: a token already carrying one of these has
+# been redacted before, and must not be counted or rewritten a second time.
+MASKED_IPV4 = 'XXX.XXX.XXX.XXX'
+MASKED_IPV6 = 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX'
+MASKED_IP_TOKENS: frozenset[str] = frozenset({
+    MASKED_IPV4, MASKED_IPV6, f'[{MASKED_IPV6}]',
+})
+
 # Summary lines, in print order. Labels are parsed by the StatsParser fixture in
 # tests/conftest.py, so the text must not change.
 STAT_LABELS: tuple[tuple[str, str], ...] = (
@@ -745,6 +754,14 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self.high_entropy_paths: list[str] = []
         self._path_stack: list[str] = []
 
+        # Whether IPs and domains are redacted on this run. Policy for the whole
+        # traversal rather than per element, so they are set once by
+        # redact_config rather than threaded through every method beneath it.
+        # Defaulted here so redact_element stays callable on a bare element,
+        # which is how most of the unit tests drive it.
+        self.redact_ips: bool = True
+        self.redact_domains: bool = True
+
         # Every <refid> defined in the config being processed, so a short value
         # in a certificate-named element can be resolved rather than guessed at.
         # Populated by _collect_refids before the traversal starts; empty here
@@ -912,21 +929,32 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return True
         return any(ip in net for net in self.allowlist_ip_networks)
 
+    @staticmethod
+    def _mask_v4_sample(value: str) -> str:
+        """Keep the first two octets and the last, hide the third"""
+        parts = value.split('.')
+        if len(parts) != 4:
+            return value
+        return f"{parts[0]}.{parts[1]}.***.{parts[3]}"
+
+    @staticmethod
+    def _mask_v6_sample(value: str) -> str:
+        """Keep the leading hextets and the last, hide the middle"""
+        parts = value.split(':')
+        if len(parts) < 3:
+            return value
+        return f"{parts[0]}:{parts[1]}:*:****::{parts[-1]}"
+
     def _mask_ip_sample(self, value: str) -> str:
         """Mask IP address for sample display"""
         try:
             ip = ipaddress.ip_address(value)
-            if ip.version == 4:
-                parts = value.split('.')
-                if len(parts) == 4:
-                    return f"{parts[0]}.{parts[1]}.***.{parts[3]}"
-            else:
-                parts = value.split(':')
-                if len(parts) >= 3:
-                    return f"{parts[0]}:{parts[1]}:*:****::{parts[-1]}"
         except ValueError:
-            pass
-        return value
+            return value
+
+        if ip.version == 4:
+            return self._mask_v4_sample(value)
+        return self._mask_v6_sample(value)
 
     @staticmethod
     def _mask_sample_host(host: str) -> str:
@@ -1021,16 +1049,28 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             return f"***.{value}"
         return value
 
+    @staticmethod
+    def _mask_colon_mac(value: str) -> str:
+        """Six-group form: keep the OUI and the last two groups"""
+        parts = value.split(':')
+        if len(parts) != 6:
+            return value
+        return f"{parts[0]}:{parts[1]}:**:**:{parts[4]}:{parts[5]}"
+
+    @staticmethod
+    def _mask_dotted_mac(value: str) -> str:
+        """Cisco three-group form"""
+        parts = value.split('.')
+        if len(parts) != 3:
+            return value
+        return f"{parts[0]}.****.{parts[2]}"
+
     def _mask_mac_sample(self, value: str) -> str:
         """Mask MAC address for sample display"""
         if ':' in value:
-            parts = value.split(':')
-            if len(parts) == 6:
-                return f"{parts[0]}:{parts[1]}:**:**:{parts[4]}:{parts[5]}"
-        elif '.' in value:
-            parts = value.split('.')
-            if len(parts) == 3:
-                return f"{parts[0]}.****.{parts[2]}"
+            return self._mask_colon_mac(value)
+        if '.' in value:
+            return self._mask_dotted_mac(value)
         return value
 
     def _mask_secret_sample(self, value: str) -> str:
@@ -1367,7 +1407,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         unit.
         """
         # Skip already-masked tokens
-        if token in ('XXX.XXX.XXX.XXX', 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX', '[XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]'):
+        if token in MASKED_IP_TOKENS:
             return token
         original_token = token
 
@@ -1380,20 +1420,8 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if self._should_preserve_ip(ip):
             return original_token
 
-        # Anonymisation mode
-        if self.anonymise:
-            rep = self._anonymise_ip(str(ip))
-        else:
-            # Standard redaction
-            rep = 'XXX.XXX.XXX.XXX' if ip.version == 4 else 'XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX'
-
-        # Preserve zone identifier if present
-        if zone:
-            rep = f"{rep}%{zone}"
-        if bracketed:
-            rep = f"[{rep}]"
-
-        result = rep + port_suffix
+        rep = self._ip_replacement(ip)
+        result = self._restore_token_shape(rep, zone, bracketed) + port_suffix
 
         # Only count if actually changed
         if result != original_token:
@@ -1402,6 +1430,26 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             self._add_sample('IP', str(ip), rep)
 
         return result
+
+    def _ip_replacement(self, ip: IPAddress) -> str:
+        """The masked form of one address, honouring --anonymise"""
+        if self.anonymise:
+            return self._anonymise_ip(str(ip))
+        return MASKED_IPV4 if ip.version == 4 else MASKED_IPV6
+
+    @staticmethod
+    def _restore_token_shape(rep: str, zone: str | None, bracketed: bool) -> str:
+        """Put back the zone identifier and brackets the token arrived with
+
+        Both are structure rather than address, so they survive redaction: a
+        zone id names a local interface and brackets are what make an IPv6
+        literal parseable inside a netloc.
+        """
+        if zone:
+            rep = f"{rep}%{zone}"
+        if bracketed:
+            rep = f"[{rep}]"
+        return rep
 
     def _mask_ip_like_tokens(self, text: str) -> str:
         """IP address masking using ipaddress module"""
@@ -1646,39 +1694,42 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         return redacted
 
     @staticmethod
-    def _is_secretish_path_segment(segment: str) -> bool:
-        """Check whether a URL path segment looks like an embedded credential
+    def _is_secretish_token(part: str) -> bool:
+        """Whether one colon-separated piece of a path segment is a credential
 
         Uses a lower length floor than _is_high_entropy_value: webhook tokens
         sit around 20-24 chars, below the threshold used for key material.
 
-        Boundaries here are load-bearing, so each is justified:
+        Every boundary here is load-bearing, so each is justified:
 
         - >= 20, not > 20. AWS access key IDs (AKIA...) are exactly 20
           characters, so a > 20 test excluded the entire format.
-        - Colon-separated segments are split first. Telegram bot tokens are
-          'bot<id>:<secret>', and the colon fails BASE64ISH_RE, which let a
-          47-character credential through as an ordinary path segment.
         - A digit is required only below DIGITLESS_TOKEN_LENGTH. The digit rule
           exists to protect underscore-joined route names such as
           'Open_VM_Tools_package' (21 chars); beyond that length an all-letter
           segment is far more likely to be a token than a route. Requiring a
           digit unconditionally silently missed alphabetic Slack tokens.
         """
-        for part in segment.split(':'):
-            if len(part) < SECRETISH_SEGMENT_MIN_LENGTH:
-                continue
-            if not BASE64ISH_RE.match(part):
-                continue
+        if len(part) < SECRETISH_SEGMENT_MIN_LENGTH:
+            return False
+        if not BASE64ISH_RE.match(part):
+            return False
+        if not any(c.isalpha() for c in part):
+            return False
 
-            has_letter = any(c.isalpha() for c in part)
-            has_digit = any(c.isdigit() for c in part)
-            if not has_letter:
-                continue
-            if has_digit or len(part) >= DIGITLESS_TOKEN_LENGTH:
-                return True
+        if any(c.isdigit() for c in part):
+            return True
+        return len(part) >= DIGITLESS_TOKEN_LENGTH
 
-        return False
+    @classmethod
+    def _is_secretish_path_segment(cls, segment: str) -> bool:
+        """Check whether a URL path segment looks like an embedded credential
+
+        Split on colons before testing. Telegram bot tokens are
+        'bot<id>:<secret>', and the colon fails BASE64ISH_RE, which let a
+        47-character credential through as an ordinary path segment.
+        """
+        return any(cls._is_secretish_token(part) for part in segment.split(':'))
 
     @classmethod
     def _build_redacted_path(cls, path: str) -> tuple[str, bool]:
@@ -2064,9 +2115,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return bool(CERT_TAG_PATTERN.search(tag) or CERT_TAG_PATTERN.search(tag_base))
 
-    def _should_redact_completely(
-        self, tag: str, tag_base: str, element: ET.Element, redact_ips: bool, redact_domains: bool
-    ) -> bool:
+    def _should_redact_completely(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Check if element should be completely redacted and handle it. Returns True if handled."""
         if not self._is_secret_tag(tag, tag_base):
             return False
@@ -2083,7 +2132,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         # Process children recursively
         for child in element:
-            self.redact_element(child, redact_ips, redact_domains)
+            self.redact_element(child)
 
         return True
 
@@ -2252,7 +2301,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
             self.high_entropy_paths.append(path)
         return False
 
-    def _redact_key_element_if_needed(self, tag: str, element: ET.Element, redact_ips: bool, redact_domains: bool) -> bool:
+    def _redact_key_element_if_needed(self, tag: str, element: ET.Element) -> bool:
         """Redact <key> element if needed - can be short secret or PEM blob. Returns True if handled."""
         if tag != 'key' or not element.text:
             return False
@@ -2266,7 +2315,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         # Process children
         for child in element:
-            self.redact_element(child, redact_ips, redact_domains)
+            self.redact_element(child)
 
         return True
 
@@ -2368,13 +2417,11 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return True
 
-    def _redact_ip_containing_element(
-        self, tag: str, tag_base: str, element: ET.Element, redact_ips: bool, redact_domains: bool
-    ) -> bool:
+    def _redact_ip_containing_element(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Redact IPs/domains in known IP-containing elements. Returns True if processed."""
         if (tag in self.ip_containing_elements or tag_base in self.ip_containing_elements):
             if element.text:
-                element.text = self.redact_text(element.text, redact_ips, redact_domains)
+                element.text = self.redact_text(element.text, self.redact_ips, self.redact_domains)
                 return True
         return False
 
@@ -2441,9 +2488,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 continue
             self._account_for_attribute_blob(element, tag, attr)
 
-    def _redact_text_aggressive(
-        self, element: ET.Element, text_already_processed: bool, redact_ips: bool, redact_domains: bool
-    ) -> None:
+    def _redact_text_aggressive(self, element: ET.Element, text_already_processed: bool) -> None:
         """Redact text and attributes in aggressive mode"""
         tag = self._normalise_tag(element.tag)
         if self._is_secret_tag(tag, self._get_tag_base(tag)):
@@ -2451,17 +2496,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         # Process text if not already done
         if element.text and not text_already_processed:
-            element.text = self.redact_text(element.text, redact_ips, redact_domains)
+            element.text = self.redact_text(element.text, self.redact_ips, self.redact_domains)
 
         # Process tail
         if element.tail:
-            element.tail = self.redact_text(element.tail, redact_ips, redact_domains)
+            element.tail = self.redact_text(element.tail, self.redact_ips, self.redact_domains)
 
         # Process attributes
         for attr in list(element.attrib.keys()):
             if element.attrib[attr]:
                 element.attrib[attr] = self.redact_text(
-                    element.attrib[attr], redact_ips, redact_domains
+                    element.attrib[attr], self.redact_ips, self.redact_domains
                 )
 
     @staticmethod
@@ -2473,10 +2518,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         """
         return bool(text) and not handled and '://' in text
 
-    def _redact_element_text(
-        self, tag: str, tag_base: str, element: ET.Element,
-        redact_ips: bool, redact_domains: bool
-    ) -> bool:
+    def _redact_element_text(self, tag: str, tag_base: str, element: ET.Element) -> bool:
         """Run the text-content passes. Returns whether the text was handled
 
         The return value gates the later passes, so a pass that fully rewrote
@@ -2495,7 +2537,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         if self._redact_unknown_blob_element(tag, element):
             handled = True
 
-        if self._redact_ip_containing_element(tag, tag_base, element, redact_ips, redact_domains):
+        if self._redact_ip_containing_element(tag, tag_base, element):
             handled = True
 
         # Credentials embedded in URLs in elements that are not known URL
@@ -2507,7 +2549,7 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
 
         return handled
 
-    def redact_element(self, element: ET.Element, redact_ips: bool = True, redact_domains: bool = True) -> None:
+    def redact_element(self, element: ET.Element) -> None:
         """Recursively redact sensitive information from XML element"""
 
         # Normalise tag name to handle namespaced exports
@@ -2519,19 +2561,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         # <key> is handled specially (PEM blob vs short secret) and must be
         # checked before the generic secret match, which would otherwise claim
         # it via SECRET_TAG_PATTERN and lose the cert/key distinction.
-        if self._redact_key_element_if_needed(tag, element, redact_ips, redact_domains):
+        if self._redact_key_element_if_needed(tag, element):
             return
 
         # Handle complete redaction cases
-        if self._should_redact_completely(tag, tag_base, element, redact_ips, redact_domains):
+        if self._should_redact_completely(tag, tag_base, element):
             return
 
         # Handle cert/key elements (don't return - continue to process children)
         self._redact_cert_key_element(tag, tag_base, element)
 
-        text_already_processed = self._redact_element_text(
-            tag, tag_base, element, redact_ips, redact_domains
-        )
+        text_already_processed = self._redact_element_text(tag, tag_base, element)
 
         # Redact attributes with sensitive names, and account for high-entropy
         # values in the rest. Runs before the aggressive text pass below, which
@@ -2542,13 +2582,13 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
         self._path_stack.append(tag)
         try:
             for child in element:
-                self.redact_element(child, redact_ips, redact_domains)
+                self.redact_element(child)
         finally:
             self._path_stack.pop()
 
         # Aggressive mode: apply redaction to text content, tail, and attributes
         if self.aggressive:
-            self._redact_text_aggressive(element, text_already_processed, redact_ips, redact_domains)
+            self._redact_text_aggressive(element, text_already_processed)
 
     def _add_redaction_comment(self, root: ET.Element) -> None:
         """Add a comment to the XML indicating it was redacted"""
@@ -2645,11 +2685,17 @@ class PfSenseRedactor:  # pylint: disable=too-many-instance-attributes
                 self.logger.info("[+] Parsing XML configuration from: %s", input_file)
                 self.logger.info("[+] Redacting sensitive information...")
 
+            # Policy for this run, set before the traversal reads it. Assigned
+            # on every call so a reused instance cannot inherit the previous
+            # run's flags.
+            self.redact_ips = redact_ips
+            self.redact_domains = redact_domains
+
             # Before the traversal, so certificate references can be resolved
             # against what the config actually defines
             self.known_refids = self._collect_refids(root)
 
-            self.redact_element(root, redact_ips, redact_domains)
+            self.redact_element(root)
 
             # Dry run mode: just print stats
             if dry_run:
@@ -3389,38 +3435,56 @@ def _resolve_keep_private_ips(args: argparse.Namespace) -> bool:
     return keep_private_ips
 
 
+Allowlists = tuple[set[str], list[IPNetwork], set[str]]
+
+
+def _merge_allowlist(target: Allowlists, parsed: Allowlists) -> None:
+    """Fold one parsed (ips, networks, domains) triple into the accumulators
+
+    Networks extend rather than update: they are a list because overlapping
+    CIDRs are checked in order, not deduplicated.
+    """
+    ips, networks, domains = target
+    parsed_ips, parsed_networks, parsed_domains = parsed
+    ips.update(parsed_ips)
+    networks.extend(parsed_networks)
+    domains.update(parsed_domains)
+
+
+def _load_default_allowlists(
+    args: argparse.Namespace, logger: logging.Logger, target: Allowlists
+) -> None:
+    """Merge every default allow-list file found on disk, unless disabled"""
+    if getattr(args, 'no_default_allowlist', False):
+        return
+
+    for default_file in find_default_allowlist_files():
+        _merge_allowlist(target, parse_allowlist_file(default_file, silent_if_missing=True))
+        if not args.dry_run and not args.stdout:
+            logger.info("[+] Loaded default allow-list: %s", default_file)
+
+
 def _collect_allowlists(
     args: argparse.Namespace, logger: logging.Logger
-) -> tuple[set[str], list[IPNetwork], set[str]]:
-    """Merge allow-list entries from default files, --allowlist-file and CLI flags"""
-    # Build allow-lists from multiple sources (merge all)
-    allowlist_ips = set()
-    allowlist_networks = []
-    allowlist_domains = set()
+) -> Allowlists:
+    """Merge allow-list entries from default files, --allowlist-file and CLI flags
 
-    # 1. Load default allow-list files (unless disabled)
-    if not getattr(args, 'no_default_allowlist', False):
-        default_files = find_default_allowlist_files()
-        for default_file in default_files:
-            file_ips, file_networks, file_domains = parse_allowlist_file(default_file, silent_if_missing=True)
-            allowlist_ips.update(file_ips)
-            allowlist_networks.extend(file_networks)
-            allowlist_domains.update(file_domains)
-            if not args.dry_run and not args.stdout:
-                logger.info("[+] Loaded default allow-list: %s", default_file)
+    Sources are applied in order and all of them merge; a later source adds to
+    the earlier ones rather than replacing them.
+    """
+    collected: Allowlists = (set(), [], set())
 
-    # 2. Load explicit allow-list file if provided
+    _load_default_allowlists(args, logger, collected)
+
     if args.allowlist_file:
-        file_ips, file_networks, file_domains = parse_allowlist_file(args.allowlist_file, silent_if_missing=False)
-        allowlist_ips.update(file_ips)
-        allowlist_networks.extend(file_networks)
-        allowlist_domains.update(file_domains)
+        _merge_allowlist(collected, parse_allowlist_file(args.allowlist_file, silent_if_missing=False))
 
-    # 3. Add IPs/CIDRs from CLI
+    allowlist_ips, allowlist_networks, allowlist_domains = collected
+
     for entry in args.allowlist_ips or ():
         _add_cli_allowlist_ip(entry, allowlist_ips, allowlist_networks, logger)
 
-    # 4. Add domains from CLI (case-insensitive)
+    # Domains are compared case-insensitively
     for domain in args.allowlist_domains or ():
         allowlist_domains.add(domain.lower())
 

--- a/tests/corpus/canary-corpus-supplementary.xml
+++ b/tests/corpus/canary-corpus-supplementary.xml
@@ -36,9 +36,29 @@
     is a different problem, covered by the 'redact-descriptions' flag, and the
     frozen corpus already carries a marker for it.
   -->
+  <!--
+    CANARY_ZONEADDR: a bracketed IPv6 address carrying a zone identifier.
+
+    The marker is the interface name rather than the address, because the
+    address has to be a real one to be redacted at all. If redaction works the
+    marker survives as the zone and the address is masked; if tokenising breaks
+    again the whole value passes through untouched, address included.
+
+    '%' used to be a token separator, so '[2001:db8::99%CANARY_ZONEADDR]:51820'
+    was split into '[2001:db8::99' and 'CANARY_ZONEADDR]:51820'. The first half
+    carried an unbalanced bracket, failed to parse, and was returned as-is.
+    Routable addresses leaked this way, not only link-local ones. This is the
+    shape pfSense writes for a WireGuard peer endpoint.
+
+    Scored by asserting the *address* is gone, in
+    tests/integration/test_canary_corpus.py.
+  -->
   <installedpackages>
     <mycustompkg><config>
       <telemetry endpoint_id="CANARY_ATTR_BLOBaG7kQ2xZpR9vN4tY8wL3mB6dF1sJ0c">enabled</telemetry>
     </config></mycustompkg>
+    <wireguard><tunnels><item>
+      <endpoint>[2001:db8::99%CANARY_ZONEADDR]:51820</endpoint>
+    </item></tunnels></wireguard>
   </installedpackages>
 </pfsense>

--- a/tests/integration/test_canary_corpus.py
+++ b/tests/integration/test_canary_corpus.py
@@ -236,10 +236,28 @@ class TestSupplementaryCorpus:
         assert 'telemetry[@endpoint_id]' in result.stderr
 
     def test_aggressive_catches_everything_here(self):
-        """No known survivors in this corpus, so any survivor is a regression"""
-        left = survivors(redact_file(SUPPLEMENTARY, '--aggressive'))
+        """No known survivors in this corpus, so any survivor is a regression
+
+        CANARY_ZONEADDR is excluded: it marks an interface name, which is
+        structure rather than address and is meant to survive. What must not
+        survive is the address beside it, checked below.
+        """
+        left = survivors(redact_file(SUPPLEMENTARY, '--aggressive')) - {'CANARY_ZONEADDR'}
 
         assert not left, 'survived --aggressive: ' + ', '.join(sorted(left))
+
+    @pytest.mark.parametrize('flags', [(), ('--aggressive',)])
+    def test_bracketed_address_with_a_zone_is_redacted(self, flags):
+        """The address in '[addr%zone]:port', which used to pass through whole
+
+        Asserted on the address rather than on the marker, because the marker
+        is the zone and the zone is supposed to survive. A test that checked
+        only the zone passed for years while the address leaked.
+        """
+        stdout = redact_file(SUPPLEMENTARY, *flags).stdout
+
+        assert '2001:db8::99' not in stdout, 'bracketed address with a zone leaked'
+        assert 'CANARY_ZONEADDR' in stdout, 'the interface name should survive'
 
 
 class TestRetainedValuesAreReported:

--- a/tests/unit/test_check_structure.py
+++ b/tests/unit/test_check_structure.py
@@ -114,6 +114,143 @@ class TestBumps:
 
         assert not [r for r in reasons(tool, src) if 'blocks' in r]
 
+    def test_elif_branches_count_separately(self, tool):
+        """An if/elif chain is one ast.If, but two humps
+
+        Counting the node once read a two-way branch as a single block, so this
+        shape passed the gate while CodeScene reported it. _mask_mac_sample was
+        the real instance.
+        """
+        src = (
+            "def f(value):\n"
+            "    if ':' in value:\n"
+            "        parts = value.split(':')\n"
+            "        if len(parts) == 6:\n"
+            "            return 'a'\n"
+            "    elif '.' in value:\n"
+            "        parts = value.split('.')\n"
+            "        if len(parts) == 3:\n"
+            "            return 'b'\n"
+            "    return value\n"
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    def test_else_branch_counts_too(self, tool):
+        """The same applies to a plain else, not only to elif"""
+        src = (
+            "def f(value):\n"
+            "    if value:\n"
+            "        for i in value:\n"
+            "            print(i)\n"
+            "    else:\n"
+            "        for j in range(3):\n"
+            "            print(j)\n"
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    def test_a_try_contributes_its_body_not_itself(self, tool):
+        """Error handling must not hide the humps inside it
+
+        A try wrapping the real work contributed only itself, so a function
+        whose whole body sat inside one was measured as a single block.
+        _mask_ip_sample was the real instance.
+        """
+        src = (
+            "def f(value):\n"
+            "    try:\n"
+            "        if value.version == 4:\n"
+            "            parts = value.split('.')\n"
+            "            if len(parts) == 4:\n"
+            "                return 'a'\n"
+            "        else:\n"
+            "            parts = value.split(':')\n"
+            "            if len(parts) >= 3:\n"
+            "                return 'b'\n"
+            "    except ValueError:\n"
+            "        pass\n"
+            "    return value\n"
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    HUMP = (
+        "        for {var} in {seq}:\n"
+        "            if {var}:\n"
+        "                print({var})\n"
+    )
+
+    @pytest.mark.parametrize('second_branch', ['except ValueError:', 'finally:'])
+    def test_humps_hiding_in_a_try_branch_are_counted(self, tool, second_branch):
+        """A handler is the easiest place to hide one
+
+        Measuring `try:` while ignoring `except:` would leave error handling,
+        where awkward logic tends to accumulate, entirely unmeasured.
+        """
+        src = (
+            "def f(items, other):\n"
+            "    try:\n"
+            + self.HUMP.format(var='i', seq='items')
+            + f"    {second_branch}\n"
+            + self.HUMP.format(var='j', seq='other')
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    def test_a_hump_in_the_else_branch_is_counted(self, tool):
+        """try/except/else, where the else is the interesting half"""
+        src = (
+            "def f(items, other):\n"
+            "    try:\n"
+            "        risky()\n"
+            "    except ValueError:\n"
+            + self.HUMP.format(var='i', seq='items')
+            + "    else:\n"
+            + self.HUMP.format(var='j', seq='other')
+        )
+
+        assert any('blocks of nested logic' in r for r in reasons(tool, src))
+
+    def test_a_plain_handler_is_not_a_hump(self, tool):
+        """try/except around one block stays within budget"""
+        src = (
+            "def f(items):\n"
+            "    try:\n"
+            "        for i in items:\n"
+            "            if i:\n"
+            "                print(i)\n"
+            "    except ValueError:\n"
+            "        pass\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'blocks' in r]
+
+    def test_dispatching_to_named_helpers_is_clean(self, tool):
+        """The shape the two rules above push you toward"""
+        src = (
+            "def f(self, value):\n"
+            "    if ':' in value:\n"
+            "        return self._colon(value)\n"
+            "    if '.' in value:\n"
+            "        return self._dotted(value)\n"
+            "    return value\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'blocks' in r]
+
+    def test_a_single_guarded_block_is_still_allowed(self, tool):
+        """One hump is the budget; the rules must not drop it to zero"""
+        src = (
+            "def f(value):\n"
+            "    if value:\n"
+            "        for i in value:\n"
+            "            print(i)\n"
+            "    return value\n"
+        )
+
+        assert not [r for r in reasons(tool, src) if 'blocks' in r]
+
 
 class TestComplexConditional:
     """Conditions chaining several operators are reported"""

--- a/tests/unit/test_default_allowlist_discovery.py
+++ b/tests/unit/test_default_allowlist_discovery.py
@@ -1,0 +1,140 @@
+"""
+Tests for the default allow-list file being found, read and merged.
+
+`.pfsense-allowlist` in the working directory is picked up with no flag at all,
+which makes it the one allow-list source a user can forget they have. It is also
+the source that was never exercised: _collect_allowlists was covered only
+through --allowlist-file and the CLI flags, so the default-file path ran in
+production and nowhere else.
+
+--no-default-allowlist is the opt out, and needs a test for the same reason: a
+flag that silently fails to disable something is worse than no flag.
+"""
+import argparse
+import logging
+
+import pytest
+
+from pfsense_redactor.redactor import _collect_allowlists, find_default_allowlist_files
+
+LOGGER = logging.getLogger('pfsense_redactor')
+
+
+def make_args(**overrides):
+    """A Namespace shaped like the one argparse hands _collect_allowlists"""
+    defaults = {
+        'no_default_allowlist': False,
+        'allowlist_file': None,
+        'allowlist_ips': [],
+        'allowlist_domains': [],
+        'dry_run': False,
+        'stdout': True,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def collect(**overrides):
+    """Run the collector with a Namespace built from the defaults above"""
+    return _collect_allowlists(make_args(**overrides), LOGGER)
+
+
+@pytest.fixture(name='in_dir_with_default')
+def in_dir_with_default_fixture(tmp_path, monkeypatch):
+    """Run inside a directory holding a .pfsense-allowlist file
+
+    monkeypatch.chdir rather than passing a path, because discovery is by
+    convention: the file is found relative to the working directory.
+    """
+    (tmp_path / '.pfsense-allowlist').write_text(
+        '# defaults\n10.20.30.40\n172.16.0.0/12\ndefault.acme.example\n',
+        encoding='utf-8'
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestDiscovery:
+    """find_default_allowlist_files looks in the working directory"""
+
+    def test_local_file_is_found(self, in_dir_with_default):
+        """The file the fixture just wrote"""
+        found = find_default_allowlist_files()
+
+        assert any(p.name == '.pfsense-allowlist' for p in found)
+
+    def test_nothing_found_in_an_empty_directory(self, tmp_path, monkeypatch):
+        """No file, no error: this runs on every invocation"""
+        monkeypatch.chdir(tmp_path)
+
+        assert all(p.name != '.pfsense-allowlist' for p in find_default_allowlist_files())
+
+
+class TestDefaultFileIsMerged:
+    """The path that previously ran only in production"""
+
+    def test_entries_reach_the_allowlists(self, in_dir_with_default):
+        """All three kinds from one file, no flags involved"""
+        ips, networks, domains = collect()
+
+        assert '10.20.30.40' in ips
+        assert any(str(n) == '172.16.0.0/12' for n in networks)
+        assert 'default.acme.example' in domains
+
+    def test_default_and_explicit_file_both_apply(self, in_dir_with_default, tmp_path):
+        """A later source adds to the default rather than replacing it"""
+        explicit = tmp_path / 'extra.txt'
+        explicit.write_text('192.0.2.1\nextra.acme.example\n', encoding='utf-8')
+
+        ips, _, domains = collect(allowlist_file=str(explicit))
+
+        assert {'10.20.30.40', '192.0.2.1'} <= ips
+        assert {'default.acme.example', 'extra.acme.example'} <= domains
+
+    def test_cli_flags_merge_on_top_of_the_default_file(self, in_dir_with_default):
+        """Every source is additive, which is the documented behaviour"""
+        ips, _, domains = collect(
+            allowlist_ips=['198.51.100.7'], allowlist_domains=['CLI.acme.example']
+        )
+
+        assert {'10.20.30.40', '198.51.100.7'} <= ips
+        assert 'cli.acme.example' in domains, 'CLI domains are lower-cased'
+
+
+class TestOptOut:
+    """--no-default-allowlist has to actually disable it"""
+
+    def test_default_file_is_ignored(self, in_dir_with_default):
+        """The early return, which nothing reached before"""
+        ips, networks, domains = collect(no_default_allowlist=True)
+
+        assert not ips
+        assert not networks
+        assert not domains
+
+    def test_explicit_file_still_applies(self, in_dir_with_default, tmp_path):
+        """Opting out of defaults must not disable an allow-list asked for by name"""
+        explicit = tmp_path / 'extra.txt'
+        explicit.write_text('192.0.2.1\n', encoding='utf-8')
+
+        ips, _, _ = collect(no_default_allowlist=True, allowlist_file=str(explicit))
+
+        assert ips == {'192.0.2.1'}
+
+
+class TestLoadIsAnnounced:
+    """A file picked up without being asked for should say so"""
+
+    def test_logged_when_writing_a_file(self, in_dir_with_default, caplog):
+        """Not in --stdout or --dry-run, where output is the product"""
+        with caplog.at_level(logging.INFO, logger='pfsense_redactor'):
+            collect(stdout=False)
+
+        assert 'default allow-list' in caplog.text
+
+    def test_not_logged_in_stdout_mode(self, in_dir_with_default, caplog):
+        """stdout carries the redacted config, so nothing else may land there"""
+        with caplog.at_level(logging.INFO, logger='pfsense_redactor'):
+            collect(stdout=True)
+
+        assert 'default allow-list' not in caplog.text

--- a/tests/unit/test_sample_masking.py
+++ b/tests/unit/test_sample_masking.py
@@ -7,6 +7,8 @@ These tests verify the correctness of targeted bug fixes and improvements.
 import io
 import logging
 
+import pytest
+
 
 class TestIPv6URLReconstruction:
     """Test that IPv6 addresses in URLs are properly wrapped in brackets"""
@@ -431,3 +433,94 @@ class TestSampleMaskingNeverLeaksSecrets:
     def test_unknown_category_returns_value_unchanged(self, basic_redactor):
         """Unknown categories fall through rather than raising"""
         assert basic_redactor._safe_mask_for_sample('plain', 'NoSuchCategory') == 'plain'
+
+
+class TestMaskerFormatBranches:
+    """Each address format the sample maskers dispatch to
+
+    These branches existed before the maskers were split into a helper per
+    format, and were untested then too - inlined in a nested conditional, they
+    were simply harder to see. Covering them here so the split does not leave
+    the same gap behind under a new name.
+    """
+
+    def test_ipv6_sample_keeps_the_ends(self, basic_redactor):
+        """The v6 arm, which the v4 test above never reaches"""
+        masked = basic_redactor._safe_mask_for_sample('2001:db8:1234:5678::abcd', 'IP')
+
+        assert masked.startswith('2001:db8:')
+        assert masked.endswith('abcd')
+        assert '****' in masked
+
+    def test_the_shortest_ipv6_is_still_masked(self, basic_redactor):
+        """'::1' splits into three empty-ish groups, so it takes the normal path"""
+        assert basic_redactor._safe_mask_for_sample('::1', 'IP') == '::*:****::1'
+
+    @pytest.mark.parametrize('masker,value', [
+        ('_mask_v6_sample', 'nocolons'),
+        ('_mask_v4_sample', '1.2.3'),
+    ])
+    def test_group_count_guards_return_the_value(self, basic_redactor, masker, value):
+        """Defensive guards, exercised directly because nothing else reaches them
+
+        _mask_ip_sample only calls these once ipaddress has parsed the value, and
+        no address it accepts can fail the group count: the shortest IPv6 is '::'
+        which still splits into three. The guards stay because the maskers are
+        reachable from _safe_mask_for_sample, which is handed whatever was
+        redacted rather than a known-good address.
+        """
+        assert getattr(basic_redactor, masker)(value) == value
+
+    def test_a_non_address_is_returned_unchanged(self, basic_redactor):
+        """The masker is fed whatever was redacted, so it must not raise"""
+        assert basic_redactor._safe_mask_for_sample('not-an-address', 'IP') == 'not-an-address'
+
+    def test_dotted_cisco_mac(self, basic_redactor):
+        """Three-group Cisco form takes the other branch from aa:bb:cc:dd:ee:ff"""
+        masked = basic_redactor._safe_mask_for_sample('aabb.ccdd.eeff', 'MAC')
+
+        assert masked == 'aabb.****.eeff'
+
+    @pytest.mark.parametrize('value', ['aa:bb:cc', 'aabb.ccdd', 'nothing'])
+    def test_malformed_macs_are_returned_unchanged(self, basic_redactor, value):
+        """Wrong group counts fall through rather than being mangled"""
+        assert basic_redactor._safe_mask_for_sample(value, 'MAC') == value
+
+
+class TestZoneAndBracketsSurviveRedaction:
+    """_restore_token_shape puts back what the token arrived with
+
+    A zone identifier names a local interface and brackets are what make an
+    IPv6 literal parseable inside a netloc, so both are structure rather than
+    address and outlive the address they decorated.
+    """
+
+    def test_zone_identifier_is_preserved(self, basic_redactor):
+        """fe80::1%igb0 keeps %igb0 after the address is masked"""
+        result = basic_redactor.redact_text('fe80::1%igb0')
+
+        assert '2001' not in result
+        assert 'fe80::1' not in result, 'the address itself must go'
+        assert '%igb0' in result, 'the interface name is structure, not address'
+
+    def test_brackets_are_preserved(self, basic_redactor):
+        """A bracketed literal stays bracketed, so the netloc still parses"""
+        result = basic_redactor.redact_text('[2001:db8::1]:8080')
+
+        assert '2001:db8::1' not in result, 'the address itself must go'
+        assert result.startswith('[')
+        assert result.endswith(']:8080')
+
+    def test_both_together(self, basic_redactor):
+        """Brackets, zone and port at once, which is the WireGuard peer shape
+
+        This shape used to pass through redact_text untouched, because '%' was
+        a token separator and the closing bracket was severed from the address.
+        See tests/unit/test_ipv6_zone_identifiers.py for the full case.
+        """
+        result = basic_redactor.redact_text('[fe80::1%igb0]:51820')
+
+        assert 'fe80::1' not in result
+        assert '%igb0' in result
+        assert result.startswith('[')
+        assert result.endswith(']:51820')

--- a/tests/unit/test_traversal_policy_state.py
+++ b/tests/unit/test_traversal_policy_state.py
@@ -1,0 +1,135 @@
+"""
+Tests for redact_ips/redact_domains as per-run instance state.
+
+These two are policy for a whole run, not a per-element decision, so they are
+set once by redact_config rather than threaded through every method beneath it.
+That removed two arguments from six signatures, but it moves a value that used
+to be passed explicitly into state that persists on the instance, which is
+worth pinning:
+
+- redact_config must assign on every call, so a reused redactor cannot inherit
+  the previous run's policy
+- the defaults must stay permissive-to-redact, because redact_element is
+  callable on a bare element and most unit tests drive it that way
+
+redact_text keeps its explicit parameters. It is a leaf utility called directly
+with varying flags, and nothing about this change should alter that.
+"""
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from pfsense_redactor.redactor import PfSenseRedactor
+
+CONFIG = (
+    '<?xml version="1.0"?><pfsense><a>'
+    '<ipaddr>10.1.2.3</ipaddr><host>fw.acme.example</host>'
+    '</a></pfsense>'
+)
+
+
+def write(tmp_path, name='config.xml'):
+    """A config carrying one IP and one domain"""
+    source = tmp_path / name
+    source.write_text(CONFIG, encoding='utf-8')
+    return source
+
+
+def run(redactor, tmp_path, **kwargs):
+    """Redact and return the output text"""
+    out = tmp_path / f'out-{len(list(tmp_path.iterdir()))}.xml'
+    redactor.redact_config(str(write(tmp_path)), str(out), **kwargs)
+    return out.read_text(encoding='utf-8')
+
+
+class TestDefaults:
+    """A freshly constructed redactor redacts both"""
+
+    def test_both_flags_default_to_true(self):
+        """redact_element on a bare element must not silently keep everything"""
+        redactor = PfSenseRedactor()
+
+        assert redactor.redact_ips is True
+        assert redactor.redact_domains is True
+
+    def test_bare_redact_element_still_redacts(self):
+        """The path 143 existing unit tests take"""
+        redactor = PfSenseRedactor()
+        root = ET.fromstring(CONFIG)
+        redactor.redact_element(root)
+        out = ET.tostring(root, encoding='unicode')
+
+        assert '10.1.2.3' not in out
+        assert 'fw.acme.example' not in out
+
+
+class TestRedactConfigSetsPolicy:
+    """Each flag reaches the traversal"""
+
+    @pytest.mark.parametrize('ips,domains,ip_kept,domain_kept', [
+        (True, True, False, False),
+        (False, True, True, False),
+        (True, False, False, True),
+        (False, False, True, True),
+    ])
+    def test_the_matrix(self, tmp_path, ips, domains, ip_kept, domain_kept):
+        """All four combinations, which is what the reference snapshots cover"""
+        out = run(PfSenseRedactor(), tmp_path, redact_ips=ips, redact_domains=domains)
+
+        assert ('10.1.2.3' in out) is ip_kept
+        assert ('fw.acme.example' in out) is domain_kept
+
+
+class TestNoStateLeakBetweenRuns:
+    """The risk this refactor introduces, closed on purpose
+
+    The flags used to be passed per call, so nothing could carry over. Now they
+    live on the instance, and redact_config assigns them every time precisely so
+    a second run cannot inherit the first run's policy.
+    """
+
+    def test_permissive_run_does_not_leak_into_a_default_run(self, tmp_path):
+        """The dangerous direction: a later run must not under-redact"""
+        redactor = PfSenseRedactor()
+        run(redactor, tmp_path, redact_ips=False, redact_domains=False)
+
+        out = run(redactor, tmp_path)
+
+        assert '10.1.2.3' not in out, 'previous run kept IPs and this one inherited it'
+        assert 'fw.acme.example' not in out
+
+    def test_default_run_does_not_leak_into_a_permissive_run(self, tmp_path):
+        """And the other direction, so the flags are honoured either way"""
+        redactor = PfSenseRedactor()
+        run(redactor, tmp_path)
+
+        out = run(redactor, tmp_path, redact_ips=False, redact_domains=False)
+
+        assert '10.1.2.3' in out
+        assert 'fw.acme.example' in out
+
+    def test_the_attributes_reflect_the_last_run(self, tmp_path):
+        """State is observable, so state should be correct"""
+        redactor = PfSenseRedactor()
+        run(redactor, tmp_path, redact_ips=False, redact_domains=True)
+
+        assert redactor.redact_ips is False
+        assert redactor.redact_domains is True
+
+
+class TestRedactTextKeepsItsParameters:
+    """The boundary this refactor deliberately did not cross"""
+
+    def test_explicit_flags_still_honoured(self):
+        """Called directly with flags by 11 existing tests"""
+        redactor = PfSenseRedactor()
+
+        assert '10.1.2.3' in redactor.redact_text('10.1.2.3', redact_ips=False)
+        assert '10.1.2.3' not in redactor.redact_text('10.1.2.3', redact_ips=True)
+
+    def test_its_parameters_win_over_instance_state(self):
+        """They are independent, so an explicit argument is not second-guessed"""
+        redactor = PfSenseRedactor()
+        redactor.redact_ips = True
+
+        assert '10.1.2.3' in redactor.redact_text('10.1.2.3', redact_ips=False)

--- a/tools/check_structure.py
+++ b/tools/check_structure.py
@@ -16,6 +16,43 @@ Usage:
 
 Prints `path:line function: reason` for each violation and exits 1, or exits 0
 in silence.
+
+Relationship to CodeScene
+-------------------------
+This gate approximates CodeScene's Bumpy Road rule, and the two agreed only
+after `blocks()` was taught about if/elif chains and `try` bodies. On
+complexity they still differ in both directions: mccabe scores `redact_text`
+and `redact_config` at 8 and CodeScene calls neither complex, while it scored
+`_is_secretish_path_segment` at 9 where mccabe said 6. There is no single
+number to chase, so the rules here encode shape, which both agree on.
+
+The three functions CodeScene called Complex Method were split rather than
+argued with, each into a named predicate or step with the original reasoning
+carried across intact:
+
+- `_is_secretish_token` holds the boundary comments that justify the >= 20
+  floor and the conditional digit rule; the colon split that catches Telegram
+  tokens stays with the segment-level function that does the splitting.
+- `_ip_replacement` and `_restore_token_shape` separate choosing a mask from
+  putting back the zone id, brackets and port the token arrived with.
+- `_merge_allowlist` and `_load_default_allowlists` separate folding one parsed
+  triple into the accumulators from deciding which files to read.
+
+Findings deliberately not acted on, so they are not re-opened each time the
+dashboard is read:
+
+- **Low Cohesion** and **Number of Functions in a Single Module** on
+  redactor.py. Both follow from the single-file design, which that module's
+  docstring explains and tests/integration/test_standalone_script.py enforces:
+  the file has to run when copied alone to a firewall or jump host. For a tool
+  trusted with secrets that guarantee is worth more than a tidier module tree,
+  and splitting the file to satisfy a metric would trade it away.
+
+- **Excess Number of Function Arguments** on `PfSenseRedactor.__init__`. Each
+  argument is an independent user-facing policy toggle mapped 1:1 to a CLI
+  flag; a config object would add indirection without removing a choice. The
+  same finding on the traversal methods *was* acted on: redact_ips and
+  redact_domains became per-run instance state.
 """
 from __future__ import annotations
 
@@ -61,15 +98,74 @@ def too_deep(func: ast.AST):
         yield func.lineno, func.name, f"nested {depth} deep (max {MAX_NESTING})"
 
 
+def _as_block(body: list) -> ast.AST:
+    """Wrap a list of statements so nesting_depth can measure it"""
+    return ast.Module(body=body, type_ignores=[])
+
+
+def _try_branches(stmt: ast.Try) -> list:
+    """Every statement list a try can carry: body, each handler, else, finally"""
+    branches = [stmt.body, stmt.orelse, stmt.finalbody]
+    branches.extend(handler.body for handler in stmt.handlers)
+    return [b for b in branches if b]
+
+
+def _try_blocks(stmt: ast.Try):
+    """The blocks inside a try, from whichever branch they sit in"""
+    for branch in _try_branches(stmt):
+        for inner in branch:
+            if isinstance(inner, NESTING_NODES):
+                yield from blocks(inner)
+
+
+def blocks(stmt: ast.AST):
+    """Yield each separately-reachable block of logic within a statement
+
+    Two shapes hide bumps from a naive count of `func.body`, and both were
+    found by comparing this tool against CodeScene's Bumpy Road rule, which
+    reported functions this gate had passed:
+
+    - An `if/elif/else` chain is a *single* ast.If, with each `elif` buried in
+      the previous branch's orelse. Counting the node once reads a three-way
+      branch as one block.
+    - A `try` wrapping the real work contributes only itself, so everything
+      inside it is invisible.
+
+    Every branch of a `try` counts, not just its body. A handler is where the
+    awkward logic tends to accumulate, so measuring `try:` while ignoring
+    `except:` would leave the easiest place to hide a hump unmeasured.
+
+    Anything else is its own single block.
+    """
+    if isinstance(stmt, ast.Try):
+        yield from _try_blocks(stmt)
+        return
+
+    if not isinstance(stmt, ast.If):
+        yield stmt
+        return
+
+    yield _as_block(stmt.body)
+    orelse = stmt.orelse
+    while len(orelse) == 1 and isinstance(orelse[0], ast.If):
+        yield _as_block(orelse[0].body)
+        orelse = orelse[0].orelse
+    if orelse:
+        yield _as_block(orelse)
+
+
 def too_bumpy(func: ast.AST):
     """Report a function carrying several separate blocks of nested logic
 
     A bump is a top-level block that itself contains nested logic. A flat loop
     is not one; a loop wrapping a conditional is. Two of them in one function
     means two things are going on in it.
+
+    Branches of an if/elif chain count separately, and a try contributes its
+    body rather than itself - see blocks() for why.
     """
-    bumps = sum(1 for stmt in func.body
-                if isinstance(stmt, NESTING_NODES) and nesting_depth(stmt) >= 1)
+    bumps = sum(1 for stmt in func.body if isinstance(stmt, NESTING_NODES)
+                for block in blocks(stmt) if nesting_depth(block) >= 1)
     if bumps > MAX_BUMPS:
         yield func.lineno, func.name, f"{bumps} blocks of nested logic (max {MAX_BUMPS})"
 


### PR DESCRIPTION
# Restore PR #62 — it merged into a branch that had already left

## What happened

[#62 "Clear the CodeScene findings, and close the gate blind spot"](https://github.com/grounzero/pfsense-redactor/pull/62) is reported as **MERGED**, and it is — into `ipv6-zone-leak`, 27 seconds after that branch had already been squash-merged into `main`:

```
14:26:05   #63 squash-merged ipv6-zone-leak -> main       (11 lines of redactor.py)
14:26:32   #62 merged codescene-structure -> ipv6-zone-leak   (27 seconds too late)
```

The squash in #63 captured `ipv6-zone-leak` as it was *before* #62 arrived, so none of #62's content reached `main`. It has been sitting on `origin/codescene-structure` (`849c580`) ever since.

Verified:

- `git merge-base --is-ancestor 849c580 origin/main` → **no**
- none of `_merge_allowlist`, `_load_default_allowlists`, `_is_secretish_token`, `_ip_replacement`, `_restore_token_shape` exist on `main`
- `main`'s tip changed 11 lines of `redactor.py`; #62 changed 274

**This PR is not new work.** It is `git cherry-pick 849c580` onto today's `main`, which applied with no conflicts. It was reviewed once as #62; the diff here is identical to what was approved.

## Why it matters now

CodeScene currently reports 16 findings on `redactor.py`. **Seven of them are the ones #62 fixed**, and they came back the moment its content failed to land:

| Finding | Function |
| --- | --- |
| Bumpy Road (bumps 2) | `_mask_ip_sample` |
| Bumpy Road (bumps 2) | `_mask_mac_sample` |
| Complex Method (cc 9) | `_mask_one_ip_token` |
| Complex Method (cc 9) | `_is_secretish_path_segment` |
| Excess Arguments (5) | `_should_redact_completely` |
| Excess Arguments (5) | `_redact_ip_containing_element` |
| Excess Arguments (5) | `_redact_element_text` |

The gate blind spot is real and still open on `main`. `tools/check_structure.py` on `main` does not understand `if`/`elif` chains (a single `ast.If` with the elifs buried in `orelse`) or `try` bodies and handlers, so it passes on two functions CodeScene flags. The restored version catches exactly those two:

```
redactor.py:1419 _mask_ip_sample:  2 blocks of nested logic (max 1)
redactor.py:1528 _mask_mac_sample: 2 blocks of nested logic (max 1)
```

It also restores the maintainer's written policy — the "Relationship to CodeScene" section of `tools/check_structure.py` — recording which findings are **deliberately not acted on** (Low Cohesion, module function count, and `__init__`'s argument count) and why. Without it on `main`, those six findings look open rather than decided.

## What it contains

| File | |
| --- | --- |
| `pfsense_redactor/redactor.py` | 274 lines: per-format dispatch in the sample maskers; `_mask_one_ip_token` → `_ip_replacement` + `_restore_token_shape`; `_is_secretish_path_segment` → `_is_secretish_token`; `_collect_allowlists` → `_merge_allowlist` + `_load_default_allowlists`; `redact_ips`/`redact_domains` moved from threaded parameters to per-run instance state |
| `tools/check_structure.py` | +100 lines: if/elif and try awareness, plus the CodeScene policy docstring |
| `tests/unit/test_check_structure.py` | new, 137 lines |
| `tests/unit/test_traversal_policy_state.py` | new, 135 lines |
| `tests/unit/test_default_allowlist_discovery.py` | new, 140 lines |
| `tests/unit/test_sample_masking.py` | new, 93 lines |
| `tests/integration/test_canary_corpus.py`, `tests/corpus/canary-corpus-supplementary.xml` | corpus additions |

## Verification

```
python -m pytest tests/ -q                                          803 passed, 1 skipped
python tools/check_structure.py pfsense_redactor/ tests/ tools/     exit 0  (stricter version)
python -m flake8 … --select=C901 --max-complexity=8                 0
pylint production / tests                                           10.00/10 / 10.00/10
```

Run in both CI environments, since they diverge: package installed (`tests.yml`) and not installed (`python-app.yml`). Identical results.

## Merge order

**Merge this before #65.** The five security PRs (#65–#69) were built on a `main` that should have contained this, and will be rebased onto it afterwards. Expected conflicts there are confined to `_should_redact_completely`, `_redact_element_text` and `_redact_ip_containing_element`, whose signatures change here.

## How to avoid the repeat

The race is a property of squash-merging a parent branch while a child PR is still open against it. GitHub retargets the child to the parent's base, but the squash has already discarded whatever the child added. Worth checking, before squashing any branch, whether an open PR targets it.
