### PR TITLE
chore: date 1.4.0 as 2026-08-08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0][] - 2026-08-05
+## [1.4.0][] - 2026-08-08
 
 A mode for output intended to be read by anyone, and the machinery a caller
 needs to check a sharing decision without reading prose on stderr.


### PR DESCRIPTION
The 1.4.0 entry was dated 2026-08-05, when the branch was prepared. The merge
landed on 2026-08-08.

Two problems with leaving it:

- 2026-08-05 is **1.3.0's** release date, so two releases would carry the same one.
- The entry would be dated before the release exists.

This is the same correction `62a3d99 chore: bump changelog` made for 1.2.1 —
the date goes in when the release goes out, not when the branch was written.

One line, changelog only. `tests/unit/test_version_consistency.py` still passes.